### PR TITLE
feat(singbox): dynamic profile groups (collapse for single node)

### DIFF
--- a/ansible/roles/singbox/README.md
+++ b/ansible/roles/singbox/README.md
@@ -13,17 +13,24 @@ Per node there are two transports:
 
 ## The picker
 
-- **`main`** (top selector) — pick `auto-all` (fastest transport across every
-  node) or a specific host group. This is what routing points at.
-- **`<host>`** (per-node selector, e.g. `helsinki`, `primary`) — pick that
-  node's `auto-<host>`, or force `hy2-<host>` / `reality-<host>` for field
-  experimentation.
-- **`auto-<host>`** / **`auto-all`** — urltest groups that pick the live/fastest
-  transport automatically.
+The group structure **expands with node count**, so a single-node profile
+stays simple and the nesting only appears when it earns its keep:
 
+- **One node** → flat: `main` (selector) over `[auto, hy2-<host>, reality-<host>]`,
+  defaulting to `auto`. Two groups in the app — obvious.
+- **Two+ nodes** → nested:
+  - **`main`** (top selector) — `auto-all` (fastest transport across every node)
+    or a specific host group.
+  - **`<host>`** (per-node selector, e.g. `helsinki`) — that node's `auto-<host>`,
+    or force `hy2-<host>` / `reality-<host>` for field experimentation.
+  - **`auto-<host>`** / **`auto-all`** — urltest groups that auto-pick the
+    live/fastest transport.
+
+Routing always points at `main`, so the rest of the config is count-agnostic.
 Leaf outbound tags are prefixed per host (`hy2-helsinki`, …) because sing-box
 tags must be globally unique; the selectors are what you navigate in the app's
-Groups tab.
+Groups tab. These are *choices*, not a chain — traffic flows through exactly one
+resolved transport, not through every group in sequence.
 
 Tailnet traffic (`100.64.0.0/10`) routes through `main` too, so it rides
 hy2/reality to whichever node is selected — each node is a tailnet member and

