### PR TITLE
chore(ansible): rotate deploy ssh public key

### DIFF
--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -9,4 +9,4 @@ oldboy-local ansible_host=oldboy.local
 # Global SSH settings
 ansible_ssh_common_args='-o StrictHostKeyChecking=accept-new'
 ansible_python_interpreter=/usr/bin/python3
-ssh_public_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA+uP2y62/O3KZbRVq6M7p0a9bQOOHgFexpk5aCDYplj'
+ssh_public_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIOKFd98fp579BSC4svd/E8h1Bs5aeu9Iv5qix40+WmI'


### PR DESCRIPTION
Rotates the `ssh_public_key` in `ansible/inventory/hosts` to the freshly-rolled ed25519 key. The `users` role pushes this into `authorized_keys` for `{{ oldboy_user }}`.

Merging triggers `run-playbook.yml` (paths: `ansible/**`), which re-runs the playbook against `homeservers` and installs the new key — no physical access needed.

CI's own deploy key (`SSH_PRIVATE_KEY` secret) is untouched, so the playbook run can still connect.

**Note:** `authorized_key` is non-exclusive, so this adds the new key but does not actively remove the old one if it was manually present. The old key simply stops being re-added by ansible.