### PR TITLE
feat(gateway): tailnet relay for censorship-resistant 100.x

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,6 +45,8 @@ on:
         required: true
       BLIT_HOSTNAME:
         required: true
+      TS_AUTHKEY:
+        required: false
 
 concurrency:
   group: ci-cd-${{ github.ref }}
@@ -218,3 +220,4 @@ jobs:
           KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}

--- a/clients/README.md
+++ b/clients/README.md
@@ -10,26 +10,33 @@ config for the gateway. It carries two transports behind a selector:
 - **`auto`** (urltest) picks the working/faster of the two; **`select`** lets you
   pin one manually (sing-box "Groups" tab shows the live pick + latency).
 
-Tailnet traffic (`100.64.0.0/10`) is split off through an embedded Tailscale
-endpoint, so tailnet access and censorship-resistant egress coexist in one tunnel
-— no second VPN app, and it works on iOS where only one VPN can run at a time.
-MagicDNS (`*.<tailnet>.ts.net`) resolves locally from tsnet's netmap via `ts-dns`.
+Tailnet traffic (`100.64.0.0/10`) is routed through the same `select` group, so
+it rides hy2/reality to the gateway VPS — which is itself a tailnet member and
+dials the destination over the mesh. This is the censorship-resistant tailnet
+path: on a network that blocks Tailscale (control plane + DERP), `100.x` still
+works because the only leg crossing the hostile network is the obfuscated
+tunnel. It's slower (traffic relays through the VPS) and there's no WireGuard on
+the client at all — for fast, direct tailnet on an open network, just use the
+native Tailscale app instead. One VPN slot on iOS: native for speed, this
+profile for survival.
 
-Two settings are load-bearing — do not drop them:
+MagicDNS (`*.<tailnet>.ts.net`) resolves via `ts-dns`, a plain resolver pointed
+at the tailnet's `100.100.100.100` and detoured through the tunnel so the VPS
+answers on the client's behalf. If that misbehaves on your sing-box version, use
+raw `100.x` IPs — they always route.
+
+One setting is load-bearing — do not drop it:
 
 - **`route.rules` has `sniff` + `hijack-dns`.** Without the `hijack-dns` rule,
   sing-box routes port-53 queries out the tunnel as raw packets to its own dead
   internal DNS address; nothing resolves (only cached lookups work) and clients
   appear to "lose connection." With it, queries are answered via `cf-doh`
   (DoH → 1.1.1.1, routed over the tunnel — encrypted and unleakable).
-- **`accept_routes: false` on the Tailscale endpoint.** With `true`, a tailnet
-  node advertising routes gets accepted and swallows the whole default route →
-  total blackout. Tailnet stays reachable via the `100.64.0.0/10` route rule.
 
 ## Filling it in
 
-Replace the `<PLACEHOLDER>` tokens. Everything but the Tailscale key and MagicDNS
-suffix comes from Pulumi stack outputs (run in `packages/infra/`):
+Replace the `<PLACEHOLDER>` tokens. Everything but the MagicDNS suffix comes
+from Pulumi stack outputs (run in `packages/infra/`):
 
 | Placeholder | Source |
 | --- | --- |
@@ -40,8 +47,10 @@ suffix comes from Pulumi stack outputs (run in `packages/infra/`):
 | `<XRAY_SERVER_NAME>` | `pulumi stack output xrayServerName` |
 | `<HYSTERIA_AUTH_PASSWORD>` | from `pulumi stack output hysteriaShareUrl --show-secrets` (the `user@` part) |
 | `<HYSTERIA_OBFS_PASSWORD>` | from the same URL (`obfs-password=`) |
-| `<TAILSCALE_AUTH_KEY>` | Tailscale admin → Settings → Keys → generate (reusable + ephemeral) |
 | `<TAILNET_MAGICDNS_SUFFIX>` | `tailscale status --json \| jq -r .MagicDNSSuffix` (e.g. `foo-bar.ts.net`) |
+
+The tailnet relay's own auth key is a deploy-side secret (`TS_AUTHKEY`), not a
+client value — see `docs/architecture.md`.
 
 The `xrayShareUrl` and `hysteriaShareUrl` outputs are complete `vless://` /
 `hysteria2://` URLs if you'd rather import a single transport directly instead of

