### PR TITLE
chore(gateway): drop Tailscale SSH from the relay node

### DIFF
--- a/packages/infra/src/modules/tailscale.ts
+++ b/packages/infra/src/modules/tailscale.ts
@@ -22,8 +22,9 @@ type Connection = {
  *
  * `accept-routes=false` is load-bearing: a peer advertising an exit node or
  * routes must not be able to swallow the VPS default route, or the relay
- * (and every service riding it) goes dark. `--ssh` exposes Tailscale SSH so
- * the box is reachable over the tailnet without the public :22.
+ * (and every service riding it) goes dark. `--ssh=false` is explicit: the
+ * gateway is managed purely by config and exposes no human SSH over the
+ * tailnet (explicit rather than omitted so a re-run definitely clears it).
  *
  * `authKey` is an OAuth client secret (`tskey-client-...`, auth_keys scope +
  * the tag), used directly as the auth key — those don't hit the 90-day
@@ -50,11 +51,11 @@ tailscale up \
   --hostname="${tailnet.hostname}" \
   --advertise-tags="${tailnet.tag}" \
   --accept-routes=false \
-  --ssh`,
+  --ssh=false`,
       // Not keyed on authKey: the node persists after first auth, so
-      // re-running only matters when hostname/tag change. Bump the version
-      // to force a re-auth after rotating the key.
-      triggers: ["tailscale-v1", tailnet.hostname, tailnet.tag],
+      // re-running only matters when the command changes. Bump the version
+      // to force a re-run (e.g. after rotating the key or changing flags).
+      triggers: ["tailscale-v2", tailnet.hostname, tailnet.tag],
     },
     { dependsOn: [server] },
   );


### PR DESCRIPTION
## What

Removes Tailscale SSH from the gateway relay node. The box is cattle — fully declared in Pulumi, secrets minted on-box, never hand-managed — so an SSH capability into it is dead attack surface.

- `--ssh=false` (explicit, not omitted) so a re-run definitely clears SSH from the running node rather than relying on `tailscale up` reset semantics.
- Trigger bumped `tailscale-v1` → `tailscale-v2` so Pulumi actually re-runs `tailscale up` (a command-body change alone doesn't retrigger).

Public `:22` is untouched — that's Pulumi's provisioning path (the `command.remote.Command`s run over it), not a human one.

## Verify

On the next deploy, `tailscale up` re-runs with `--ssh=false`; the `jaritanet-gw` node no longer advertises SSH. Relay data path (client → tunnel → VPS → tailnet → oldboy) is unaffected — SSH was never part of it.

Typecheck/lint/fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)