### PR TITLE
chore(gateway): dry up xray comments

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -190,7 +190,6 @@ jobs:
           pulumi config set --path jaritanet:services.navidrome.hostname "$NAVIDROME_HOSTNAME"
           pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
           pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
-          # Reality decoy is the blit CV site, so reuse its hostname secret
           pulumi config set --path jaritanet:gateway.xray.serverName "$BLIT_HOSTNAME"
           if [[ -n "$EXTERNAL_IP" ]]; then
             pulumi config set jaritanet:externalIp "$EXTERNAL_IP"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Everything deploys in one `pulumi up` from `packages/infra/`:
 
 - **`src/modules/gateway.ts`** — Hetzner VPS + firewall + Rathole server provisioning
 - **`src/modules/gateway-oci.ts`** — Oracle Cloud ARM instance + VCN + Rathole via Docker
-- **`src/modules/xray.ts`** — optional Xray VLESS-REALITY VPN sharing :443 with the gateway
+- **`src/modules/xray.ts`** — optional Xray VLESS-REALITY proxy sharing :443 with the gateway
 - **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoute CRDs, IP watcher
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
 - **`src/templates/service.ts`** — K8s Deployment/Service/PV/PVC templates
@@ -74,7 +74,7 @@ Without a gateway, Traefik serves directly via hostPort 443 and DNS points at th
 ### Key Components
 
 - **Rathole** — Rust-based TCP tunnel. Server on VPS, client in K8s. Stateless relay, no TLS/routing knowledge.
-- **Xray (optional)** — When `gateway.xray` is set, Xray-core owns the VPS `:443` running VLESS-Vision-REALITY and rathole's https bind moves to local `:8443`. Unauthenticated traffic (probes, browsers) is relayed to `dest` (rathole → Traefik) so the box looks like an ordinary TLS site; authenticated clients are proxied out as a censorship-resistant VPN. The REALITY keypair is minted on-box and never leaves it; the client `vless://` URL is a stack output (`xrayShareUrl`). `serverName` must be a hostname Traefik serves a real cert for.
+- **Xray (optional)** — When `gateway.xray` is set, Xray-core takes the VPS `:443` (VLESS-Vision-REALITY) and rathole's https bind moves to local `:8443`. Traffic that doesn't match a client is relayed to `dest` (rathole → Traefik); matched clients are proxied out. The keypair is minted on-box and never leaves it; the client `vless://` URL is a stack output (`xrayShareUrl`). `serverName` must be a hostname Traefik serves a real cert for.
 - **Traefik** — Ingress controller with built-in ACME. Handles Let's Encrypt certs via DNS-01 challenge against Cloudflare. Always binds hostPort 443 as fallback.
 - **Cloudflare** — DNS only. A records pointing at VPS or server IP, plus Fastmail MX/DKIM and Bluesky ATProto records.
 - **IP watcher** — Pod that checks external IP every 60s via Cloudflare's 1.1.1.1/cdn-cgi/trace and triggers deploy on change.

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -9,11 +9,9 @@ config:
     acmeEmail: ''
     chartVersion: "41.0.2"
   jaritanet:gateway:
-    # Xray VLESS-Vision-REALITY on :443. Unauthenticated traffic is relayed
-    # to the local rathole https port (dest) so the box just looks like the
-    # decoy site; authenticated clients get proxied out as a VPN.
-    # serverName injected from the BLIT_HOSTNAME secret in CI (the decoy IS
-    # the blit CV site), so it never sits in plain config.
+    # xray shares :443; traffic that doesn't match a client falls back to
+    # dest (local rathole https). serverName is injected from BLIT_HOSTNAME
+    # in CI, so it stays out of plain config.
     xray:
       serverName: ''
       dest: 127.0.0.1:8443

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -6,15 +6,13 @@ export const CloudflareConfSchema = z.object({
 });
 
 /**
- * Xray-core with VLESS-Vision-REALITY on the gateway VPS, sharing :443
- * with rathole. Unauthenticated connections (probes, browsers) are relayed
- * to `dest` so the box looks like an ordinary TLS site; authenticated
- * clients get proxied out to the internet as a censorship-resistant VPN.
+ * Xray-core (VLESS-Vision-REALITY) on the gateway VPS, sharing :443 with
+ * rathole. Traffic that doesn't match a client is relayed to `dest`;
+ * matched clients are proxied out.
  *
- * `serverName` is the SNI clients present and the domain the decoy pretends
- * to be — it must match the cert served at `dest`. `dest` defaults to the
- * local rathole https port (so the decoy is your own Traefik); point it at
- * an external site (e.g. "www.microsoft.com:443") to borrow someone else's.
+ * `serverName` is the SNI clients present and must match the TLS cert served
+ * at `dest`. `dest` defaults to the local rathole https port; point it at an
+ * external "host:port" to use a different backend.
  */
 export const XrayConfSchema = z.object({
   dest: z.string().default("127.0.0.1:8443"),

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -12,18 +12,13 @@ type Connection = {
 };
 
 /**
- * Provisions Xray-core with VLESS-Vision-REALITY on the gateway VPS.
+ * Provisions Xray-core (VLESS-Vision-REALITY) on the gateway VPS.
  *
- * Xray owns :443 and impersonates a real TLS site. Unauthenticated
- * connections (active probes, browsers) are relayed byte-for-byte to
- * `dest` — the local rathole https port that tunnels to in-cluster
- * Traefik — so an observer sees the genuine site and its real cert.
- * Authenticated VLESS clients are proxied straight out to the internet,
- * giving a censorship-resistant VPN over what looks like plain HTTPS.
- *
- * Keys are minted on first boot and never leave the box: the x25519
- * private key stays in /etc/xray, and the UUID + shortId are Pulumi
- * secrets. A ready-to-paste vless:// share URL is returned for clients.
+ * Xray takes :443; traffic that doesn't match a client is relayed to `dest`
+ * (the local rathole https port → in-cluster Traefik), matched clients are
+ * proxied out. Keys are minted on first boot and never leave the box: the
+ * x25519 private key stays in /usr/local/etc/xray and the UUID + shortId
+ * are Pulumi secrets. Returns a vless:// share URL for client import.
  */
 export function createXray(
   connection: Connection,
@@ -117,7 +112,7 @@ systemctl restart xray`,
     { dependsOn: [publicKey] },
   );
 
-  // vless:// URL that Shadowrocket / sing-box / v2box import directly.
+  // vless:// share URL for client import.
   const shareUrl = pulumi.interpolate`vless://${uuid.result}@${connection.host}:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=${xray.serverName}&fp=chrome&pbk=${publicKey.stdout}&sid=${shortId.hex}&type=tcp#jaritanet`;
 
   return {


### PR DESCRIPTION
Strips the editorial framing (VPN / decoy / censorship prose) from the xray comments and docs so config and docblocks read as flat technical description. No behaviour change — comments only.

Note: git history and the #55 PR body still describe intent; this only cleans the current tree.