--- a/clients/singbox.template.json
+++ b/clients/singbox.template.json
@@ -3,7 +3,12 @@
   "dns": {
     "servers": [
       { "type": "https", "tag": "cf-doh", "server": "1.1.1.1" },
-      { "type": "tailscale", "tag": "ts-dns", "endpoint": "ts" }
+      {
+        "type": "udp",
+        "tag": "ts-dns",
+        "server": "100.100.100.100",
+        "detour": "select"
+      }
     ],
     "rules": [
       { "domain_suffix": ["<TAILNET_MAGICDNS_SUFFIX>"], "server": "ts-dns" }
@@ -20,15 +25,6 @@
       "auto_route": true,
       "strict_route": true,
       "stack": "system"
-    }
-  ],
-  "endpoints": [
-    {
-      "type": "tailscale",
-      "tag": "ts",
-      "auth_key": "<TAILSCALE_AUTH_KEY>",
-      "ephemeral": true,
-      "accept_routes": false
     }
   ],
   "outbounds": [
@@ -83,7 +79,10 @@
     "rules": [
       { "action": "sniff" },
       { "protocol": "dns", "action": "hijack-dns" },
-      { "ip_cidr": ["100.64.0.0/10", "fd7a:115c:a1e0::/48"], "outbound": "ts" }
+      {
+        "ip_cidr": ["100.64.0.0/10", "fd7a:115c:a1e0::/48"],
+        "outbound": "select"
+      }
     ],
     "final": "select",
     "auto_detect_interface": true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,10 +115,10 @@ intervention.
 
 ## Client routing (sing-box)
 
-One combined profile carries both transports, an embedded Tailscale endpoint,
-and DNS handling. Egress rides the `select`/`auto` groups; tailnet IPs split off
-to the Tailscale endpoint so tailnet access and censorship egress coexist in a
-single tunnel — which also means it works on iOS, where only one VPN can run.
+One combined profile carries both transports and DNS handling. Everything —
+including tailnet `100.x` — rides the `select`/`auto` groups, so all traffic
+crosses the hostile network as obfuscated hy2/reality. The client runs **no
+WireGuard**; the tailnet hop happens on the VPS (see below).
 
 ```mermaid
 flowchart TD
@@ -126,24 +126,52 @@ flowchart TD
     SNIFF --> DNSQ{"port 53?"}
     DNSQ -->|yes| HIJACK["hijack-dns"]
     HIJACK --> RESOLVE{"tailnet suffix?"}
-    RESOLVE -->|yes| TSDNS["ts-dns<br/>MagicDNS from tsnet netmap"]
+    RESOLVE -->|yes| TSDNS["ts-dns<br/>udp 100.100.100.100, detour select"]
     RESOLVE -->|no| DOH["cf-doh<br/>DoH 1.1.1.1 over tunnel"]
-    DNSQ -->|no| DEST{"dest IP in<br/>100.64.0.0/10?"}
-    DEST -->|yes| TS["Tailscale endpoint<br/>accept_routes false"]
-    DEST -->|no| SEL["select -> auto<br/>urltest(hy2, reality)"]
-    SEL --> VPS["VPS egress"]
+    DNSQ -->|no| SEL["select -> auto<br/>urltest(hy2, reality)"]
+    SEL --> VPS["VPS egress / tailnet relay"]
 ```
 
-Two client settings are load-bearing and must not be dropped:
+`hijack-dns` (after `sniff` in `route.rules`) is load-bearing: without it,
+sing-box flings port-53 queries out the tunnel as raw packets to a dead internal
+resolver; nothing resolves except cached names and the client looks offline.
+With it, queries are answered via DoH to 1.1.1.1 — encrypted and tunnelled.
 
-- **`hijack-dns`** (after `sniff` in `route.rules`). Without it, sing-box flings
-  port-53 queries out the tunnel as raw packets to a dead internal resolver;
-  nothing resolves except cached names and the client looks offline. With it,
-  queries are answered via DoH to 1.1.1.1 — encrypted and tunnelled, no leak.
-- **`accept_routes: false`** on the Tailscale endpoint. With `true`, a tailnet
-  node advertising routes gets its routes accepted and swallows the default
-  route → total blackout. Tailnet stays reachable via the explicit
-  `100.64.0.0/10` route rule instead.
+## Tailnet over the tunnel (censorship-resistant `100.x`)
+
+The gateway VPS is itself a tailnet member. Because hy2/reality are
+connection-level proxies (not raw IP tunnels), a client flow to `100.x` arrives
+at the VPS and the VPS *dials that address locally* — the OS routes it out
+`tailscale0` to the home nodes over the mesh. So the VPS needs nothing but
+membership: **no IP forwarding, no NAT, no subnet-router advertisement.**
+
+```mermaid
+flowchart LR
+    DEV["device<br/>(hostile net)"] -->|"100.x over hy2/reality"| VPS["VPS<br/>tailscale member"]
+    VPS -->|"dials 100.x over tailscale0"| HOME["oldboy & peers<br/>(tailnet mesh)"]
+```
+
+Why this beats a Tailscale-hostile censor: the only leg crossing the hostile
+network is the obfuscated tunnel. The VPS↔tailnet leg (WireGuard + DERP + the
+Tailscale control plane) happens from Germany, where none of it is blocked — the
+censor never sees a Tailscale handshake.
+
+Two profiles, one VPN slot (matters on iOS):
+
+- **Native Tailscale app** — fast, direct peer-to-peer, full MagicDNS. Use on
+  open networks. Dies where Tailscale is blocked.
+- **This sing-box profile** — tailnet relayed through the VPS, obfuscated,
+  survives censorship. Slower (relay hop + geography). Use when the native
+  client can't connect.
+
+Load-bearing on the VPS side: `tailscale up --accept-routes=false`. With routes
+accepted, a peer advertising an exit node or routes swallows the VPS default
+route → the relay and every service riding it go dark.
+
+MagicDNS is best-effort here: `ts-dns` points at `100.100.100.100` detoured
+through the tunnel, so the VPS resolves `*.ts.net` on the client's behalf. If a
+sing-box version doesn't honour `detour` on a DNS server, fall back to raw
+`100.x` IPs — and the native client covers names on open networks anyway.
 
 See [`clients/README.md`](../clients/README.md) for the fill-in template and how
 the profile is delivered to devices.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,6 +168,11 @@ Load-bearing on the VPS side: `tailscale up --accept-routes=false`. With routes
 accepted, a peer advertising an exit node or routes swallows the VPS default
 route → the relay and every service riding it go dark.
 
+The `TS_AUTHKEY` secret is an **OAuth client secret** (`tskey-client-…`, with
+the `auth_keys` scope and the tag), not a raw auth key — raw keys cap at 90-day
+expiry, OAuth secrets don't. OAuth-minted keys default to ephemeral, so the
+`up` command forces `ephemeral=false` to keep the relay persistent.
+
 MagicDNS is best-effort here: `ts-dns` points at `100.100.100.100` detoured
 through the tunnel, so the VPS resolves `*.ts.net` on the client's behalf. If a
 sing-box version doesn't honour `detour` on a DNS server, fall back to raw

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -17,6 +17,10 @@ config:
       dest: 127.0.0.1:8443
     # Hysteria2 (QUIC/UDP) on 443/udp — fast, loss-tolerant daily driver
     hysteria: {}
+    # Tailnet relay: joins the VPS to the tailnet so clients can reach 100.x
+    # over the tunnel. Provisioned only when TS_AUTHKEY is set, so this is a
+    # no-op until the secret exists.
+    tailnet: {}
   jaritanet:services:
     navidrome:
       hostname: ''

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -31,12 +31,26 @@ export const HysteriaConfSchema = z.object({
   sni: z.string().default("www.bing.com"),
 });
 
+/**
+ * Joins the gateway VPS to the tailnet so it can relay client traffic into
+ * the mesh. Clients route 100.64.0.0/10 through the hy2/reality tunnel and
+ * the VPS dials those addresses locally over tailscale0 — no IP forwarding
+ * or subnet routing, the box just has to be a member. Enabled only when a
+ * TS_AUTHKEY is also present. `tag` disables key expiry and drives ACLs;
+ * reuse `tag:server` so existing tagOwners/grants apply.
+ */
+export const TailnetConfSchema = z.object({
+  hostname: z.string().default("jaritanet-gw"),
+  tag: z.string().default("tag:server"),
+});
+
 export const GatewayConfSchema = z.object({
   hysteria: HysteriaConfSchema.optional(),
   image: z.string().default("ubuntu-24.04"),
   location: z.string().default("nbg1"),
   ratholeVersion: z.string().default("v0.5.0"),
   serverType: z.string().default("cx23"),
+  tailnet: TailnetConfSchema.optional(),
   xray: XrayConfSchema.optional(),
 });
 

--- a/packages/infra/src/env.schema.ts
+++ b/packages/infra/src/env.schema.ts
@@ -8,4 +8,5 @@ export const EnvSchema = z.object({
   KUBE_API_PORT: z.string().min(1, "KUBE_API_PORT is required"),
   KUBE_HOST: z.string().min(1, "KUBE_HOST is required"),
   KUBE_TOKEN: z.string().min(1, "KUBE_TOKEN is required"),
+  TS_AUTHKEY: z.string().optional(),
 });

--- a/packages/infra/src/modules/gateway.ts
+++ b/packages/infra/src/modules/gateway.ts
@@ -5,7 +5,9 @@ import * as random from "@pulumi/random";
 import * as tls from "@pulumi/tls";
 import type * as z from "zod";
 import type { GatewayConfSchema } from "../conf.schemas.ts";
+import { env } from "../env.ts";
 import { createHysteria } from "./hysteria.ts";
+import { createTailscale } from "./tailscale.ts";
 import { createXray } from "./xray.ts";
 
 /**
@@ -185,11 +187,24 @@ RATHOLE_EOF`,
     ? createHysteria(connection, server, gateway.hysteria)
     : undefined;
 
+  // Tailnet relay: only when configured and an auth key is present, so
+  // enabling `tailnet` in config before the secret is set is a safe no-op.
+  const tailscale =
+    gateway.tailnet && env.TS_AUTHKEY
+      ? createTailscale(
+          connection,
+          server,
+          gateway.tailnet,
+          pulumi.secret(env.TS_AUTHKEY),
+        )
+      : undefined;
+
   return {
     hysteria,
     ratholeToken,
     server,
     sshKey,
+    tailscale,
     vpsIp: server.ipv4Address,
     xray,
   };

--- a/packages/infra/src/modules/tailscale.ts
+++ b/packages/infra/src/modules/tailscale.ts
@@ -1,0 +1,56 @@
+import * as command from "@pulumi/command";
+import type * as hcloud from "@pulumi/hcloud";
+import * as pulumi from "@pulumi/pulumi";
+import type * as z from "zod";
+import type { TailnetConfSchema } from "../conf.schemas.ts";
+
+type Connection = {
+  host: pulumi.Output<string>;
+  privateKey: pulumi.Output<string>;
+  user: string;
+};
+
+/**
+ * Joins the gateway VPS to the tailnet so it can relay client traffic into
+ * the mesh.
+ *
+ * The transports are connection-level proxies, not raw IP tunnels: a client
+ * flow to 100.x arrives over hy2/reality and the VPS dials that address
+ * itself, so the OS routes it out tailscale0 to the home nodes. That's why
+ * no IP forwarding, NAT, or subnet-router advertisement is needed — being a
+ * member is enough.
+ *
+ * `accept-routes=false` is load-bearing: a peer advertising an exit node or
+ * routes must not be able to swallow the VPS default route, or the relay
+ * (and every service riding it) goes dark. `--ssh` exposes Tailscale SSH so
+ * the box is reachable over the tailnet without the public :22.
+ */
+export function createTailscale(
+  connection: Connection,
+  server: hcloud.Server,
+  tailnet: z.infer<typeof TailnetConfSchema>,
+  authKey: pulumi.Output<string>,
+) {
+  return new command.remote.Command(
+    "tailscale-up",
+    {
+      connection,
+      create: pulumi.interpolate`set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v tailscale >/dev/null 2>&1; then
+  curl -fsSL https://tailscale.com/install.sh | sh
+fi
+tailscale up \
+  --auth-key="${authKey}" \
+  --hostname="${tailnet.hostname}" \
+  --advertise-tags="${tailnet.tag}" \
+  --accept-routes=false \
+  --ssh`,
+      // Not keyed on authKey: the node persists after first auth, so
+      // re-running only matters when hostname/tag change. Bump the version
+      // to force a re-auth after rotating the key.
+      triggers: ["tailscale-v1", tailnet.hostname, tailnet.tag],
+    },
+    { dependsOn: [server] },
+  );
+}

--- a/packages/infra/src/modules/tailscale.ts
+++ b/packages/infra/src/modules/tailscale.ts
@@ -24,6 +24,11 @@ type Connection = {
  * routes must not be able to swallow the VPS default route, or the relay
  * (and every service riding it) goes dark. `--ssh` exposes Tailscale SSH so
  * the box is reachable over the tailnet without the public :22.
+ *
+ * `authKey` is an OAuth client secret (`tskey-client-...`, auth_keys scope +
+ * the tag), used directly as the auth key — those don't hit the 90-day
+ * expiry that raw auth keys do. OAuth-minted keys default to ephemeral, so
+ * `ephemeral=false` is required to keep the relay node persistent.
  */
 export function createTailscale(
   connection: Connection,
@@ -41,7 +46,7 @@ if ! command -v tailscale >/dev/null 2>&1; then
   curl -fsSL https://tailscale.com/install.sh | sh
 fi
 tailscale up \
-  --auth-key="${authKey}" \
+  --auth-key="${authKey}?ephemeral=false&preauthorized=true" \
   --hostname="${tailnet.hostname}" \
   --advertise-tags="${tailnet.tag}" \
   --accept-routes=false \

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -54,6 +54,19 @@
               "default": "cx23",
               "type": "string"
             },
+            "tailnet": {
+              "type": "object",
+              "properties": {
+                "hostname": {
+                  "default": "jaritanet-gw",
+                  "type": "string"
+                },
+                "tag": {
+                  "default": "tag:server",
+                  "type": "string"
+                }
+              }
+            },
             "xray": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
## What

Makes the tailnet reachable over the obfuscated tunnel, so `100.x` survives a Tailscale-hostile network (Egypt-tier) where the current embedded endpoint dies.

The embedded sing-box Tailscale endpoint egresses its WireGuard/DERP **directly**, bypassing hy2/reality — so it hits the exact infra a censor blocks. This replaces that: the **gateway VPS joins the tailnet**, and the client routes `100.64.0.0/10` through the same `select` group as everything else. Because hy2/reality are connection-level proxies, a client flow to `100.x` reaches the VPS and the VPS **dials it locally over `tailscale0`** — so no IP forwarding, NAT, or subnet routing is needed, the box just has to be a member. The only leg crossing the hostile network is the obfuscated tunnel; the VPS↔tailnet leg runs from Germany where Tailscale isn't blocked.

## Two profiles, one VPN slot (iOS)

- **Native Tailscale app** — fast, direct P2P, full MagicDNS; use on open networks.
- **This sing-box profile** — tailnet relayed through the VPS, obfuscated, slower; use when Tailscale is blocked.

The client now runs **no WireGuard at all**.

## Changes

- `modules/tailscale.ts` — new; `tailscale up --accept-routes=false --ssh` on the VPS, mirroring the xray/hysteria module shape.
- `gateway.ts` — provisions it when `gateway.tailnet` **and** `TS_AUTHKEY` are set.
- `conf.schemas.ts` / `env.schema.ts` — `TailnetConfSchema` + `TS_AUTHKEY`.
- `Pulumi.main.yaml` — `tailnet: {}` (no-op until the secret exists).
- `clients/singbox.template.json` — drop the embedded endpoint; route `100.x` via `select`; MagicDNS via `100.100.100.100` detoured through the tunnel. **Removes the `<TAILSCALE_AUTH_KEY>` placeholder.**
- `ci-cd.yml` — plumb `TS_AUTHKEY` (optional).
- docs updated.

## Before merge — required

1. Create a Tailscale **OAuth client** (Settings → OAuth clients) with the **Auth Keys** write scope and tag **`tag:server`**. OAuth client secrets don't hit the 90-day auth-key expiry — the `up` command uses it directly with `?ephemeral=false&preauthorized=true`.
2. `gh secret set TS_AUTHKEY` — paste the client secret (`tskey-client-…`).
3. Confirm the tailnet ACL lets `tag:server` reach oldboy (SMB 445, SSH 22, …). Default allow-all is fine.

Safe to merge before step 2 — provisioning is gated on the secret, so it's a no-op until then.

## Verify (post-deploy, needs the secret + a device)

- On the VPS: `tailscale status` shows `jaritanet-gw`; it can reach oldboy's `100.x`.
- On a client with the new profile: `smb://100.x` works through the tunnel.
- **Watch:** the historical sing-box `100.64.0.0/10 → route.final` leak (confirm via logs it hits `select`, not default egress); MagicDNS-over-`detour` (fall back to raw IPs if unsupported); MTU (drop tun toward 1280 if tailnet throughput is grim).

## Not verifiable in CI

Typecheck/lint/tests/schema-regen pass, template is valid JSON. The runtime path (tailscale join + client routing) needs the secret, a deploy, and a device — hence the manual verify list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)