### PR TITLE
refactor(singbox): rename selector group select -> main

### DIFF
--- a/ansible/roles/singbox/README.md
+++ b/ansible/roles/singbox/README.md
@@ -7,10 +7,12 @@ client config for the gateway. It carries two transports behind a selector:
   smooth on lossy links where TCP melts down. Salamander obfs hides it from DPI.
 - **`reality`** (VLESS-Vision-REALITY / TCP) — fallback for UDP-hostile networks
   (some state censors throttle/block UDP). Slower, but survives where QUIC can't.
-- **`auto`** (urltest) picks the working/faster of the two; **`select`** lets you
-  pin one manually (sing-box "Groups" tab shows the live pick + latency).
+- **`auto`** (urltest) picks the working/faster of the two; **`main`** (selector)
+  is the group you tap in the app's "Groups" tab to pin one manually (it shows
+  the live pick + latency). `main` is `route.final` — all traffic enters here,
+  defaulting to `auto`.
 
-Tailnet traffic (`100.64.0.0/10`) is routed through the same `select` group, so
+Tailnet traffic (`100.64.0.0/10`) is routed through the same `main` group, so
 it rides hy2/reality to the gateway VPS — which is itself a tailnet member and
 dials the destination over the mesh. This is the censorship-resistant tailnet
 path: on a network that blocks Tailscale (control plane + DERP), `100.x` still

--- a/ansible/roles/singbox/files/singbox.template.json
+++ b/ansible/roles/singbox/files/singbox.template.json
@@ -7,7 +7,7 @@
         "type": "udp",
         "tag": "ts-dns",
         "server": "100.100.100.100",
-        "detour": "select"
+        "detour": "main"
       }
     ],
     "rules": [
@@ -69,7 +69,7 @@
     },
     {
       "type": "selector",
-      "tag": "select",
+      "tag": "main",
       "outbounds": ["auto", "hy2", "reality"],
       "default": "auto"
     }
@@ -81,10 +81,10 @@
       { "protocol": "dns", "action": "hijack-dns" },
       {
         "ip_cidr": ["100.64.0.0/10", "fd7a:115c:a1e0::/48"],
-        "outbound": "select"
+        "outbound": "main"
       }
     ],
-    "final": "select",
+    "final": "main",
     "auto_detect_interface": true
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ intervention.
 ## Client routing (sing-box)
 
 One combined profile carries both transports and DNS handling. Everything —
-including tailnet `100.x` — rides the `select`/`auto` groups, so all traffic
+including tailnet `100.x` — rides the `main`/`auto` groups, so all traffic
 crosses the hostile network as obfuscated hy2/reality. The client runs **no
 WireGuard**; the tailnet hop happens on the VPS (see below).
 
@@ -126,9 +126,9 @@ flowchart TD
     SNIFF --> DNSQ{"port 53?"}
     DNSQ -->|yes| HIJACK["hijack-dns"]
     HIJACK --> RESOLVE{"tailnet suffix?"}
-    RESOLVE -->|yes| TSDNS["ts-dns<br/>udp 100.100.100.100, detour select"]
+    RESOLVE -->|yes| TSDNS["ts-dns<br/>udp 100.100.100.100, detour main"]
     RESOLVE -->|no| DOH["cf-doh<br/>DoH 1.1.1.1 over tunnel"]
-    DNSQ -->|no| SEL["select -> auto<br/>urltest(hy2, reality)"]
+    DNSQ -->|no| SEL["main -> auto<br/>urltest(hy2, reality)"]
     SEL --> VPS["VPS egress / tailnet relay"]
 ```
 


### PR DESCRIPTION
Renames the sing-box manual selector group from `select` to `main` for clarity — `select` read as an action, not the network entry point you tap in the app. The urltest group keeps its (already clear) `auto` name.

## Result in the app
```
main   (Selector)          <- you tap this; route.final
  ├ auto   (urltest, fastest live pick)
  ├ hy2
  └ reality
```

## Scope
Updates every reference so nothing dangles: selector tag + members, `route.final`, the tailnet `100.x` route rule outbound, and the `ts-dns` detour — plus the role README and architecture doc.

## Notes
- Pure rename, no behavioural change. JSON validated; all references resolve to `main`.
- Touches only `roles/singbox/**` + a doc, so the deploy runs `--tags singbox` alone (first payoff of the selective-CI change).
- On deploy the profile re-renders → Telegram push. Devices pick it up on "Update"; a manually-pinned transport resets to the default (`auto`) since the group tag changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)