### PR TITLE
ci(ansible): use Mitogen strategy for faster runs

### DIFF
--- a/.github/workflows/run-playbook.yml
+++ b/.github/workflows/run-playbook.yml
@@ -83,6 +83,18 @@ jobs:
       - name: Install qrencode
         run: sudo apt-get update && sudo apt-get install -y qrencode
 
+      # Mitogen replaces Ansible's per-task interpreter spawn with one long-lived
+      # remote process — typically 1.5-3x faster. Wired via env only, so
+      # ansible.cfg stays default and local runs are unaffected.
+      - name: Enable Mitogen strategy
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user mitogen
+          DIR="$(python3 -c 'import os, ansible_mitogen; print(os.path.join(os.path.dirname(ansible_mitogen.__file__), "plugins", "strategy"))')"
+          echo "using strategy plugins: $DIR"
+          echo "ANSIBLE_STRATEGY_PLUGINS=$DIR" >> "$GITHUB_ENV"
+          echo "ANSIBLE_STRATEGY=mitogen_linear" >> "$GITHUB_ENV"
+
       - name: Execute Ansible Playbook
         uses: dawidd6/action-ansible-playbook@93764e7048f4dd16117d134dadb4b36e8ee73227 # v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Daily check for new releases of deployed services (currently Navidrome). Uses a 
 
 ### Ansible Deployment (`run-playbook.yml`)
 
-Triggered on ansible/ changes. Connects via Tailscale, runs playbooks, updates GitHub secrets.
+Triggered on ansible/ changes. Connects via Tailscale, runs playbooks, updates GitHub secrets. Roles are tagged with their own name; the workflow diffs the push and runs only the changed roles (`--tags`), falling back to a full run on shared-file changes. `workflow_dispatch` takes a `tags` input for targeted manual runs. CI runs use the Mitogen strategy (env-only) for speed.
 
 ### Container Builds (`build-files-container.yml`)
 


### PR DESCRIPTION
Adds the [Mitogen for Ansible](https://mitogen.networkgenomics.com/ansible_detailed.html) strategy to CI. Mitogen bootstraps one long-lived Python process per target and runs every task inside it via RPC, instead of Ansible's default spawn-an-interpreter-per-task model — typically 1.5–3× faster, most on task-heavy roles like microk8s.

## How it's wired
- CI-only, via `ANSIBLE_STRATEGY=mitogen_linear` + `ANSIBLE_STRATEGY_PLUGINS` (path derived from the installed package, not hardcoded).
- `ansible.cfg` untouched → local runs use the default `linear` strategy, and reverting is just deleting the step. No playbook changes.

## Verifying (before trusting on a full deploy)
Mitogen is a third-party plugin that trails ansible-core, so it can break on newer versions or exotic `become`. Validate with a low-blast-radius manual run first:

    gh workflow run run-playbook.yml --ref feat/ansible-mitogen -f tags=singbox

That renders the sing-box profile via Mitogen on oldboy — idempotent (no diff → no Telegram push), but proves Mitogen connects, does `become`, and handles the `delegate_to: localhost` tasks. If green, merge; the speedup then applies to every run.

## Risk
Contained: env-only, one role validates it, trivial revert. Worst case a run fails fast on the strategy init and we drop the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)