### PR TITLE
chore: bump dev tools — oxlint, oxfmt, typescript, vitest, lefthook

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -34,20 +34,20 @@ time:
   '@opentelemetry/propagator-jaeger@1.30.1': 2025-01-14T09:16:22.182Z
   '@opentelemetry/sdk-logs@0.57.2': 2025-02-13T17:09:20.633Z
   '@opentelemetry/sdk-trace-node@1.30.1': 2025-01-14T09:16:52.299Z
-  '@oxfmt/binding-darwin-arm64@0.43.0': 2026-03-31T09:22:01.581Z
-  '@oxfmt/binding-linux-arm64-gnu@0.43.0': 2026-03-31T09:22:14.108Z
-  '@oxfmt/binding-linux-arm64-musl@0.43.0': 2026-03-31T09:22:18.347Z
-  '@oxfmt/binding-linux-x64-gnu@0.43.0': 2026-03-31T09:23:12.997Z
-  '@oxfmt/binding-linux-x64-musl@0.43.0': 2026-03-31T09:23:17.263Z
-  '@oxfmt/binding-win32-arm64-msvc@0.43.0': 2026-03-31T09:22:09.738Z
-  '@oxfmt/binding-win32-x64-msvc@0.43.0': 2026-03-31T09:23:04.271Z
-  '@oxlint/binding-darwin-arm64@1.58.0': 2026-03-31T09:29:53.473Z
-  '@oxlint/binding-linux-arm64-gnu@1.58.0': 2026-03-31T09:30:07.838Z
-  '@oxlint/binding-linux-arm64-musl@1.58.0': 2026-03-31T09:30:12.866Z
-  '@oxlint/binding-linux-x64-gnu@1.58.0': 2026-03-31T09:31:19.012Z
-  '@oxlint/binding-linux-x64-musl@1.58.0': 2026-03-31T09:31:24.296Z
-  '@oxlint/binding-win32-arm64-msvc@1.58.0': 2026-03-31T09:30:02.293Z
-  '@oxlint/binding-win32-x64-msvc@1.58.0': 2026-03-31T09:31:08.146Z
+  '@oxfmt/binding-darwin-arm64@0.49.0': 2026-05-11T18:49:15.026Z
+  '@oxfmt/binding-linux-arm64-gnu@0.49.0': 2026-05-11T18:49:31.141Z
+  '@oxfmt/binding-linux-arm64-musl@0.49.0': 2026-05-11T18:49:35.946Z
+  '@oxfmt/binding-linux-x64-gnu@0.49.0': 2026-05-11T18:50:37.625Z
+  '@oxfmt/binding-linux-x64-musl@0.49.0': 2026-05-11T18:50:42.076Z
+  '@oxfmt/binding-win32-arm64-msvc@0.49.0': 2026-05-11T18:49:26.491Z
+  '@oxfmt/binding-win32-x64-msvc@0.49.0': 2026-05-11T18:50:28.795Z
+  '@oxlint/binding-darwin-arm64@1.64.0': 2026-05-11T18:48:27.880Z
+  '@oxlint/binding-linux-arm64-gnu@1.64.0': 2026-05-11T18:48:43.582Z
+  '@oxlint/binding-linux-arm64-musl@1.64.0': 2026-05-11T18:48:48.642Z
+  '@oxlint/binding-linux-x64-gnu@1.64.0': 2026-05-11T18:50:00.155Z
+  '@oxlint/binding-linux-x64-musl@1.64.0': 2026-05-11T18:50:05.932Z
+  '@oxlint/binding-win32-arm64-msvc@1.64.0': 2026-05-11T18:48:38.476Z
+  '@oxlint/binding-win32-x64-msvc@1.64.0': 2026-05-11T18:49:49.714Z
   '@polka/url@1.0.0-next.29': 2025-04-09T18:41:21.389Z
   '@pulumi/cloudflare@6.14.0': 2026-04-02T19:13:17.609Z
   '@pulumi/command@1.2.1': 2026-03-04T00:23:22.954Z
@@ -73,14 +73,18 @@ time:
   '@types/google-protobuf@3.15.12': 2023-11-21T08:36:25.002Z
   '@types/http-cache-semantics@4.2.0': 2026-01-27T09:06:17.247Z
   '@types/keyv@3.1.4': 2022-03-17T05:31:48.941Z
