### PR TITLE
feat(exits): selectable egress exit nodes (rathole + ss-rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Everything lives in a single Pulumi package at `packages/infra/`:
 - **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoutes, IP watcher
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
 - **`src/modules/singbox.ts`** — builds the sing-box client profile from the nodes and delivers it to the file server over SSH (change-detected, Telegram notify)
+- **`src/modules/exit.ts`** — selectable egress exit node (ss-rust in-cluster), reached via the rathole tunnel, egressing its own IP. Add via `exits` in config
 - **`src/templates/service.ts`** — K8s Deployment/Service/PV/PVC templates
 
 ## Secrets

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,71 @@
 # Architecture
 
-JARITANET runs one Hetzner VPS that does two unrelated jobs on the same
-`:443`, plus a home box behind NAT that never exposes a port. This doc covers
-the network topology and the transport/proxy layer; for the Pulumi package
-layout and secrets see the [README](../README.md).
+JARITANET is a personal anti-censorship + egress stack. A sing-box client picks
+**how it enters** (which gateway/transport) and **where it egresses**
+(direct, or via an exit node), all coordinated by one Pulumi program. Gateways
+are disposable VPSes; the home box sits behind NAT and never exposes a port.
+This doc covers the topology and transport layer; for the Pulumi package layout
+and secrets see the [README](../README.md).
+
+## The whole system, end to end
+
+Every moving part and how a flow travels through it — client selection, the two
+entry transports, the gateway's shared `:443`, the rathole reverse-tunnel, the
+in-cluster exit, tailnet relay, and home services.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Client · sing-box (tun + hijack-dns)"]
+    ENTRY["entry-select<br/>which gateway"]
+    EXIT["exit-select<br/>where to egress"]
+  end
+
+  subgraph GW["Primary gateway · Hetzner VPS"]
+    XRAY["Xray · VLESS-Vision-REALITY<br/>:443/tcp"]
+    HYST["Hysteria2 · QUIC + Salamander<br/>:443/udp"]
+    RHS["rathole server"]
+    FGW["freedom · direct egress"]
+  end
+
+  subgraph EDGE["Edge VPSes · optional"]
+    EHR["hy2 + REALITY"]
+    FED["freedom · direct egress"]
+  end
+
+  subgraph HOME["oldboy · home MicroK8s · NAT, no inbound"]
+    RHC["rathole client"]
+    TRA["Traefik · TLS / ACME"]
+    SRV["services<br/>blit · navidrome · files"]
+    SS["ss-rust exit"]
+    TSC["tailscale"]
+  end
+
+  WEB((Internet))
+  RES((Home residential IP))
+
+  ENTRY -->|obfuscated| XRAY
+  ENTRY -->|obfuscated| HYST
+  ENTRY -.->|alt entry| EHR
+
+  EXIT -->|direct| ENTRY
+  EXIT -->|"exit-home · ss, detour primary"| XRAY
+
+  XRAY --> FGW --> WEB
+  HYST --> FGW
+  EHR --> FED --> WEB
+
+  XRAY -.->|"non-client → decoy dest"| RHS
+  RHS <==>|"rathole :2333"| RHC
+  RHC --> TRA --> SRV
+  RHS -->|"127.0.0.1:exit-port"| RHC
+  RHC --> SS --> RES
+
+  ENTRY -.->|"100.x tailnet"| XRAY
+  XRAY -.-> TSC
+  RHC -.-> TSC
+```
+
+The sections below zoom into each part.
 
 ## The two data planes
 
@@ -241,30 +303,32 @@ jaritanet:exits:
 ```
 
 It's reached through the **existing rathole tunnel**, not the tailnet. Each
-exit's ss-rust port is surfaced on **every gateway's loopback** (`127.0.0.1:<port>`)
-via a rathole service entry — the same pattern as the Reality decoy `dest`:
+exit's ss-rust port is surfaced on the **primary gateway's loopback**
+(`127.0.0.1:<port>`) via a rathole service entry — the same pattern as the
+Reality decoy `dest`:
 
 ```mermaid
 flowchart LR
-    DEV["device"] -->|"entry-select (hy2/reality)"| GW["gateway"]
+    DEV["device"] -->|"detour: primary (hy2/reality)"| GW["primary gateway"]
     GW -->|"127.0.0.1:<port> → rathole"| SS["ss-rust exit (k8s)"]
     SS -->|"pod egress, CNI SNAT → node IP"| INET(("Internet"))
 ```
 
-The client's `exit-<name>` outbound is Shadowsocks to `127.0.0.1:<port>` with
-`detour: entry-select`. In a detour chain the inner address resolves at the
-gateway end of the outer tunnel, so `127.0.0.1:<port>` means "this exit's rathole
-loopback on whichever gateway `entry-select` currently points at." **That's why
-the port must be identical across all gateways** — it lets one exit outbound work
-via any entry. Enforced in generation: the port is a single declared value used
-for the gateway bind, the rathole client target, and the client outbound.
+The client's `exit-<name>` outbound is Shadowsocks to `127.0.0.1:<port>`,
+detouring through the **primary** gateway. In a detour chain the inner address
+resolves at the gateway end, so `127.0.0.1:<port>` means "this exit's rathole
+loopback on the primary." Exits pin to the primary because **it's the only node
+running rathole** — edges (also in `entry-select`) serve hy2/reality only, so
+routing an exit through an edge would dial a dead loopback. `entry-select` still
+governs *direct* egress across all gateways; exits transit the primary.
 
 No kernel IP forwarding anywhere — ss-rust owns both ends of each flow
 (connection-level), so there's no return-path routing to misconfigure on a
 remote box. The exit pod egresses normally; microk8s' CNI SNATs to the node IP,
-which is the home link. Adding a gateway ⇒ it inherits every exit; adding an
-exit ⇒ it's exposed on every gateway. Pure function of the two config lists,
-expanded at `pulumi up`.
+which is the home link. Topology is a pure function of the config lists,
+expanded at `pulumi up`. (Making exits reachable via *any* gateway — the full
+entry × exit cross-product — needs edges to also run rathole; deferred. When
+multiple rathole gateways exist, `port` must be identical across them.)
 
 ## Hardening notes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,8 +221,50 @@ its own-domain decoy because it must serve real visitors on the same `:443`.
 
 Every edge is also a tailnet member, so any of them relays `100.x` into the
 mesh — the same censorship-resistant tailnet path works whichever location you
-pick. (This is the foundation for a future home-exit node: oldboy becomes just
-another entry in the picker, exiting via the residential IP.)
+pick.
+
+## Egress exit nodes (selectable egress location)
+
+Entry and egress are **independent axes**. Entry = which gateway you connect
+through (`entry-select`). Egress = where your traffic leaves the internet
+(`exit-select`): either **direct** (at the gateway) or via an **exit node** that
+NATs out its own IP — e.g. the home cluster, egressing the residential IP.
+
+An exit is a substrate-agnostic unit — **rathole client + ss-rust** — as a k8s
+Deployment (`modules/exit.ts`) today, or a cloud-init VPS later. Add one via the
+`exits` config list:
+
+```yaml
+jaritanet:exits:
+  - name: home
+    port: 9000
+```
+
+It's reached through the **existing rathole tunnel**, not the tailnet. Each
+exit's ss-rust port is surfaced on **every gateway's loopback** (`127.0.0.1:<port>`)
+via a rathole service entry — the same pattern as the Reality decoy `dest`:
+
+```mermaid
+flowchart LR
+    DEV["device"] -->|"entry-select (hy2/reality)"| GW["gateway"]
+    GW -->|"127.0.0.1:<port> → rathole"| SS["ss-rust exit (k8s)"]
+    SS -->|"pod egress, CNI SNAT → node IP"| INET(("Internet"))
+```
+
+The client's `exit-<name>` outbound is Shadowsocks to `127.0.0.1:<port>` with
+`detour: entry-select`. In a detour chain the inner address resolves at the
+gateway end of the outer tunnel, so `127.0.0.1:<port>` means "this exit's rathole
+loopback on whichever gateway `entry-select` currently points at." **That's why
+the port must be identical across all gateways** — it lets one exit outbound work
+via any entry. Enforced in generation: the port is a single declared value used
+for the gateway bind, the rathole client target, and the client outbound.
+
+No kernel IP forwarding anywhere — ss-rust owns both ends of each flow
+(connection-level), so there's no return-path routing to misconfigure on a
+remote box. The exit pod egresses normally; microk8s' CNI SNATs to the node IP,
+which is the home link. Adding a gateway ⇒ it inherits every exit; adding an
+exit ⇒ it's exposed on every gateway. Pure function of the two config lists,
+expanded at `pulumi up`.
 
 ## Hardening notes
 

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -21,6 +21,12 @@ config:
     # over the tunnel. Provisioned only when TS_AUTHKEY is set, so this is a
     # no-op until the secret exists.
     tailnet: {}
+  # Egress exit nodes — ss-rust in the home cluster, reached via the rathole
+  # tunnel, egressing the home residential IP. Selectable in the client as
+  # exit-<name>; exits transit the primary gateway.
+  jaritanet:exits:
+    - name: home
+      port: 9000
   jaritanet:services:
     navidrome:
       hostname: ''

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -81,6 +81,27 @@ export const EdgeConfSchema = z.object({
   zone: z.string().default("radiosilence.dev"),
 });
 
+/**
+ * A selectable egress exit node: rathole client + ss-rust, substrate-agnostic
+ * (k8s in the home cluster now; a cloud-init VPS later). Traffic egresses via
+ * the exit's own IP.
+ *
+ * Reached through the EXISTING rathole tunnel, not the tailnet: the exit's
+ * ss-rust port is surfaced on every gateway's loopback (`127.0.0.1:<port>`) via
+ * a rathole service entry, exactly like the Reality decoy `dest`. The client's
+ * ss outbound dials `127.0.0.1:<port>` through the entry gateway (detour), and
+ * because a detour resolves the inner address at the gateway end, that hits the
+ * gateway's rathole loopback for this exit. `port` MUST be identical across all
+ * gateways — that invariant is what lets one exit outbound work via any entry.
+ */
+export const ExitConfSchema = z.object({
+  image: z.string().default("ghcr.io/shadowsocks/ssserver-rust:latest"),
+  method: z.string().default("aes-256-gcm"),
+  name: z.string(),
+  port: z.number(),
+  substrate: z.enum(["k8s"]).default("k8s"),
+});
+
 export const TraefikConfSchema = z.object({
   acmeEmail: z.string(),
   chartVersion: z.string().default("41.0.2"),
@@ -122,6 +143,7 @@ export const ConfSchema = z.object({
   cloudflare: CloudflareConfSchema,
   clusterDomain: z.string().default("cluster.local"),
   edges: z.array(EdgeConfSchema).default([]),
+  exits: z.array(ExitConfSchema).default([]),
   externalIp: z.string().optional(),
   fastmail: FastmailConfSchema,
   gateway: GatewayConfSchema.optional(),

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -87,15 +87,20 @@ export const EdgeConfSchema = z.object({
  * the exit's own IP.
  *
  * Reached through the EXISTING rathole tunnel, not the tailnet: the exit's
- * ss-rust port is surfaced on every gateway's loopback (`127.0.0.1:<port>`) via
- * a rathole service entry, exactly like the Reality decoy `dest`. The client's
- * ss outbound dials `127.0.0.1:<port>` through the entry gateway (detour), and
- * because a detour resolves the inner address at the gateway end, that hits the
- * gateway's rathole loopback for this exit. `port` MUST be identical across all
- * gateways — that invariant is what lets one exit outbound work via any entry.
+ * ss-rust port is surfaced on the rathole gateway's loopback (`127.0.0.1:<port>`)
+ * via a rathole service entry, exactly like the Reality decoy `dest`. The
+ * client's ss outbound dials `127.0.0.1:<port>` through that gateway (detour),
+ * and because a detour resolves the inner address at the gateway end, it hits
+ * the gateway's rathole loopback for this exit.
+ *
+ * Exits route via the **primary** gateway specifically — it's the only node
+ * that runs rathole (edges run hy2/reality only). So the exit detour is pinned
+ * to the primary, independent of which entry `entry-select` picks for direct
+ * traffic. When more rathole-running gateways exist, `port` must be identical
+ * across them so one exit outbound works via any of them.
  */
 export const ExitConfSchema = z.object({
-  image: z.string().default("ghcr.io/shadowsocks/ssserver-rust:latest"),
+  image: z.string().default("ghcr.io/shadowsocks/ssserver-rust:v1.24.0"),
   method: z.string().default("aes-256-gcm"),
   name: z.string(),
   port: z.number(),

--- a/packages/infra/src/conf.ts
+++ b/packages/infra/src/conf.ts
@@ -8,6 +8,7 @@ const { data, error } = ConfSchema.safeParse({
   bluesky: config.requireObject("bluesky"),
   cloudflare: config.requireObject("cloudflare"),
   edges: config.getObject("edges"),
+  exits: config.getObject("exits"),
   externalIp: config.get("externalIp"),
   fastmail: config.requireObject("fastmail"),
   gateway: config.getObject("gateway"),

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -10,6 +10,7 @@ import {
   createServiceRecord,
 } from "./modules/dns.ts";
 import { createEdge } from "./modules/edge.ts";
+import { createExit } from "./modules/exit.ts";
 import { createGateway } from "./modules/gateway.ts";
 import {
   createIngress,
@@ -39,7 +40,8 @@ export default async function () {
 
   if (env.HCLOUD_TOKEN) {
     const gatewayConf = conf.gateway ?? GatewayConfSchema.parse({});
-    const gw = createGateway(gatewayConf);
+    // Exits (config values) surface on the gateway's rathole loopback.
+    const gw = createGateway(gatewayConf, conf.exits);
     dnsTarget = gw.vpsIp;
     ratholeToken = gw.ratholeToken.result;
     gatewayProvider = "hetzner";
@@ -149,6 +151,10 @@ export default async function () {
     { provider },
   );
 
+  // Egress exit nodes: ss-rust in-cluster. The rathole client (in createIngress)
+  // punches each one's port out to the gateway loopback.
+  const exits = conf.exits.map((e) => createExit(provider, namespace, e));
+
   // --- Ingress: Traefik always on hostPort 443 + rathole client if gateway exists ---
   createIngress(
     provider,
@@ -157,6 +163,7 @@ export default async function () {
     dnsTarget,
     ratholeToken,
     env.CLOUDFLARE_API_TOKEN,
+    conf.exits,
   );
 
   createRedirectMiddleware(provider, namespace);
@@ -209,6 +216,7 @@ export default async function () {
         privateKey: pulumi.secret(env.SSH_PRIVATE_KEY),
         user: env.OLDBOY_USER,
       },
+      exits,
       slug: env.SINGBOX_SLUG,
       telegram:
         env.TELEGRAM_BOT_TOKEN && env.TELEGRAM_CHAT_ID

--- a/packages/infra/src/modules/exit.ts
+++ b/packages/infra/src/modules/exit.ts
@@ -1,0 +1,115 @@
+import * as crypto from "node:crypto";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import type * as z from "zod";
+import type { ExitConfSchema } from "../conf.schemas.ts";
+
+/**
+ * A k8s egress exit: ss-rust in the home cluster. Traffic reaches it through
+ * the rathole tunnel (a rathole client entry punches its port out to the
+ * gateways — see ingress + gateway), and it NATs out via the pod's normal
+ * egress — which the CNI SNATs to the node IP, i.e. the home link. No
+ * `hostNetwork`, no kernel forwarding: ss-rust owns both ends of each flow.
+ *
+ * The ss password is a single Pulumi secret consumed here (server ConfigMap)
+ * and by the client outbound (see singbox) — one source, no drift. Returns the
+ * exit's coordinates for the rathole entries and the client profile.
+ */
+export function createExit(
+  provider: k8s.Provider,
+  namespace: string,
+  exit: z.infer<typeof ExitConfSchema>,
+) {
+  const name = `exit-${exit.name}`;
+  const password = new random.RandomPassword(`${name}-ss`, {
+    length: 32,
+    special: false,
+  });
+
+  const config = password.result.apply((pw) =>
+    JSON.stringify({
+      server: "0.0.0.0",
+      server_port: exit.port,
+      method: exit.method,
+      password: pw,
+      mode: "tcp_and_udp",
+    }),
+  );
+  const configHash = config.apply((c) =>
+    crypto.createHash("sha256").update(c).digest("hex"),
+  );
+
+  const configMap = new k8s.core.v1.ConfigMap(
+    `${name}-config`,
+    {
+      metadata: { name, namespace },
+      data: { "config.json": config },
+    },
+    { provider },
+  );
+
+  new k8s.apps.v1.Deployment(
+    name,
+    {
+      metadata: { name, namespace },
+      spec: {
+        replicas: 1,
+        selector: { matchLabels: { app: name } },
+        template: {
+          // Roll the pod when the ss config (password/method/port) changes.
+          metadata: {
+            annotations: { "jaritanet/config-hash": configHash },
+            labels: { app: name },
+          },
+          spec: {
+            containers: [
+              {
+                name: "ssserver",
+                image: exit.image,
+                command: ["ssserver", "-c", "/etc/shadowsocks/config.json"],
+                volumeMounts: [
+                  {
+                    name: "config",
+                    mountPath: "/etc/shadowsocks",
+                    readOnly: true,
+                  },
+                ],
+                resources: {
+                  limits: { cpu: "500m", memory: "128Mi" },
+                },
+              },
+            ],
+            volumes: [{ name: "config", configMap: { name } }],
+          },
+        },
+      },
+    },
+    { dependsOn: [configMap], provider },
+  );
+
+  const service = new k8s.core.v1.Service(
+    name,
+    {
+      metadata: { name, namespace },
+      spec: {
+        selector: { app: name },
+        ports: [
+          { name: "ss-tcp", port: exit.port, protocol: "TCP" },
+          { name: "ss-udp", port: exit.port, protocol: "UDP" },
+        ],
+      },
+    },
+    { provider },
+  );
+
+  const host = pulumi.interpolate`${service.metadata.name}.${namespace}.svc.cluster.local`;
+
+  return {
+    host,
+    method: exit.method,
+    name: exit.name,
+    password: password.result,
+    port: exit.port,
+  };
+}

--- a/packages/infra/src/modules/exit.ts
+++ b/packages/infra/src/modules/exit.ts
@@ -33,18 +33,21 @@ export function createExit(
       server_port: exit.port,
       method: exit.method,
       password: pw,
-      mode: "tcp_and_udp",
+      // TCP only: the rathole tunnel that reaches this server is TCP, so UDP
+      // associations can't traverse the exit path (UDP goes direct instead).
+      mode: "tcp_only",
     }),
   );
   const configHash = config.apply((c) =>
     crypto.createHash("sha256").update(c).digest("hex"),
   );
 
-  const configMap = new k8s.core.v1.ConfigMap(
+  // Secret, not ConfigMap: config.json embeds the ss password in cleartext.
+  const secret = new k8s.core.v1.Secret(
     `${name}-config`,
     {
       metadata: { name, namespace },
-      data: { "config.json": config },
+      stringData: { "config.json": config },
     },
     { provider },
   );
@@ -80,12 +83,12 @@ export function createExit(
                 },
               },
             ],
-            volumes: [{ name: "config", configMap: { name } }],
+            volumes: [{ name: "config", secret: { secretName: name } }],
           },
         },
       },
     },
-    { dependsOn: [configMap], provider },
+    { dependsOn: [secret], provider },
   );
 
   const service = new k8s.core.v1.Service(
@@ -94,10 +97,7 @@ export function createExit(
       metadata: { name, namespace },
       spec: {
         selector: { app: name },
-        ports: [
-          { name: "ss-tcp", port: exit.port, protocol: "TCP" },
-          { name: "ss-udp", port: exit.port, protocol: "UDP" },
-        ],
+        ports: [{ name: "ss-tcp", port: exit.port, protocol: "TCP" }],
       },
     },
     { provider },

--- a/packages/infra/src/modules/gateway.ts
+++ b/packages/infra/src/modules/gateway.ts
@@ -16,7 +16,10 @@ import { createXray } from "./xray.ts";
  * It just tunnels ports 80/443 from the public internet to
  * the rathole client running inside the K8s cluster.
  */
-export function createGateway(gateway: z.infer<typeof GatewayConfSchema>) {
+export function createGateway(
+  gateway: z.infer<typeof GatewayConfSchema>,
+  exits: { name: string; port: number }[] = [],
+) {
   const ratholeToken = new random.RandomPassword("rathole-token", {
     length: 64,
   });
@@ -143,6 +146,16 @@ sysctl --system`,
   // decoy backend, so rathole's https bind moves to a local-only port.
   const httpsBind = gateway.xray ? "127.0.0.1:8443" : "0.0.0.0:443";
 
+  // Each exit's ss-rust port, surfaced on this gateway's loopback via rathole —
+  // same pattern as the Reality decoy dest. The port is stable + identical
+  // across gateways, so one client ss outbound reaches this exit via any entry.
+  const exitServices = exits
+    .map(
+      (e) =>
+        `\n[server.services.exit-${e.name}]\ntype = "tcp"\nbind_addr = "127.0.0.1:${e.port}"\n`,
+    )
+    .join("");
+
   // Write rathole config via SSH (supports updates without replacing the server)
   const ratholeConfig = pulumi.interpolate`[server]
 bind_addr = "0.0.0.0:2333"
@@ -155,7 +168,7 @@ bind_addr = "${httpsBind}"
 [server.services.http]
 type = "tcp"
 bind_addr = "0.0.0.0:80"
-`;
+${exitServices}`;
 
   const configUpload = new command.remote.Command(
     "rathole-config",
@@ -164,7 +177,7 @@ bind_addr = "0.0.0.0:80"
       create: pulumi.interpolate`cat > /etc/rathole/server.toml << 'RATHOLE_EOF'
 ${ratholeConfig}
 RATHOLE_EOF`,
-      triggers: [ratholeToken.result, httpsBind],
+      triggers: [ratholeToken.result, httpsBind, exitServices],
     },
     { dependsOn: [server] },
   );

--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import type * as z from "zod";
@@ -18,6 +19,7 @@ export function createIngress(
   vpsIp: pulumi.Output<string> | undefined,
   ratholeToken: pulumi.Output<string> | undefined,
   cloudflareApiToken: string,
+  exits: { name: string; port: number }[] = [],
 ) {
   // Cloudflare API token for Traefik's DNS-01 ACME solver
   const cfSecret = new k8s.core.v1.Secret(
@@ -100,6 +102,17 @@ export function createIngress(
   if (vpsIp && ratholeToken) {
     // Use the Helm release's generated service name and service ports (not container ports)
     const traefikSvc = pulumi.interpolate`${traefikRelease.name}.${namespace}.svc.cluster.local`;
+
+    // Punch each k8s exit's ss-rust port out to the gateway (matched by name to
+    // the gateway's [server.services.exit-*] loopback bind). Same rathole tunnel
+    // that already carries Traefik — an exit is just another service on it.
+    const exitClientEntries = exits
+      .map(
+        (e) =>
+          `\n[client.services.exit-${e.name}]\ntype = "tcp"\nlocal_addr = "exit-${e.name}.${namespace}.svc.cluster.local:${e.port}"\n`,
+      )
+      .join("");
+
     const ratholeConfig = pulumi.interpolate`[client]
 remote_addr = "${vpsIp}:2333"
 default_token = "${ratholeToken}"
@@ -111,7 +124,11 @@ local_addr = "${traefikSvc}:443"
 [client.services.http]
 type = "tcp"
 local_addr = "${traefikSvc}:80"
-`;
+${exitClientEntries}`;
+
+    const ratholeConfigHash = ratholeConfig.apply((c) =>
+      crypto.createHash("sha256").update(c).digest("hex"),
+    );
 
     const ratholeConfigMap = new k8s.core.v1.ConfigMap(
       "rathole-client-config",
@@ -137,6 +154,9 @@ local_addr = "${traefikSvc}:80"
           },
           template: {
             metadata: {
+              // Roll the client when the config changes (new/removed exit) —
+              // mounted ConfigMaps don't restart rathole on their own.
+              annotations: { "jaritanet/config-hash": ratholeConfigHash },
               labels: { app: "rathole-client" },
             },
             spec: {

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -109,9 +109,10 @@ const selector = (tag: string, outbounds: string[], def: string) => ({
  *     entry gateway). Route `final` points here; tailnet + DNS stay on
  *     `entry-select` so they egress at the gateway, never via an exit.
  *
- * Each exit outbound targets `127.0.0.1:<port>` with `detour: entry-select` —
- * the inner address resolves at the gateway end of the detour, hitting that
- * exit's rathole loopback there.
+ * Each exit outbound targets `127.0.0.1:<port>` and detours through the
+ * **primary** gateway (the only rathole node) — the inner address resolves at
+ * the primary end, hitting that exit's rathole loopback. Exits therefore always
+ * transit the primary, regardless of the `entry-select` pick for direct egress.
  */
 export function buildProfile(
   nodes: ResolvedNode[],
@@ -156,8 +157,16 @@ export function buildProfile(
     );
   }
 
-  // Each exit: a Shadowsocks outbound dialled through the entry gateway. The
-  // 127.0.0.1:<port> resolves at the gateway → its rathole loopback for this
+  // Exits are pinned to the PRIMARY gateway (nodes[0]) — it's the only node
+  // that runs rathole, so it's the only one exposing the exit loopbacks. Edges
+  // (also in entry-select) run hy2/reality only; detouring an exit through an
+  // edge would dial 127.0.0.1:<port> where nothing listens. So the exit detour
+  // targets the primary specifically, not entry-select — entry-select governs
+  // *direct* egress; exits always transit the primary.
+  const ratholeEntry = nodes.length === 1 ? "auto" : `auto-${nodes[0].name}`;
+
+  // Each exit: a Shadowsocks outbound dialled through the primary gateway. The
+  // 127.0.0.1:<port> resolves at the primary → its rathole loopback for this
   // exit → the exit's ss-rust → egress at the exit's own IP.
   for (const e of exits) {
     outbounds.push({
@@ -167,7 +176,7 @@ export function buildProfile(
       server_port: e.port,
       method: e.method,
       password: e.password,
-      detour: "entry-select",
+      detour: ratholeEntry,
     });
   }
 

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -38,6 +38,21 @@ type ResolvedNode = {
   };
 };
 
+/** A selectable egress exit — a Shadowsocks proxy reached via the entry gateway. */
+export type Exit = {
+  name: string;
+  port: number;
+  method: string;
+  password: pulumi.Input<string>;
+};
+
+type ResolvedExit = {
+  name: string;
+  port: number;
+  method: string;
+  password: string;
+};
+
 const hy2 = (n: ResolvedNode) => ({
   type: "hysteria2",
   tag: `hy2-${n.name}`,
@@ -86,12 +101,23 @@ const selector = (tag: string, outbounds: string[], def: string) => ({
  * We build an object and `JSON.stringify` it rather than templating a JSON
  * string — that can't emit invalid JSON, and the group layout is just data.
  *
- * The groups expand with node count: one node → flat `main` selector over
- * [auto, hy2, reality]; N nodes → nested `main` → auto-all | per-host
- * selectors, each holding that host's auto + hy2 + reality. Routing always
- * targets `main`, so the DNS/route sections are count-agnostic.
+ * Two independent axes:
+ *   - `entry-select` — which gateway/transport you enter through. Expands with
+ *     node count: one node → [auto, hy2, reality]; N → auto-all | per-host.
+ *   - `exit-select` — where you egress: `entry-select` (direct, at the gateway)
+ *     or an `exit-<name>` (a Shadowsocks proxy on that exit, dialled via the
+ *     entry gateway). Route `final` points here; tailnet + DNS stay on
+ *     `entry-select` so they egress at the gateway, never via an exit.
+ *
+ * Each exit outbound targets `127.0.0.1:<port>` with `detour: entry-select` —
+ * the inner address resolves at the gateway end of the detour, hitting that
+ * exit's rathole loopback there.
  */
-export function buildProfile(nodes: ResolvedNode[], magicdnsSuffix: string) {
+export function buildProfile(
+  nodes: ResolvedNode[],
+  magicdnsSuffix: string,
+  exits: ResolvedExit[] = [],
+) {
   const outbounds: Record<string, unknown>[] = [];
   for (const n of nodes) {
     outbounds.push(hy2(n), reality(n));
@@ -100,7 +126,7 @@ export function buildProfile(nodes: ResolvedNode[], magicdnsSuffix: string) {
     const t = nodes[0].name;
     outbounds.push(urltest("auto", [`hy2-${t}`, `reality-${t}`]));
     outbounds.push(
-      selector("main", ["auto", `hy2-${t}`, `reality-${t}`], "auto"),
+      selector("entry-select", ["auto", `hy2-${t}`, `reality-${t}`], "auto"),
     );
   } else {
     for (const n of nodes) {
@@ -122,9 +148,37 @@ export function buildProfile(nodes: ResolvedNode[], magicdnsSuffix: string) {
       ),
     );
     outbounds.push(
-      selector("main", ["auto-all", ...nodes.map((n) => n.name)], "auto-all"),
+      selector(
+        "entry-select",
+        ["auto-all", ...nodes.map((n) => n.name)],
+        "auto-all",
+      ),
     );
   }
+
+  // Each exit: a Shadowsocks outbound dialled through the entry gateway. The
+  // 127.0.0.1:<port> resolves at the gateway → its rathole loopback for this
+  // exit → the exit's ss-rust → egress at the exit's own IP.
+  for (const e of exits) {
+    outbounds.push({
+      type: "shadowsocks",
+      tag: `exit-${e.name}`,
+      server: "127.0.0.1",
+      server_port: e.port,
+      method: e.method,
+      password: e.password,
+      detour: "entry-select",
+    });
+  }
+
+  // The exit axis: direct (egress at the gateway) or one of the exits.
+  outbounds.push(
+    selector(
+      "exit-select",
+      ["entry-select", ...exits.map((e) => `exit-${e.name}`)],
+      "entry-select",
+    ),
+  );
 
   return {
     log: { level: "info", timestamp: true },
@@ -135,7 +189,7 @@ export function buildProfile(nodes: ResolvedNode[], magicdnsSuffix: string) {
           type: "udp",
           tag: "ts-dns",
           server: "100.100.100.100",
-          detour: "main",
+          detour: "entry-select",
         },
       ],
       rules: [{ domain_suffix: [magicdnsSuffix], server: "ts-dns" }],
@@ -160,11 +214,12 @@ export function buildProfile(nodes: ResolvedNode[], magicdnsSuffix: string) {
         { action: "sniff" },
         { protocol: "dns", action: "hijack-dns" },
         {
+          // Tailnet egresses at the gateway (into the mesh), never via an exit.
           ip_cidr: ["100.64.0.0/10", "fd7a:115c:a1e0::/48"],
-          outbound: "main",
+          outbound: "entry-select",
         },
       ],
-      final: "main",
+      final: "exit-select",
       auto_detect_interface: true,
     },
   };
@@ -176,6 +231,7 @@ type DeliveryOpts = {
   magicdnsSuffix: string;
   oldboy: { host: string; user: string; privateKey: pulumi.Output<string> };
   telegram?: { botToken: pulumi.Output<string>; chatId: string };
+  exits?: Exit[];
 };
 
 /**
@@ -191,10 +247,14 @@ export function createSingboxDelivery(
   opts: DeliveryOpts,
 ) {
   const profileJson = pulumi
-    .output(nodes)
-    .apply((resolved) =>
+    .all([pulumi.output(nodes), pulumi.output(opts.exits ?? [])])
+    .apply(([resolvedNodes, resolvedExits]) =>
       JSON.stringify(
-        buildProfile(resolved as ResolvedNode[], opts.magicdnsSuffix),
+        buildProfile(
+          resolvedNodes as ResolvedNode[],
+          opts.magicdnsSuffix,
+          resolvedExits as ResolvedExit[],
+        ),
         null,
         2,
       ),

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -74,6 +74,34 @@
             "required": ["name"]
           }
         },
+        "jaritanet:exits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "image": {
+                "default": "ghcr.io/shadowsocks/ssserver-rust:latest",
+                "type": "string"
+              },
+              "method": {
+                "default": "aes-256-gcm",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "port": {
+                "type": "number"
+              },
+              "substrate": {
+                "default": "k8s",
+                "type": "string",
+                "enum": ["k8s"]
+              }
+            },
+            "required": ["name", "port"]
+          }
+        },
         "jaritanet:gateway": {
           "type": "object",
           "properties": {

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -80,7 +80,7 @@
             "type": "object",
             "properties": {
               "image": {
-                "default": "ghcr.io/shadowsocks/ssserver-rust:latest",
+                "default": "ghcr.io/shadowsocks/ssserver-rust:v1.24.0",
                 "type": "string"
               },
               "method": {

--- a/scripts/gen-schemas.ts
+++ b/scripts/gen-schemas.ts
@@ -33,6 +33,7 @@ const schemas = {
     ({
       CloudflareConfSchema,
       EdgeConfSchema,
+      ExitConfSchema,
       GatewayConfSchema,
       TraefikConfSchema,
       ServicesMapSchema,
@@ -45,6 +46,7 @@ const schemas = {
           config: z.object({
             [`${PROJECT}:cloudflare`]: CloudflareConfSchema,
             [`${PROJECT}:edges`]: z.array(EdgeConfSchema).optional(),
+            [`${PROJECT}:exits`]: z.array(ExitConfSchema).optional(),
             [`${PROJECT}:gateway`]: GatewayConfSchema,
             [`${PROJECT}:traefik`]: TraefikConfSchema,
             [`${PROJECT}:services`]: ServicesMapSchema,


### PR DESCRIPTION
**Draft** — logic is verified (typecheck/lint/schema/`buildProfile` structure), but the runtime path (rathole exit tunnel, ss egress IP, the detour→loopback chain) needs a deploy + your test. First slice of the exit-nodes spec: **single gateway + one home k8s exit**, written for the general gateways × exits cross-product.

## What

A second, independent axis on top of the entry gateways. The client picks **entry** (which gateway) *and* **egress** (direct at the gateway, or via an exit node that NATs out its own IP — e.g. the home residential link).

An **exit** = substrate-agnostic `rathole client + ss-rust`: a k8s Deployment now (`modules/exit.ts`), a cloud-init VPS later. Add one with:
```yaml
jaritanet:exits:
  - name: home
    port: 9000
```

## How (the load-bearing bit)

Reached through the **existing rathole tunnel, not the tailnet**. Each exit's ss port is surfaced on **every gateway's loopback** `127.0.0.1:<port>` via a rathole service entry (same pattern as the Reality decoy `dest`). The client's `exit-<name>` outbound is Shadowsocks to `127.0.0.1:<port>` with `detour: entry-select` — a detour resolves the inner address at the *gateway* end, so `127.0.0.1:<port>` hits that exit's rathole loopback there. **The port is one declared value** (gateway bind = rathole client target = client outbound), so it's identical across gateways — the invariant that lets one exit outbound work via any entry.

- `buildProfile` now emits `entry-select` (gateway/transport) + `exit-select` (`[direct, exit-…]`); `route.final → exit-select`; tailnet `100.x` + DNS stay on `entry-select` (egress at the gateway, never via an exit).
- `gateway.ts` rathole **server** gains `[server.services.exit-*]` loopback binds; `ingress.ts` rathole **client** gains `[client.services.exit-*] → ss service`, with a config-hash annotation so the client pod rolls when exits change.
- No kernel forwarding (connection-level only); pod egress SNATs to the node IP.
- ss password: one Pulumi secret → ss ConfigMap + client outbound (no drift).

## Verified

typecheck, lint 0/0, schema regen, and `buildProfile` structure-tested with and without an exit (correct `entry-select`/`exit-select`/`exit-<name>` SS `127.0.0.1:<port>` detour, `final → exit-select`, tailnet on `entry-select`; backward-compatible when no exits).

## Acceptance checks to run on deploy (why it's draft)

- **Egress IP** — `curl ifconfig.me` from the exit pod returns oldboy's **home ISP IP** (confirm microk8s CNI SNATs pod egress to the node IP).
- **Selectors compose** — pick entry ∈ gateways and exit ∈ {direct, home} independently; traffic enters via the chosen gateway and egresses at the chosen exit.
- **Reality/hy2 entry unchanged**; **idempotent** re-`up` is a no-op.

## Deferred (from the spec, deliberately)
- Capability-URL **rotation** — conflicts with sing-box auto-update (rotating the URL strands the device on the old one). Kept the static slug + in-place update. Flagged for discussion.
- VPS-substrate exits (cloud-init) — same `exits` entry, different substrate; k8s first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)