### PR TITLE
feat(gateway): Xray VLESS-REALITY VPN on shared :443

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -186,9 +186,12 @@ jobs:
         run: |
           pulumi stack select radiosilence/jaritanet/main
           pulumi config set --path jaritanet:cloudflare.accountId "$CLOUDFLARE_ACCOUNT_ID"
+          pulumi config set --path jaritanet:traefik.acmeEmail "$ACME_EMAIL"
           pulumi config set --path jaritanet:services.navidrome.hostname "$NAVIDROME_HOSTNAME"
           pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
           pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
+          # Reality decoy is the blit CV site, so reuse its hostname secret
+          pulumi config set --path jaritanet:gateway.xray.serverName "$BLIT_HOSTNAME"
           if [[ -n "$EXTERNAL_IP" ]]; then
             pulumi config set jaritanet:externalIp "$EXTERNAL_IP"
           fi
@@ -196,6 +199,7 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
           NAVIDROME_HOSTNAME: ${{ secrets.NAVIDROME_HOSTNAME }}
           FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           BLIT_HOSTNAME: ${{ secrets.BLIT_HOSTNAME }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Everything deploys in one `pulumi up` from `packages/infra/`:
 
 - **`src/modules/gateway.ts`** — Hetzner VPS + firewall + Rathole server provisioning
 - **`src/modules/gateway-oci.ts`** — Oracle Cloud ARM instance + VCN + Rathole via Docker
+- **`src/modules/xray.ts`** — optional Xray VLESS-REALITY VPN sharing :443 with the gateway
 - **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoute CRDs, IP watcher
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
 - **`src/templates/service.ts`** — K8s Deployment/Service/PV/PVC templates
@@ -73,6 +74,7 @@ Without a gateway, Traefik serves directly via hostPort 443 and DNS points at th
 ### Key Components
 
 - **Rathole** — Rust-based TCP tunnel. Server on VPS, client in K8s. Stateless relay, no TLS/routing knowledge.
+- **Xray (optional)** — When `gateway.xray` is set, Xray-core owns the VPS `:443` running VLESS-Vision-REALITY and rathole's https bind moves to local `:8443`. Unauthenticated traffic (probes, browsers) is relayed to `dest` (rathole → Traefik) so the box looks like an ordinary TLS site; authenticated clients are proxied out as a censorship-resistant VPN. The REALITY keypair is minted on-box and never leaves it; the client `vless://` URL is a stack output (`xrayShareUrl`). `serverName` must be a hostname Traefik serves a real cert for.
 - **Traefik** — Ingress controller with built-in ACME. Handles Let's Encrypt certs via DNS-01 challenge against Cloudflare. Always binds hostPort 443 as fallback.
 - **Cloudflare** — DNS only. A records pointing at VPS or server IP, plus Fastmail MX/DKIM and Bluesky ATProto records.
 - **IP watcher** — Pod that checks external IP every 60s via Cloudflare's 1.1.1.1/cdn-cgi/trace and triggers deploy on change.

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -5,14 +5,17 @@ config:
   jaritanet:cloudflare:
     accountId: ''
   jaritanet:traefik:
-    acmeEmail: jc@blit.cc
+    # acmeEmail injected from the ACME_EMAIL secret in CI (see ci-cd.yml)
+    acmeEmail: ''
     chartVersion: "41.0.2"
   jaritanet:gateway:
     # Xray VLESS-Vision-REALITY on :443. Unauthenticated traffic is relayed
     # to the local rathole https port (dest) so the box just looks like the
-    # blit.cc CV site; authenticated clients get proxied out as a VPN.
+    # decoy site; authenticated clients get proxied out as a VPN.
+    # serverName injected from the BLIT_HOSTNAME secret in CI (the decoy IS
+    # the blit CV site), so it never sits in plain config.
     xray:
-      serverName: blit.cc
+      serverName: ''
       dest: 127.0.0.1:8443
   jaritanet:services:
     navidrome:
@@ -92,7 +95,7 @@ config:
             readOnly: true
             nodeAffinityHostname: oldboy
     blit:
-      hostname: 'blit.cc'
+      hostname: ''
       args:
         replicas: 2
         healthCheck: {}

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -7,6 +7,13 @@ config:
   jaritanet:traefik:
     acmeEmail: jc@blit.cc
     chartVersion: "40.2.0"
+  jaritanet:gateway:
+    # Xray VLESS-Vision-REALITY on :443. Unauthenticated traffic is relayed
+    # to the local rathole https port (dest) so the box just looks like the
+    # blit.cc CV site; authenticated clients get proxied out as a VPN.
+    xray:
+      serverName: blit.cc
+      dest: 127.0.0.1:8443
   jaritanet:services:
     navidrome:
       hostname: ''
@@ -85,7 +92,7 @@ config:
             readOnly: true
             nodeAffinityHostname: oldboy
     blit:
-      hostname: ''
+      hostname: 'blit.cc'
       args:
         replicas: 2
         healthCheck: {}

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -5,11 +5,29 @@ export const CloudflareConfSchema = z.object({
   accountId: z.string(),
 });
 
+/**
+ * Xray-core with VLESS-Vision-REALITY on the gateway VPS, sharing :443
+ * with rathole. Unauthenticated connections (probes, browsers) are relayed
+ * to `dest` so the box looks like an ordinary TLS site; authenticated
+ * clients get proxied out to the internet as a censorship-resistant VPN.
+ *
+ * `serverName` is the SNI clients present and the domain the decoy pretends
+ * to be — it must match the cert served at `dest`. `dest` defaults to the
+ * local rathole https port (so the decoy is your own Traefik); point it at
+ * an external site (e.g. "www.microsoft.com:443") to borrow someone else's.
+ */
+export const XrayConfSchema = z.object({
+  dest: z.string().default("127.0.0.1:8443"),
+  serverName: z.string(),
+  version: z.string().default("v1.8.24"),
+});
+
 export const GatewayConfSchema = z.object({
   image: z.string().default("ubuntu-24.04"),
   location: z.string().default("nbg1"),
   ratholeVersion: z.string().default("v0.5.0"),
   serverType: z.string().default("cx23"),
+  xray: XrayConfSchema.optional(),
 });
 
 export const TraefikConfSchema = z.object({

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -28,12 +28,14 @@ export default async function () {
   let dnsTarget: pulumi.Output<string> | undefined;
   let ratholeToken: pulumi.Output<string> | undefined;
   let gatewayProvider: string | undefined;
+  let xray: ReturnType<typeof createGateway>["xray"];
 
   if (env.HCLOUD_TOKEN) {
     const gw = createGateway(conf.gateway ?? GatewayConfSchema.parse({}));
     dnsTarget = gw.vpsIp;
     ratholeToken = gw.ratholeToken.result;
     gatewayProvider = "hetzner";
+    xray = gw.xray;
   } else if (conf.externalIp) {
     dnsTarget = pulumi.output(conf.externalIp);
   }
@@ -133,5 +135,12 @@ export default async function () {
     namespace,
     services: Object.fromEntries(services),
     ...(dnsTarget && { vpsIp: dnsTarget }),
+    ...(xray && {
+      xrayPublicKey: xray.publicKey,
+      xrayServerName: conf.gateway?.xray?.serverName,
+      xrayShareUrl: xray.shareUrl,
+      xrayShortId: xray.shortId,
+      xrayUuid: xray.uuid,
+    }),
   };
 }

--- a/packages/infra/src/modules/gateway.ts
+++ b/packages/infra/src/modules/gateway.ts
@@ -5,6 +5,7 @@ import * as random from "@pulumi/random";
 import * as tls from "@pulumi/tls";
 import type * as z from "zod";
 import type { GatewayConfSchema } from "../conf.schemas.ts";
+import { createXray } from "./xray.ts";
 
 /**
  * Provisions a Hetzner VPS running rathole as a TCP relay.
@@ -106,6 +107,10 @@ systemctl enable rathole
     user: "root",
   };
 
+  // When Xray is enabled it owns the public :443 and uses rathole as its
+  // decoy backend, so rathole's https bind moves to a local-only port.
+  const httpsBind = gateway.xray ? "127.0.0.1:8443" : "0.0.0.0:443";
+
   // Write rathole config via SSH (supports updates without replacing the server)
   const ratholeConfig = pulumi.interpolate`[server]
 bind_addr = "0.0.0.0:2333"
@@ -113,7 +118,7 @@ default_token = "${ratholeToken.result}"
 
 [server.services.https]
 type = "tcp"
-bind_addr = "0.0.0.0:443"
+bind_addr = "${httpsBind}"
 
 [server.services.http]
 type = "tcp"
@@ -127,7 +132,7 @@ bind_addr = "0.0.0.0:80"
       create: pulumi.interpolate`cat > /etc/rathole/server.toml << 'RATHOLE_EOF'
 ${ratholeConfig}
 RATHOLE_EOF`,
-      triggers: [ratholeToken.result],
+      triggers: [ratholeToken.result, httpsBind],
     },
     { dependsOn: [server] },
   );
@@ -142,10 +147,15 @@ RATHOLE_EOF`,
     { dependsOn: [configUpload] },
   );
 
+  const xray = gateway.xray
+    ? createXray(connection, server, gateway.xray)
+    : undefined;
+
   return {
     ratholeToken,
     server,
     sshKey,
     vpsIp: server.ipv4Address,
+    xray,
   };
 }

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -38,38 +38,20 @@ export function createXray(
     {
       connection,
       create: pulumi.interpolate`set -euo pipefail
-curl -fsSL "https://github.com/XTLS/Xray-core/releases/download/${xray.version}/Xray-linux-64.zip" -o /tmp/xray.zip
-apt-get update && apt-get install -y unzip
-unzip -o /tmp/xray.zip -d /usr/local/bin/ xray
-chmod +x /usr/local/bin/xray
-rm /tmp/xray.zip
-mkdir -p /etc/xray
+export DEBIAN_FRONTEND=noninteractive
+XRAY_VERSION=$(printf '%s' "${xray.version}" | sed 's/^v//')
+
+# Official XTLS installer: sets up the systemd unit, a dedicated user,
+# CAP_NET_BIND_SERVICE for :443, plus geodata and log dirs.
+bash -c "$(curl -fsSL https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --version "$XRAY_VERSION"
 
 # Mint the REALITY keypair once; the private key never leaves the box.
-if [ ! -f /etc/xray/private.key ]; then
-  /usr/local/bin/xray x25519 > /etc/xray/keypair.txt
-  sed -n '1p' /etc/xray/keypair.txt | awk '{print $NF}' > /etc/xray/private.key
-  sed -n '2p' /etc/xray/keypair.txt | awk '{print $NF}' > /etc/xray/public.key
-  rm /etc/xray/keypair.txt
-fi
-
-cat > /etc/systemd/system/xray.service << 'UNIT'
-[Unit]
-Description=Xray
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-ExecStart=/usr/local/bin/xray run -c /etc/xray/config.json
-Restart=always
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-systemctl daemon-reload
-systemctl enable xray`,
+if [ ! -f /usr/local/etc/xray/private.key ]; then
+  /usr/local/bin/xray x25519 > /tmp/xray-keypair.txt
+  sed -n '1p' /tmp/xray-keypair.txt | awk '{print $NF}' > /usr/local/etc/xray/private.key
+  sed -n '2p' /tmp/xray-keypair.txt | awk '{print $NF}' > /usr/local/etc/xray/public.key
+  rm -f /tmp/xray-keypair.txt
+fi`,
       triggers: [xray.version],
     },
     { dependsOn: [server] },
@@ -80,7 +62,7 @@ systemctl enable xray`,
     "xray-public-key",
     {
       connection,
-      create: "cat /etc/xray/public.key",
+      create: "cat /usr/local/etc/xray/public.key",
       triggers: [install.id],
     },
     { dependsOn: [install] },
@@ -93,8 +75,8 @@ systemctl enable xray`,
     {
       connection,
       create: pulumi.interpolate`set -euo pipefail
-PRIV=$(cat /etc/xray/private.key)
-cat > /etc/xray/config.json << XRAY_EOF
+PRIV=$(cat /usr/local/etc/xray/private.key)
+cat > /usr/local/etc/xray/config.json << XRAY_EOF
 {
   "log": { "loglevel": "warning" },
   "inbounds": [

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -1,0 +1,148 @@
+import * as command from "@pulumi/command";
+import type * as hcloud from "@pulumi/hcloud";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import type * as z from "zod";
+import type { XrayConfSchema } from "../conf.schemas.ts";
+
+type Connection = {
+  host: pulumi.Output<string>;
+  privateKey: pulumi.Output<string>;
+  user: string;
+};
+
+/**
+ * Provisions Xray-core with VLESS-Vision-REALITY on the gateway VPS.
+ *
+ * Xray owns :443 and impersonates a real TLS site. Unauthenticated
+ * connections (active probes, browsers) are relayed byte-for-byte to
+ * `dest` — the local rathole https port that tunnels to in-cluster
+ * Traefik — so an observer sees the genuine site and its real cert.
+ * Authenticated VLESS clients are proxied straight out to the internet,
+ * giving a censorship-resistant VPN over what looks like plain HTTPS.
+ *
+ * Keys are minted on first boot and never leave the box: the x25519
+ * private key stays in /etc/xray, and the UUID + shortId are Pulumi
+ * secrets. A ready-to-paste vless:// share URL is returned for clients.
+ */
+export function createXray(
+  connection: Connection,
+  server: hcloud.Server,
+  xray: z.infer<typeof XrayConfSchema>,
+) {
+  const uuid = new random.RandomUuid("xray-uuid");
+  const shortId = new random.RandomId("xray-short-id", { byteLength: 8 });
+
+  const install = new command.remote.Command(
+    "xray-install",
+    {
+      connection,
+      create: pulumi.interpolate`set -euo pipefail
+curl -fsSL "https://github.com/XTLS/Xray-core/releases/download/${xray.version}/Xray-linux-64.zip" -o /tmp/xray.zip
+apt-get update && apt-get install -y unzip
+unzip -o /tmp/xray.zip -d /usr/local/bin/ xray
+chmod +x /usr/local/bin/xray
+rm /tmp/xray.zip
+mkdir -p /etc/xray
+
+# Mint the REALITY keypair once; the private key never leaves the box.
+if [ ! -f /etc/xray/private.key ]; then
+  /usr/local/bin/xray x25519 > /etc/xray/keypair.txt
+  sed -n '1p' /etc/xray/keypair.txt | awk '{print $NF}' > /etc/xray/private.key
+  sed -n '2p' /etc/xray/keypair.txt | awk '{print $NF}' > /etc/xray/public.key
+  rm /etc/xray/keypair.txt
+fi
+
+cat > /etc/systemd/system/xray.service << 'UNIT'
+[Unit]
+Description=Xray
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/xray run -c /etc/xray/config.json
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable xray`,
+      triggers: [xray.version],
+    },
+    { dependsOn: [server] },
+  );
+
+  // Read back the minted public key so clients can be configured.
+  const publicKey = new command.remote.Command(
+    "xray-public-key",
+    {
+      connection,
+      create: "cat /etc/xray/public.key",
+      triggers: [install.id],
+    },
+    { dependsOn: [install] },
+  );
+
+  // Render config.json on the box, injecting the private key from disk so
+  // it stays off the wire and out of Pulumi state.
+  const config = new command.remote.Command(
+    "xray-config",
+    {
+      connection,
+      create: pulumi.interpolate`set -euo pipefail
+PRIV=$(cat /etc/xray/private.key)
+cat > /etc/xray/config.json << XRAY_EOF
+{
+  "log": { "loglevel": "warning" },
+  "inbounds": [
+    {
+      "listen": "0.0.0.0",
+      "port": 443,
+      "protocol": "vless",
+      "settings": {
+        "clients": [{ "id": "${uuid.result}", "flow": "xtls-rprx-vision" }],
+        "decryption": "none"
+      },
+      "streamSettings": {
+        "network": "tcp",
+        "security": "reality",
+        "realitySettings": {
+          "show": false,
+          "dest": "${xray.dest}",
+          "xver": 0,
+          "serverNames": ["${xray.serverName}"],
+          "privateKey": "$PRIV",
+          "shortIds": ["${shortId.hex}"]
+        }
+      }
+    }
+  ],
+  "outbounds": [{ "protocol": "freedom" }]
+}
+XRAY_EOF
+systemctl restart xray`,
+      triggers: [
+        uuid.result,
+        shortId.hex,
+        xray.serverName,
+        xray.dest,
+        publicKey.stdout,
+      ],
+    },
+    { dependsOn: [publicKey] },
+  );
+
+  // vless:// URL that Shadowrocket / sing-box / v2box import directly.
+  const shareUrl = pulumi.interpolate`vless://${uuid.result}@${connection.host}:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=${xray.serverName}&fp=chrome&pbk=${publicKey.stdout}&sid=${shortId.hex}&type=tcp#jaritanet`;
+
+  return {
+    config,
+    publicKey: publicKey.stdout,
+    shareUrl: pulumi.secret(shareUrl),
+    shortId: shortId.hex,
+    uuid: uuid.result,
+  };
+}

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -40,6 +40,23 @@
             "serverType": {
               "default": "cx23",
               "type": "string"
+            },
+            "xray": {
+              "type": "object",
+              "properties": {
+                "dest": {
+                  "default": "127.0.0.1:8443",
+                  "type": "string"
+                },
+                "serverName": {
+                  "type": "string"
+                },
+                "version": {
+                  "default": "v1.8.24",
+                  "type": "string"
+                }
+              },
+              "required": ["serverName"]
             }
           }
         },


### PR DESCRIPTION
Adds an opt-in censorship-resistant VPN on the Hetzner gateway box, sharing port 443 with the existing rathole relay.

## What it does

Xray-core takes the VPS `:443` running **VLESS-Vision-REALITY**; rathole's https bind moves to local `:8443`. Two paths share the port:

- **Unauthenticated** (active probes, browsers) → relayed byte-for-byte to `dest` (rathole → in-cluster Traefik) → they see the real `blit.cc` CV site + its valid Let's Encrypt cert. Pure camouflage.
- **Authenticated** (Shadowrocket / sing-box with the keys) → the TLS handshake still *looks* like a session to `blit.cc`, then Xray proxies traffic straight out to the internet. VPN egress, never touches Traefik.

## Load-bearing decisions

- **Decoy = `blit.cc`** (the `blit` service, now exposed). A real, valid site is the strongest self-decoy — `serverName` must match a hostname Traefik holds a real cert for. Cloudflare proxy stays off (`proxied: false`), which REALITY requires.
- **Keys never leave the box.** `xray x25519` runs once on first boot; the private key stays in `/etc/xray`. UUID + shortId are Pulumi `random` secrets. No manual key management.
- **No server replacement.** `userData` is untouched — Xray installs and rathole reconfigures via `command.remote` SSH steps, so the box (and its IP) survive the change.
- **Opt-in.** Everything is gated behind `gateway.xray` config; absent = current behaviour (rathole on `:443`).

## How to verify

1. `pulumi up` deploys it. Confirm `blit.cc` resolves to the VPS and serves the CV site over HTTPS (the decoy path).
2. Pull the client config: `pulumi stack output xrayShareUrl --show-secrets` → paste the `vless://` URL into sing-box (SFI/SFM) or Shadowrocket → confirm tunnelled egress.
3. `firewall` unchanged — `:443` already open, `:8443` is localhost-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)