+  '@types/node@25.8.0': 2026-05-14T16:39:51.779Z
   '@types/responselike@1.0.3': 2023-11-07T15:30:27.822Z
   '@types/shimmer@1.2.0': 2024-07-08T08:09:27.106Z
   '@types/tmp@0.2.6': 2023-11-07T17:58:49.283Z
-  '@vitest/mocker@4.1.2': 2026-03-26T14:36:29.326Z
-  '@vitest/pretty-format@4.1.2': 2026-03-26T14:36:18.500Z
-  '@vitest/runner@4.1.2': 2026-03-26T14:36:32.706Z
-  '@vitest/snapshot@4.1.2': 2026-03-26T14:36:35.845Z
-  '@vitest/ui@4.1.2': 2026-03-26T14:37:11.361Z
+  '@vitest/expect@4.1.6': 2026-05-11T14:37:35.685Z
+  '@vitest/mocker@4.1.6': 2026-05-11T14:37:25.379Z
+  '@vitest/pretty-format@4.1.6': 2026-05-11T14:37:13.096Z
+  '@vitest/runner@4.1.6': 2026-05-11T14:37:28.951Z
+  '@vitest/snapshot@4.1.6': 2026-05-11T14:37:32.569Z
+  '@vitest/spy@4.1.6': 2026-05-11T14:37:16.964Z
+  '@vitest/ui@4.1.6': 2026-05-11T14:38:18.897Z
+  '@vitest/utils@4.1.6': 2026-05-11T14:37:21.389Z
   abbrev@4.0.0: 2025-10-20T18:51:05.929Z
   ansi-regex@5.0.1: 2021-09-14T15:55:19.540Z
   bin-links@6.0.0: 2025-10-23T17:45:09.603Z
@@ -101,12 +105,12 @@ time:
   json-stringify-nice@1.1.4: 2021-05-06T22:47:49.572Z
   just-diff-apply@5.5.0: 2022-12-17T20:56:53.168Z
   just-diff@6.0.2: 2023-03-26T00:59:36.579Z
-  lefthook-darwin-arm64@2.1.4: 2026-03-12T07:25:07.583Z
-  lefthook-linux-arm64@2.1.4: 2026-03-12T07:25:17.669Z
-  lefthook-linux-x64@2.1.4: 2026-03-12T07:25:22.687Z
-  lefthook-windows-arm64@2.1.4: 2026-03-12T07:25:27.955Z
-  lefthook-windows-x64@2.1.4: 2026-03-12T07:25:32.960Z
-  lefthook@2.1.4: 2026-03-12T07:25:57.898Z
+  lefthook-darwin-arm64@2.1.6: 2026-04-16T07:34:15.890Z
+  lefthook-linux-arm64@2.1.6: 2026-04-16T07:34:26.135Z
+  lefthook-linux-x64@2.1.6: 2026-04-16T07:34:31.246Z
+  lefthook-windows-arm64@2.1.6: 2026-04-16T07:34:36.141Z
+  lefthook-windows-x64@2.1.6: 2026-04-16T07:34:41.089Z
+  lefthook@2.1.6: 2026-04-16T07:35:04.384Z
   minipass@3.3.6: 2022-11-25T07:54:48.420Z
   minipass@7.1.3: 2026-02-19T00:34:33.886Z
   minizlib@3.1.0: 2025-09-21T21:27:19.983Z
@@ -116,8 +120,8 @@ time:
   npm-registry-fetch@19.1.1: 2025-11-13T17:34:09.569Z
   obug@2.1.1: 2025-11-22T09:31:55.146Z
   onetime@5.1.2: 2020-08-09T20:29:04.963Z
-  oxfmt@0.43.0: 2026-03-31T09:23:21.806Z
-  oxlint@1.58.0: 2026-03-31T09:31:28.436Z
+  oxfmt@0.49.0: 2026-05-11T18:50:47.581Z
+  oxlint@1.64.0: 2026-05-11T18:50:11.029Z
   package-directory@8.2.0: 2026-02-01T14:52:22.473Z
   parse-conflict-json@5.0.1: 2025-10-23T18:01:02.707Z
   picomatch@4.0.4: 2026-03-23T20:39:47.960Z
@@ -140,7 +144,10 @@ time:
   tinyrainbow@3.1.0: 2026-03-12T09:21:01.296Z
   treeverse@3.0.0: 2022-10-14T05:22:35.705Z
   tuf-js@4.1.0: 2025-12-18T22:03:29.192Z
