### PR TITLE
fix(ci): stop setting removed tv service config

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,8 +43,6 @@ on:
         required: true
       FILES_HOSTNAME:
         required: true
-      TV_HOSTNAME:
-        required: true
       BLIT_HOSTNAME:
         required: true
 
@@ -191,7 +189,6 @@ jobs:
           pulumi config set --path jaritanet:services.navidrome.hostname "$NAVIDROME_HOSTNAME"
           pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
           pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
-          pulumi config set --path jaritanet:services.tv.hostname "$TV_HOSTNAME"
           if [[ -n "$EXTERNAL_IP" ]]; then
             pulumi config set jaritanet:externalIp "$EXTERNAL_IP"
           fi
@@ -202,7 +199,6 @@ jobs:
           NAVIDROME_HOSTNAME: ${{ secrets.NAVIDROME_HOSTNAME }}
           FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           BLIT_HOSTNAME: ${{ secrets.BLIT_HOSTNAME }}
-          TV_HOSTNAME: ${{ secrets.TV_HOSTNAME }}
 
       - name: Deploy
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6


### PR DESCRIPTION
## What

Removes the `tv` service references left in `ci-cd.yml` after commit `480b6f0` ("remove tv for now") deleted `tv` from the config schema.

## Why

`ServiceConfSchema` requires `args`. The deploy step ran `pulumi config set --path jaritanet:services.tv.hostname "$TV_HOSTNAME"`, creating a `services.tv` entry with only a `hostname` and no `args` — which fails Zod validation. Every deploy since the schema change died with `Error: Could not parse config` ([failing run](https://github.com/radiosilence/jaritanet/actions/runs/26347218726/job/77559002371)).

## Verify

Next `pulumi up` on main no longer sets `services.tv`, so config parses. The `TV_HOSTNAME` secret is now unused and can be deleted from repo secrets.