--- a/ansible/roles/singbox/templates/singbox.template.json.j2
+++ b/ansible/roles/singbox/templates/singbox.template.json.j2
@@ -1,3 +1,85 @@
+{#-
+  Renders a sing-box profile from `singbox_nodes` (primary gateway + edges).
+
+  The outbound groups expand with node count:
+    - 1 node  → flat: main (selector) over [auto, hy2, reality]
+    - N nodes → nested: main → auto-all | per-host selectors, each holding
+                that host's auto + hy2 + reality
+
+  Routing always points at `main`, so the rest of the config is count-agnostic.
+-#}
+{%- macro ob_hy2(node) -%}
+{
+  "type": "hysteria2",
+  "tag": "hy2-{{ node.name }}",
+  "server": "{{ node.server }}",
+  "server_port": {{ node.hysteria.port }},
+  "password": "{{ node.hysteria.authPassword }}",
+  "obfs": { "type": "salamander", "password": "{{ node.hysteria.obfsPassword }}" },
+  "tls": { "enabled": true, "server_name": "{{ node.hysteria.sni }}", "insecure": true }
+}
+{%- endmacro -%}
+{%- macro ob_reality(node) -%}
+{
+  "type": "vless",
+  "tag": "reality-{{ node.name }}",
+  "server": "{{ node.server }}",
+  "server_port": 443,
+  "uuid": "{{ node.reality.uuid }}",
+  "flow": "xtls-rprx-vision",
+  "tls": {
+    "enabled": true,
+    "server_name": "{{ node.reality.serverName }}",
+    "utls": { "enabled": true, "fingerprint": "chrome" },
+    "reality": { "enabled": true, "public_key": "{{ node.reality.publicKey }}", "short_id": "{{ node.reality.shortId }}" }
+  }
+}
+{%- endmacro -%}
+{%- macro ob_urltest(tag, members) -%}
+{
+  "type": "urltest",
+  "tag": "{{ tag }}",
+  "outbounds": [{{ members | map('tojson') | join(', ') }}],
+  "url": "https://www.gstatic.com/generate_204",
+  "interval": "3m",
+  "tolerance": 100
+}
+{%- endmacro -%}
+{%- macro ob_selector(tag, members, default) -%}
+{
+  "type": "selector",
+  "tag": "{{ tag }}",
+  "outbounds": [{{ members | map('tojson') | join(', ') }}],
+  "default": "{{ default }}"
+}
+{%- endmacro -%}
+{#- Build the outbounds list, then join with commas for valid JSON. -#}
+{%- set items = [] -%}
+{%- for node in singbox_nodes -%}
+  {%- set _ = items.append(ob_hy2(node)) -%}
+  {%- set _ = items.append(ob_reality(node)) -%}
+{%- endfor -%}
+{%- if singbox_nodes | length == 1 -%}
+  {%- set n = singbox_nodes[0].name -%}
+  {%- set _ = items.append(ob_urltest('auto', ['hy2-' ~ n, 'reality-' ~ n])) -%}
+  {%- set _ = items.append(ob_selector('main', ['auto', 'hy2-' ~ n, 'reality-' ~ n], 'auto')) -%}
+{%- else -%}
+  {%- for node in singbox_nodes -%}
+    {%- set _ = items.append(ob_urltest('auto-' ~ node.name, ['hy2-' ~ node.name, 'reality-' ~ node.name])) -%}
+    {%- set _ = items.append(ob_selector(node.name, ['auto-' ~ node.name, 'hy2-' ~ node.name, 'reality-' ~ node.name], 'auto-' ~ node.name)) -%}
+  {%- endfor -%}
+  {%- set all_members = [] -%}
+  {%- for node in singbox_nodes -%}
+    {%- set _ = all_members.append('hy2-' ~ node.name) -%}
+    {%- set _ = all_members.append('reality-' ~ node.name) -%}
+  {%- endfor -%}
+  {%- set _ = items.append(ob_urltest('auto-all', all_members)) -%}
+  {%- set main_members = ['auto-all'] -%}
+  {%- for node in singbox_nodes -%}
+    {%- set _ = main_members.append(node.name) -%}
+  {%- endfor -%}
+  {%- set _ = items.append(ob_selector('main', main_members, 'auto-all')) -%}
+{%- endif -%}
 {
   "log": { "level": "info", "timestamp": true },
   "dns": {
@@ -23,59 +105,7 @@
     }
   ],
   "outbounds": [
-{% for node in singbox_nodes %}
-    {
-      "type": "hysteria2",
-      "tag": "hy2-{{ node.name }}",
-      "server": "{{ node.server }}",
-      "server_port": {{ node.hysteria.port }},
-      "password": "{{ node.hysteria.authPassword }}",
-      "obfs": { "type": "salamander", "password": "{{ node.hysteria.obfsPassword }}" },
-      "tls": { "enabled": true, "server_name": "{{ node.hysteria.sni }}", "insecure": true }
-    },
-    {
-      "type": "vless",
-      "tag": "reality-{{ node.name }}",
-      "server": "{{ node.server }}",
-      "server_port": 443,
-      "uuid": "{{ node.reality.uuid }}",
-      "flow": "xtls-rprx-vision",
-      "tls": {
-        "enabled": true,
-        "server_name": "{{ node.reality.serverName }}",
-        "utls": { "enabled": true, "fingerprint": "chrome" },
-        "reality": { "enabled": true, "public_key": "{{ node.reality.publicKey }}", "short_id": "{{ node.reality.shortId }}" }
-      }
-    },
-    {
-      "type": "urltest",
-      "tag": "auto-{{ node.name }}",
-      "outbounds": ["hy2-{{ node.name }}", "reality-{{ node.name }}"],
-      "url": "https://www.gstatic.com/generate_204",
-      "interval": "3m",
-      "tolerance": 100
-    },
-    {
-      "type": "selector",
-      "tag": "{{ node.name }}",
-      "outbounds": ["auto-{{ node.name }}", "hy2-{{ node.name }}", "reality-{{ node.name }}"],
-      "default": "auto-{{ node.name }}"
-    },
-{% endfor %}
-    {
-      "type": "urltest",
-      "tag": "auto-all",
-      "outbounds": [{% for node in singbox_nodes %}"hy2-{{ node.name }}", "reality-{{ node.name }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-      "url": "https://www.gstatic.com/generate_204",
-      "interval": "3m",
-      "tolerance": 100
-    },
-    {
-      "type": "selector",
-      "tag": "main",
-      "outbounds": ["auto-all"{% for node in singbox_nodes %}, "{{ node.name }}"{% endfor %}],
-      "default": "auto-all"
-    }
+    {{ items | join(',\n    ') }}
   ],
   "route": {
     "default_domain_resolver": "cf-doh",


### PR DESCRIPTION
## What

The multi-node picker from #67 looks absurd with a **single node** — `auto-primary`, `primary`, `auto-all`, `main` all wrap the exact same two transports (screenshot territory: "confusing as fuck"). This makes the template **expand with node count**:

- **1 node** → flat: `main` (selector) over `[auto, hy2-<host>, reality-<host>]`, default `auto`. Just two groups in the app.
- **2+ nodes** → the full nested picker (`main` → `auto-all` | per-host selectors → auto/hy2/reality).

Routing always points at `main`, so DNS/inbounds/route are count-agnostic — nothing else changed.

## How

Jinja2 macros (`ob_hy2`/`ob_reality`/`ob_urltest`/`ob_selector`) keep the blocks DRY; the outbounds are built into a list and joined into a valid JSON array. Branch on `singbox_nodes | length`.

## Verify

Render-tested locally for 1 and 2 nodes — both valid JSON:
- 1 node → `['hy2-primary','reality-primary','auto','main']`, `main`=selector[auto,hy2,reality] default auto.
- 2 nodes → full nested (`main`=[auto-all,primary,helsinki], per-host subgroups, auto-all across all transports).

Ansible-only change; no Pulumi/infra impact. Renders on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)