+  typescript@6.0.3: 2026-04-16T23:38:27.905Z
+  undici-types@7.24.6: 2026-03-25T16:01:36.357Z
   undici@6.25.0: 2026-04-14T09:30:20.026Z
+  vitest@4.1.6: 2026-05-11T14:37:46.246Z
   walk-up-path@4.0.0: 2024-07-08T22:41:10.395Z
   which@2.0.2: 2019-11-18T22:26:15.325Z
   which@6.0.1: 2026-02-10T15:41:43.706Z
@@ -157,28 +164,28 @@ importers:
         version: 1.9.1
       '@pulumi/cloudflare':
         specifier: 6.14.0
-        version: 6.14.0(typescript@6.0.2)
+        version: 6.14.0(typescript@6.0.3)
       '@pulumi/command':
         specifier: 1.2.1
-        version: 1.2.1(typescript@6.0.2)
+        version: 1.2.1(typescript@6.0.3)
       '@pulumi/hcloud':
         specifier: 1.32.1
-        version: 1.32.1(typescript@6.0.2)
+        version: 1.32.1(typescript@6.0.3)
       '@pulumi/kubernetes':
         specifier: 4.28.0
-        version: 4.28.0(typescript@6.0.2)
+        version: 4.28.0(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.229.0
-        version: 3.229.0(typescript@6.0.2)
+        version: 3.229.0(typescript@6.0.3)
       '@pulumi/random':
         specifier: 4.19.2
-        version: 4.19.2(typescript@6.0.2)
+        version: 4.19.2(typescript@6.0.3)
       '@pulumi/tls':
         specifier: 5.3.1
-        version: 5.3.1(typescript@6.0.2)
+        version: 5.3.1(typescript@6.0.3)
       vite:
         specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.0.13(@types/node@25.5.2)
+        version: 8.0.13(@types/node@25.8.0)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -190,26 +197,26 @@ importers:
         specifier: 24.0.4
         version: 24.0.4
       '@types/node':
-        specifier: 25.5.2
-        version: 25.5.2
+        specifier: 25.8.0
+        version: 25.8.0
       '@vitest/ui':
-        specifier: 4.1.2
-        version: 4.1.2(vitest@4.1.2)
+        specifier: 4.1.6
+        version: 4.1.6(vitest@4.1.6)
       lefthook:
-        specifier: 2.1.4
-        version: 2.1.4
+        specifier: 2.1.6
+        version: 2.1.6
       oxfmt:
-        specifier: 0.43.0
-        version: 0.43.0
+        specifier: 0.49.0
+        version: 0.49.0
       oxlint:
-        specifier: 1.58.0
-        version: 1.58.0
+        specifier: 1.64.0
+        version: 1.64.0
       typescript:
-        specifier: 6.0.2
-        version: 6.0.2
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
-        specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/ui@4.1.2)(vite@8.0.13(@types/node@25.5.2))
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/ui@4.1.6)(vite@8.0.13(@types/node@25.8.0))
 
   packages/infra: {}
 
@@ -418,16 +425,16 @@ packages:
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
-  '@oxfmt/binding-darwin-arm64@0.43.0':
-    resolution: {integrity: sha512-o3i49ZUSJWANzXMAAVY1wnqb65hn4JVzwlRQ5qfcwhRzIA8lGVaud31Q3by5ALHPrksp5QEaKCQF9aAS3TXpZA==}
+  '@oxfmt/binding-darwin-arm64@0.49.0':
+    resolution: {integrity: sha512-8x5DN9CsFfb432sHa9NyqX5XisGUdA53LPEGSdv/VniS+v4uEOR8Orv7A9QSB98Xxgp0t6r31DzQA/wpIobGqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - darwin
     cpu:
     - arm64
 
-  '@oxfmt/binding-linux-arm64-gnu@0.43.0':
-    resolution: {integrity: sha512-MelWqv68tX6wZEILDrTc9yewiGXe7im62+5x0bNXlCYFOZdA+VnYiJfAihbROsZ5fm90p9C3haFrqjj43XnlAA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.49.0':
+    resolution: {integrity: sha512-JIfWenFhlzx+O8YygyZhoHFzTsdgDhxhbDRnE2iJLnnM5pWKScFvPECO2vOlA7JqJ/9S1g3uzEKuRCkHFwTjvA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -436,8 +443,8 @@ packages:
     libc:
     - glibc
 
-  '@oxfmt/binding-linux-arm64-musl@0.43.0':
-    resolution: {integrity: sha512-ROaWfYh+6BSJ1Arwy5ujijTlwnZetxDxzBpDc1oBR4d7rfrPBqzeyjd5WOudowzQUgyavl2wEpzn1hw3jWcqLA==}
+  '@oxfmt/binding-linux-arm64-musl@0.49.0':
+    resolution: {integrity: sha512-iNzkMPG18jPkwBOZ4/HEjwqfzAjq4RrUQ0CgId/fC1ENvYD5jLVAaU/gWgpiqP1ys07kxSsSggDd1fp3E7mQHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -446,8 +453,8 @@ packages:
     libc:
     - musl
 
-  '@oxfmt/binding-linux-x64-gnu@0.43.0':
-    resolution: {integrity: sha512-R8Yk7iYcuZORXmCfFZClqbDxRZgZ9/HEidUuBNdoX8Ptx07cMePnMVJ/woB84lFIDjh2ROHVaOP40Ds3rBXFqg==}
+  '@oxfmt/binding-linux-x64-gnu@0.49.0':
+    resolution: {integrity: sha512-BoC/F9xHe2y/deuBGA5Aw7bes07OD2gcL2wlpzTrfImR92vPP7S/k3LBTyspQZCNIVNdagkELcqKELwMLGIfAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -456,8 +463,8 @@ packages:
     libc:
     - glibc
 
-  '@oxfmt/binding-linux-x64-musl@0.43.0':
-    resolution: {integrity: sha512-F2YYqyvnQNvi320RWZNAvsaWEHwmW3k4OwNJ1hZxRKXupY63expbBaNp6jAgvYs7y/g546vuQnGHQuCBhslhLQ==}
+  '@oxfmt/binding-linux-x64-musl@0.49.0':
+    resolution: {integrity: sha512-umY6jFADAo/oztFKl8D/S6vSrG6oBpEskcentiRuz42kZVU2kfDXMWCYavxyZR2bwPjqkHpcHZ6EZFiH3Qj9ZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -466,32 +473,32 @@ packages:
     libc:
     - musl
 
-  '@oxfmt/binding-win32-arm64-msvc@0.43.0':
-    resolution: {integrity: sha512-0nWK6a7pGkbdoypfVicmV9k/N1FwjPZENoqhlTU+5HhZnAhpIO3za30nEE33u6l6tuy9OVfpdXUqxUgZ+4lbZw==}
+  '@oxfmt/binding-win32-arm64-msvc@0.49.0':
+    resolution: {integrity: sha512-38K67XR++CoFFORDd4sMFwUVAnD6msYBdGTei+qvKGrRPO6S2PbrYPNL/eQQ1RgnnxOegNba0YQwg6uRkNcw6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - win32
     cpu:
     - arm64
 
-  '@oxfmt/binding-win32-x64-msvc@0.43.0':
-    resolution: {integrity: sha512-4bPgdQux2ZLWn3bf2TTXXMHcJB4lenmuxrLqygPmvCJ104Yqzj1UctxSRzR31TiJ4MLaG22RK8dUsVpJtrCz5g==}
+  '@oxfmt/binding-win32-x64-msvc@0.49.0':
+    resolution: {integrity: sha512-gwWLwSEmBBfIK/Wh7GGd658161o4RKAvHWRaRQbJm571iQXGKfyr7UKsI1vsWvDlNLc30CxJDc8mMmCvJ/kczQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - win32
     cpu:
     - x64
 
-  '@oxlint/binding-darwin-arm64@1.58.0':
-    resolution: {integrity: sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA==}
+  '@oxlint/binding-darwin-arm64@1.64.0':
+    resolution: {integrity: sha512-U4DMLQd10gJLuoSTLSGbfv3bGjTlUNsScm9Dgb8wwBqmCzidf1pE1pXV4doGNxqwH3KtVng1AGTINA0NvkGLvQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - darwin
     cpu:
     - arm64
 
-  '@oxlint/binding-linux-arm64-gnu@1.58.0':
-    resolution: {integrity: sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ==}
+  '@oxlint/binding-linux-arm64-gnu@1.64.0':
+    resolution: {integrity: sha512-HpSQbubwh03mMhAdy2BYtad/fsY8vDFHDAb6bUwuCYg2VD3xCQgn6ArKcO0oZyLCheacKTv4PrF3Mfu5hgoE2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -500,8 +507,8 @@ packages:
     libc:
     - glibc
 
-  '@oxlint/binding-linux-arm64-musl@1.58.0':
-    resolution: {integrity: sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw==}
+  '@oxlint/binding-linux-arm64-musl@1.64.0':
+    resolution: {integrity: sha512-00QQ0h0Y7u0G69BgiH3+ky2aaq/QvkDL6DYok8htIuJHxybiux5aQ8jwmg8qIk9wha6UagUP2BAwAzbemcJbpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -510,8 +517,8 @@ packages:
     libc:
     - musl
 
-  '@oxlint/binding-linux-x64-gnu@1.58.0':
-    resolution: {integrity: sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==}
+  '@oxlint/binding-linux-x64-gnu@1.64.0':
+    resolution: {integrity: sha512-cR60vSd7+m+KRZ3GQGfDxWwahW5RMXg0qlGvAluZr0fTUYvw0H9N9AXAF/M/PMqgytyqvVNmBAkJG9l7U30Y1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -520,8 +527,8 @@ packages:
     libc:
     - glibc
 
-  '@oxlint/binding-linux-x64-musl@1.58.0':
-    resolution: {integrity: sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w==}
+  '@oxlint/binding-linux-x64-musl@1.64.0':
+    resolution: {integrity: sha512-2u/aPZ9pEg7HnvZPDsHxUGNnrpr4qaHi+mCgLgpt+LYRzPrS4Px4wPfkIdRdr2GvKnaYyt+XSlto0Vm5sbStTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - linux
@@ -530,16 +537,16 @@ packages:
     libc:
     - musl
 
-  '@oxlint/binding-win32-arm64-msvc@1.58.0':
-    resolution: {integrity: sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ==}
+  '@oxlint/binding-win32-arm64-msvc@1.64.0':
+    resolution: {integrity: sha512-r/cNKBFieONoVu2bb1KkVouq9W+edDUgHumXJGphCRRj+U0xaD4nanrw8ZOqo0IsutPkEM4vCcGBpak6x5aXMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - win32
     cpu:
     - arm64
 
-  '@oxlint/binding-win32-x64-msvc@1.58.0':
-    resolution: {integrity: sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg==}
+  '@oxlint/binding-win32-x64-msvc@1.64.0':
+    resolution: {integrity: sha512-9CBR+LO0JVST87fNTzzNxS5I29jIUO5gxT9i9+M3SDHHALElj9sY1Prf12tad3vIRC6OD7Ehtvvh+sn13vSwHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     os:
     - win32
@@ -741,6 +748,9 @@ packages:
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
+  '@types/node@25.8.0':
+    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
@@ -753,11 +763,11 @@ packages:
   '@types/tmp@0.2.6':
     resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -767,25 +777,25 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
 
-  '@vitest/ui@4.1.2':
-    resolution: {integrity: sha512-/irhyeAcKS2u6Zokagf9tqZJ0t8S6kMZq4ZG9BHZv7I+fkRrYfQX4w7geYeC2r6obThz39PDxvXQzZX+qXqGeg==}
+  '@vitest/ui@4.1.6':
+    resolution: {integrity: sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw==}
     peerDependencies:
-      vitest: 4.1.2
+      vitest: 4.1.6
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -1121,43 +1131,43 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  lefthook-darwin-arm64@2.1.4:
-    resolution: {integrity: sha512-BUAAE9+rUrjr39a+wH/1zHmGrDdwUQ2Yq/z6BQbM/yUb9qtXBRcQ5eOXxApqWW177VhGBpX31aqIlfAZ5Q7wzw==}
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
     os:
     - darwin
     cpu:
     - arm64
 
-  lefthook-linux-arm64@2.1.4:
-    resolution: {integrity: sha512-iWN0pGnTjrIvNIcSI1vQBJXUbybTqJ5CLMniPA0olabMXQfPDrdMKVQe+mgdwHK+E3/Y0H0ZNL3lnOj6Sk6szA==}
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
     os:
     - linux
     cpu:
     - arm64
 
-  lefthook-linux-x64@2.1.4:
-    resolution: {integrity: sha512-96bTBE/JdYgqWYAJDh+/e/0MaxJ25XTOAk7iy/fKoZ1ugf6S0W9bEFbnCFNooXOcxNVTan5xWKfcjJmPIKtsJA==}
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
     os:
     - linux
     cpu:
     - x64
 
-  lefthook-windows-arm64@2.1.4:
-    resolution: {integrity: sha512-hSww7z+QX4YMnw2lK7DMrs3+w7NtxksuMKOkCKGyxUAC/0m1LAICo0ZbtdDtZ7agxRQQQ/SEbzFRhU5ysNcbjA==}
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
     os:
     - win32
     cpu:
     - arm64
 
-  lefthook-windows-x64@2.1.4:
-    resolution: {integrity: sha512-eE68LwnogxwcPgGsbVGPGxmghyMGmU9SdGwcc+uhGnUxPz1jL89oECMWJNc36zjVK24umNeDAzB5KA3lw1MuWw==}
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
     os:
     - win32
     cpu:
     - x64
 
-  lefthook@2.1.4:
-    resolution: {integrity: sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w==}
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
     hasBin: true
 
   lightningcss-darwin-arm64@1.32.0:
@@ -1377,17 +1387,22 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  oxfmt@0.43.0:
-    resolution: {integrity: sha512-KTYNG5ISfHSdmeZ25Xzb3qgz9EmQvkaGAxgBY/p38+ZiAet3uZeu7FnMwcSQJg152Qwl0wnYAxDc+Z/H6cvrwA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  oxlint@1.58.0:
-    resolution: {integrity: sha512-t4s9leczDMqlvOSjnbCQe7gtoLkWgBGZ7sBdCJ9EOj5IXFSG/X7OAzK4yuH4iW+4cAYe8kLFbC8tuYMwWZm+Cg==}
+  oxfmt@0.49.0:
+    resolution: {integrity: sha512-IAHFMdlJSWe+oAr65dx22UvjCtV9DBMisAuLnKpDqMQrctzCkGnj3QRwNHm0d+uwSWPalsDF8ZYLz9rh6nH2IQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.18.0'
+      svelte: ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  oxlint@1.64.0:
+    resolution: {integrity: sha512-Star3SNpWPeWFPw7kRXIhXUSn6fdiAl25q15CQzH/9WaOtG6e9CWTc25vNZOCr4PE1yEP1GtKJKIKglhj3OmEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -1649,13 +1664,16 @@ packages:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
@@ -1718,18 +1736,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1745,6 +1765,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -2073,33 +2097,33 @@ snapshots:
 
   '@oxc-project/types@0.130.0': {}
 
-  '@oxfmt/binding-darwin-arm64@0.43.0': {}
+  '@oxfmt/binding-darwin-arm64@0.49.0': {}
 
-  '@oxfmt/binding-linux-arm64-gnu@0.43.0': {}
+  '@oxfmt/binding-linux-arm64-gnu@0.49.0': {}
 
-  '@oxfmt/binding-linux-arm64-musl@0.43.0': {}
+  '@oxfmt/binding-linux-arm64-musl@0.49.0': {}
 
-  '@oxfmt/binding-linux-x64-gnu@0.43.0': {}
+  '@oxfmt/binding-linux-x64-gnu@0.49.0': {}
 
-  '@oxfmt/binding-linux-x64-musl@0.43.0': {}
+  '@oxfmt/binding-linux-x64-musl@0.49.0': {}
 
-  '@oxfmt/binding-win32-arm64-msvc@0.43.0': {}
+  '@oxfmt/binding-win32-arm64-msvc@0.49.0': {}
 
-  '@oxfmt/binding-win32-x64-msvc@0.43.0': {}
+  '@oxfmt/binding-win32-x64-msvc@0.49.0': {}
 
-  '@oxlint/binding-darwin-arm64@1.58.0': {}
+  '@oxlint/binding-darwin-arm64@1.64.0': {}
 
-  '@oxlint/binding-linux-arm64-gnu@1.58.0': {}
+  '@oxlint/binding-linux-arm64-gnu@1.64.0': {}
 
-  '@oxlint/binding-linux-arm64-musl@1.58.0': {}
+  '@oxlint/binding-linux-arm64-musl@1.64.0': {}
 
-  '@oxlint/binding-linux-x64-gnu@1.58.0': {}
+  '@oxlint/binding-linux-x64-gnu@1.64.0': {}
 
-  '@oxlint/binding-linux-x64-musl@1.58.0': {}
+  '@oxlint/binding-linux-x64-musl@1.64.0': {}
 
-  '@oxlint/binding-win32-arm64-msvc@1.58.0': {}
+  '@oxlint/binding-win32-arm64-msvc@1.64.0': {}
 
-  '@oxlint/binding-win32-x64-msvc@1.58.0': {}
+  '@oxlint/binding-win32-x64-msvc@1.64.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -2126,25 +2150,25 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@pulumi/cloudflare@6.14.0(typescript@6.0.2)':
+  '@pulumi/cloudflare@6.14.0(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
+      '@pulumi/pulumi': 3.229.0(typescript@6.0.3)
 
-  '@pulumi/command@1.2.1(typescript@6.0.2)':
+  '@pulumi/command@1.2.1(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
+      '@pulumi/pulumi': 3.229.0(typescript@6.0.3)
 
-  '@pulumi/hcloud@1.32.1(typescript@6.0.2)':
+  '@pulumi/hcloud@1.32.1(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
+      '@pulumi/pulumi': 3.229.0(typescript@6.0.3)
 
-  '@pulumi/kubernetes@4.28.0(typescript@6.0.2)':
+  '@pulumi/kubernetes@4.28.0(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
+      '@pulumi/pulumi': 3.229.0(typescript@6.0.3)
       glob: 12.0.0
       shell-quote: 1.8.3
 
-  '@pulumi/pulumi@3.229.0(typescript@6.0.2)':
+  '@pulumi/pulumi@3.229.0(typescript@6.0.3)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@logdna/tail-file': 2.2.0
@@ -2174,16 +2198,16 @@ snapshots:
       semver: 7.7.4
       source-map-support: 0.5.21
       tmp: 0.2.5
-      typescript: 6.0.2
+      typescript: 6.0.3
       upath: 1.2.0
 
-  '@pulumi/random@4.19.2(typescript@6.0.2)':
+  '@pulumi/random@4.19.2(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
+      '@pulumi/pulumi': 3.229.0(typescript@6.0.3)
 
-  '@pulumi/tls@5.3.1(typescript@6.0.2)':
+  '@pulumi/tls@5.3.1(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
+      '@pulumi/pulumi': 3.229.0(typescript@6.0.3)
 
   '@rolldown/binding-darwin-arm64@1.0.1': {}
 
@@ -2276,6 +2300,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.8.0':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 25.5.2
@@ -2286,54 +2314,54 @@ snapshots:
 
   '@types/tmp@0.2.6': {}
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.6':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.13(@types/node@25.5.2))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.8.0))':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 8.0.13(@types/node@25.5.2)
+      vite: 8.0.13(@types/node@25.8.0)
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.6':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.6
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.6': {}
 
-  '@vitest/ui@4.1.2(vitest@4.1.2)':
+  '@vitest/ui@4.1.6(vitest@4.1.6)':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.6
       fflate: 0.8.2
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.16(picomatch@4.0.4)
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/ui@4.1.2)(vite@8.0.13(@types/node@25.5.2))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/ui@4.1.6)(vite@8.0.13(@types/node@25.8.0))
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2637,23 +2665,23 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  lefthook-darwin-arm64@2.1.4: {}
+  lefthook-darwin-arm64@2.1.6: {}
 
-  lefthook-linux-arm64@2.1.4: {}
+  lefthook-linux-arm64@2.1.6: {}
 
-  lefthook-linux-x64@2.1.4: {}
+  lefthook-linux-x64@2.1.6: {}
 
-  lefthook-windows-arm64@2.1.4: {}
+  lefthook-windows-arm64@2.1.6: {}
 
-  lefthook-windows-x64@2.1.4: {}
+  lefthook-windows-x64@2.1.6: {}
 
-  lefthook@2.1.4:
+  lefthook@2.1.6:
     optionalDependencies:
-      lefthook-darwin-arm64: 2.1.4
-      lefthook-linux-arm64: 2.1.4
-      lefthook-linux-x64: 2.1.4
-      lefthook-windows-arm64: 2.1.4
-      lefthook-windows-x64: 2.1.4
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   lightningcss-darwin-arm64@1.32.0: {}
 
@@ -2847,27 +2875,27 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  oxfmt@0.43.0:
+  oxfmt@0.49.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-darwin-arm64': 0.43.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.43.0
-      '@oxfmt/binding-linux-arm64-musl': 0.43.0
-      '@oxfmt/binding-linux-x64-gnu': 0.43.0
-      '@oxfmt/binding-linux-x64-musl': 0.43.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.43.0
-      '@oxfmt/binding-win32-x64-msvc': 0.43.0
+      '@oxfmt/binding-darwin-arm64': 0.49.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.49.0
+      '@oxfmt/binding-linux-arm64-musl': 0.49.0
+      '@oxfmt/binding-linux-x64-gnu': 0.49.0
+      '@oxfmt/binding-linux-x64-musl': 0.49.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.49.0
+      '@oxfmt/binding-win32-x64-msvc': 0.49.0
 
-  oxlint@1.58.0:
+  oxlint@1.64.0:
     optionalDependencies:
-      '@oxlint/binding-darwin-arm64': 1.58.0
-      '@oxlint/binding-linux-arm64-gnu': 1.58.0
-      '@oxlint/binding-linux-arm64-musl': 1.58.0
-      '@oxlint/binding-linux-x64-gnu': 1.58.0
-      '@oxlint/binding-linux-x64-musl': 1.58.0
-      '@oxlint/binding-win32-arm64-msvc': 1.58.0
-      '@oxlint/binding-win32-x64-msvc': 1.58.0
+      '@oxlint/binding-darwin-arm64': 1.64.0
+      '@oxlint/binding-linux-arm64-gnu': 1.64.0
+      '@oxlint/binding-linux-arm64-musl': 1.64.0
+      '@oxlint/binding-linux-x64-gnu': 1.64.0
+      '@oxlint/binding-linux-x64-musl': 1.64.0
+      '@oxlint/binding-win32-arm64-msvc': 1.64.0
+      '@oxlint/binding-win32-x64-msvc': 1.64.0
 
   p-cancelable@2.1.1: {}
 
@@ -3132,9 +3160,11 @@ snapshots:
       debug: 4.4.3
       make-fetch-happen: 15.0.5
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
   undici-types@7.18.2: {}
+
+  undici-types@7.24.6: {}
 
   undici@6.25.0: {}
 
@@ -3149,9 +3179,9 @@ snapshots:
 
   validate-npm-package-name@7.0.2: {}
 
-  vite@8.0.13(@types/node@25.5.2):
+  vite@8.0.13(@types/node@25.8.0):
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.8.0
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.14
@@ -3160,18 +3190,18 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/ui@4.1.2)(vite@8.0.13(@types/node@25.5.2)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/ui@4.1.6)(vite@8.0.13(@types/node@25.8.0)):
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 25.5.2
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.13(@types/node@25.5.2))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/ui': 4.1.2(vitest@4.1.2)
-      '@vitest/utils': 4.1.2
+      '@types/node': 25.8.0
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.8.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/ui': 4.1.6(vitest@4.1.6)
+      '@vitest/utils': 4.1.6
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -3183,7 +3213,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16(picomatch@4.0.4)
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.5.2)
+      vite: 8.0.13(@types/node@25.8.0)
       why-is-node-running: 2.3.0
 
   walk-up-path@4.0.0: {}

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   "devDependencies": {
     "@tsconfig/node-ts": "23.6.4",
     "@tsconfig/node24": "24.0.4",
-    "@types/node": "25.5.2",
-    "@vitest/ui": "4.1.2",
-    "lefthook": "2.1.4",
-    "oxfmt": "0.43.0",
-    "oxlint": "1.58.0",
-    "typescript": "6.0.2",
-    "vitest": "4.1.2"
+    "@types/node": "25.8.0",
+    "@vitest/ui": "4.1.6",
+    "lefthook": "2.1.6",
+    "oxfmt": "0.49.0",
+    "oxlint": "1.64.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.6"
   }
 }


### PR DESCRIPTION
## Summary

- `oxlint` 1.58.0 → 1.64.0
- `oxfmt` 0.43.0 → 0.49.0
- `typescript` 6.0.2 → 6.0.3
- `@vitest/ui` + `vitest` 4.1.2 → 4.1.6
- `lefthook` 2.1.4 → 2.1.6
- `@types/node` 25.5.2 → 25.8.0

Syncing dev tooling versions with sibling repo blit.

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors (oxlint 1.64.0)
- [x] `bun run fmt:check` — all files correctly formatted (oxfmt 0.49.0)
- [x] `bun run typecheck:infra` — no type errors (typescript 6.0.3)
- [x] `bun run test` — 5/5 tests passed (vitest 4.1.6)