### PR TITLE
docs: remove Oracle, rebuild secrets table, fix stale diagrams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,6 @@ The project uses Lefthook for pre-commit validation:
 Everything deploys in one `pulumi up` from `packages/infra/`:
 
 - **`src/modules/gateway.ts`** — Hetzner VPS + firewall + Rathole server provisioning
-- **`src/modules/gateway-oci.ts`** — Oracle Cloud ARM instance + VCN + Rathole via Docker
 - **`src/modules/xray.ts`** — optional Xray VLESS-REALITY proxy sharing :443 with the gateway
 - **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoute CRDs, IP watcher
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
@@ -78,7 +77,7 @@ Without a gateway, Traefik serves directly via hostPort 443 and DNS points at th
 - **Traefik** — Ingress controller with built-in ACME. Handles Let's Encrypt certs via DNS-01 challenge against Cloudflare. Always binds hostPort 443 as fallback.
 - **Cloudflare** — DNS only. A records pointing at VPS or server IP, plus Fastmail MX/DKIM and Bluesky ATProto records.
 - **IP watcher** — Pod that checks external IP every 60s via Cloudflare's 1.1.1.1/cdn-cgi/trace and triggers deploy on change.
-- **Gateway auto-detection** — Hetzner (HCLOUD_TOKEN) > Oracle Cloud (OCI_TENANCY_OCID) > direct mode.
+- **Gateway** — Hetzner (HCLOUD_TOKEN) when set, else direct mode.
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ graph TB
 
 When gateway credentials are configured, a VPS running Rathole acts as a stateless TCP relay. Your home IP disappears from DNS and all traffic routes through the VPS. Traefik keeps hostPort 443 as a fallback regardless — if the relay dies, port-forwarding still works.
 
-The gateway provider is auto-detected from available credentials:
+Set `HCLOUD_TOKEN` and the deploy provisions a Hetzner VPS gateway; leave it
+unset for direct mode (DNS points at the home IP, Traefik serves on hostPort
+443). The gateway also doubles as the VPN entry hub — see
+[`docs/architecture.md`](docs/architecture.md).
 
-| Priority | Provider | Trigger | Cost |
-|---|---|---|---|
-| 1 | Hetzner | `HCLOUD_TOKEN` set | ~EUR3.85/mo (CX22) |
-| 2 | Oracle Cloud | `OCI_TENANCY_OCID` set | Free forever (ARM A1.Flex) |
-| 3 | Direct | Neither set | Free (uses detected external IP) |
+| Mode | Trigger | Cost |
+|---|---|---|
+| Hetzner gateway | `HCLOUD_TOKEN` set | ~EUR3.85/mo (CX23) |
+| Direct | unset | free (home IP) |
 
 ```
 User -> VPS:443 -> Rathole tunnel -> Traefik -> Service
@@ -98,8 +100,7 @@ jaritanet:exits:
 
 Everything lives in a single Pulumi package at `packages/infra/`:
 
-- **`src/modules/gateway.ts`** — Hetzner VPS gateway (optional)
-- **`src/modules/gateway-oci.ts`** — Oracle Cloud ARM gateway (optional)
+- **`src/modules/gateway.ts`** — Hetzner VPS gateway: Xray/Hysteria2 entry + rathole + tailnet relay (optional)
 - **`src/modules/edge.ts`** — standalone VPN edge boxes in other locations (hy2 + REALITY + tailnet relay); add via `edges` in config. See [`docs/architecture.md`](docs/architecture.md#edge-nodes-multi-location)
 - **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoutes, IP watcher
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
@@ -111,49 +112,63 @@ Everything lives in a single Pulumi package at `packages/infra/`:
 
 ### GitHub Actions Secrets
 
+**Deploy (`ci-cd.yml`) — Pulumi core**
+
 | Secret | Required | Purpose |
 |---|---|---|
-| `PULUMI_ACCESS_TOKEN` | Yes | Pulumi Cloud state management |
-| `CLOUDFLARE_API_TOKEN` | Yes | DNS management + Traefik ACME DNS-01 (needs DNS:Edit, Zone:Read) |
-| `CLOUDFLARE_ACCOUNT_ID` | Yes | Cloudflare account identifier |
-| `TS_OAUTH_CLIENT_ID` | Yes | Tailscale VPN access to K8s cluster |
-| `TS_OAUTH_SECRET` | Yes | Tailscale OAuth secret |
-| `KUBE_HOST` | Yes | K8s API server hostname (Tailscale IP) |
-| `KUBE_API_PORT` | Yes | K8s API server port (default: 16443) |
-| `KUBE_TOKEN` | Yes | K8s service account token (base64) |
-| `NAVIDROME_HOSTNAME` | Yes | Public hostname for Navidrome |
-| `FILES_HOSTNAME` | Yes | Public hostname for file server |
-| `BLIT_HOSTNAME` | Yes | Public hostname for Blit |
-| `DEPLOY_TOKEN` | No | GitHub PAT (Actions:write) — enables IP watcher pod |
-| `HCLOUD_TOKEN` | No | Hetzner Cloud API token — enables Hetzner gateway |
-| `OCI_TENANCY_OCID` | No | Oracle Cloud tenancy — enables OCI gateway |
-| `OCI_USER_OCID` | No | Oracle Cloud user OCID |
-| `OCI_FINGERPRINT` | No | Oracle Cloud API key fingerprint |
-| `OCI_PRIVATE_KEY` | No | Oracle Cloud API key (PEM contents) |
-| `OCI_REGION` | No | Oracle Cloud region (e.g. `eu-amsterdam-1`) |
+| `PULUMI_ACCESS_TOKEN` | Yes | Pulumi Cloud state |
+| `CLOUDFLARE_API_TOKEN` | Yes | DNS + Traefik ACME DNS-01 (DNS:Edit, Zone:Read) |
+| `CLOUDFLARE_ACCOUNT_ID` | Yes | Cloudflare account id |
+| `ACME_EMAIL` | Yes | Let's Encrypt account email (Traefik) |
+| `KUBE_HOST` / `KUBE_API_PORT` / `KUBE_TOKEN` | Yes | K8s API access (host = tailnet IP, token base64) |
+| `NAVIDROME_HOSTNAME` / `FILES_HOSTNAME` / `BLIT_HOSTNAME` | Yes | Service hostnames (`BLIT_HOSTNAME` is also injected as the REALITY `serverName`) |
 
-### Enabling a Gateway
+**Tailscale**
 
-Set credentials for one provider — the deploy auto-detects which to use.
+| Secret | Required | Purpose |
+|---|---|---|
+| `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` | Yes | OAuth for CI to reach the K8s API over the tailnet (`tag:ci`) |
+| `TS_AUTHKEY` | No | OAuth client secret (`tskey-client-…`, `tag:server`) that joins the gateway/edges to the tailnet — enables the relay |
 
-**Hetzner** (~EUR3.85/mo):
+**Gateway (optional — absent = direct mode)**
+
+| Secret | Required | Purpose |
+|---|---|---|
+| `HCLOUD_TOKEN` | No | Hetzner API token — provisions the VPS gateway |
+
+**sing-box profile delivery (optional)**
+
+| Secret | Required | Purpose |
+|---|---|---|
+| `SINGBOX_SLUG` | No | Unguessable path for the hosted client profile |
+| `TAILNET_MAGICDNS_SUFFIX` | No | Tailnet MagicDNS suffix baked into the profile |
+| `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` | No | Telegram bot + chat for the profile URL/QR notify |
+
+**Ansible / server provisioning (`run-playbook.yml`)**
+
+| Secret | Required | Purpose |
+|---|---|---|
+| `SSH_PRIVATE_KEY` | Yes | SSH key to oldboy (ansible + Pulumi's profile delivery) |
+| `OLDBOY_HOST` / `OLDBOY_USER` / `OLDBOY_PASSWORD` | Yes | oldboy tailnet host, SSH user, sudo password |
+| `SAMBA_PASSWORD` | Yes | Samba share password |
+| `GIT_SSH_KEY` | Yes | SSH key for git access during playbook runs |
+
+**Automation**
+
+| Secret | Required | Purpose |
+|---|---|---|
+| `SECRETS_PAT` | Yes | PAT for `update-secrets` (pushes generated kube secrets) |
+| `APP_PRIVATE_KEY` | Yes | GitHub App private key for `update-apps` (pairs with the `APP_ID` repo variable) |
+| `DEPLOY_TOKEN` | No | GitHub PAT (Actions:write) — enables the direct-mode IP-watcher pod |
+
+### Enabling the gateway
+
 ```bash
 # console.hetzner.cloud > Project > Security > API Tokens
 gh secret set HCLOUD_TOKEN
 ```
 
-**Oracle Cloud** (free forever):
-```bash
-# cloud.oracle.com > Profile > My profile > API keys > Add API key
-# The console shows tenancy/user OCIDs and generates the key+fingerprint
-gh secret set OCI_TENANCY_OCID   # Profile > Tenancy: <ocid shown at top>
-gh secret set OCI_USER_OCID      # Profile > My profile: <ocid under user info>
-gh secret set OCI_FINGERPRINT    # Shown after adding the API key
-gh secret set OCI_PRIVATE_KEY    # Paste the downloaded PEM private key
-gh secret set OCI_REGION         # e.g. eu-amsterdam-1, uk-london-1
-```
-
-Next deploy provisions the VPS, deploys rathole, and flips DNS to the VPS IP. To switch back to direct mode, remove the secrets.
+Next deploy provisions the VPS, deploys rathole, and flips DNS to the VPS IP. Remove the secret to fall back to direct mode.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,11 +29,11 @@ flowchart LR
     TSG["tailscale"]
   end
 
-  subgraph EX["Exit box · ss-rust + rathole<br/>(oldboy home-k8s, or a Hetzner VPS)"]
+  subgraph EX["oldboy · home MicroK8s (behind NAT)"]
     RC["rathole client"]
-    SS["ss-rust"]
+    SS["ss-rust exit"]
     TSH["tailscale"]
-    SV["Traefik + home services (oldboy)"]
+    SV["Traefik + home services"]
   end
 
   NET(("Internet · gateway IP"))
@@ -51,9 +51,13 @@ flowchart LR
 Reading it: the client always reaches the **gateway** first (via the chosen
 protocol). Then `exit-select` decides what the gateway does — egress directly
 (gateway's own IP), or dial `127.0.0.1:<port>`, which is that exit's rathole
-loopback → the exit box's ss-rust → egress at *its* IP (e.g. the home link).
-Tailnet `100.x` and DNS ride the gateway's tailscale regardless of protocol. The
-sections below zoom into each part.
+loopback → the exit's ss-rust → egress at *its* IP (here, the home link).
+Tailnet `100.x` and DNS ride the gateway's tailscale regardless of protocol.
+
+The exit shown is oldboy (which also hosts the reverse-proxied home services),
+but an exit is just `ss-rust + rathole` — a future Hetzner VPS exit is the same
+two daemons via cloud-init, minus the services/tailnet-home roles. The sections
+below zoom into each part.
 
 ## The two data planes
 
@@ -165,27 +169,33 @@ intervention.
 
 ## Client routing (sing-box)
 
-One combined profile carries both transports and DNS handling. Everything —
-including tailnet `100.x` — rides the `main`/`auto` groups, so all traffic
-crosses the hostile network as obfuscated hy2/reality. The client runs **no
-WireGuard**; the tailnet hop happens on the VPS (see below).
+One combined profile carries both transports and DNS handling, behind the two
+selectors: **`entry-select`** (how you reach the gateway) and **`exit-select`**
+(where the gateway egresses you). The client runs **no WireGuard**; the tailnet
+hop happens on the gateway (see below).
 
 ```mermaid
 flowchart TD
     APP["app traffic"] --> SNIFF["sniff"]
     SNIFF --> DNSQ{"port 53?"}
     DNSQ -->|yes| HIJACK["hijack-dns"]
-    HIJACK --> RESOLVE{"tailnet suffix?"}
-    RESOLVE -->|yes| TSDNS["ts-dns<br/>udp 100.100.100.100, detour main"]
-    RESOLVE -->|no| DOH["cf-doh<br/>DoH 1.1.1.1 over tunnel"]
-    DNSQ -->|no| SEL["main -> auto<br/>urltest(hy2, reality)"]
-    SEL --> VPS["VPS egress / tailnet relay"]
+    HIJACK --> RES{"*.ts.net?"}
+    RES -->|yes| TSDNS["ts-dns → 100.100.100.100<br/>(detour entry-select)"]
+    RES -->|no| DOH["cf-doh → 1.1.1.1"]
+    DNSQ -->|no| TN{"100.x tailnet?"}
+    TN -->|yes| ENTRY["entry-select<br/>gateway → tailscale relay"]
+    TN -->|no| EXIT["exit-select"]
+    EXIT --> ED["exit-direct → entry-select<br/>(egress at the gateway)"]
+    EXIT --> EN["exit-oldboy, …<br/>(egress at an exit box)"]
 ```
 
-`hijack-dns` (after `sniff` in `route.rules`) is load-bearing: without it,
-sing-box flings port-53 queries out the tunnel as raw packets to a dead internal
-resolver; nothing resolves except cached names and the client looks offline.
-With it, queries are answered via DoH to 1.1.1.1 — encrypted and tunnelled.
+Two route rules do the work: `100.x` → `entry-select` (tailnet egresses at the
+gateway, never via an exit), and everything else → `final: exit-select`.
+`hijack-dns` (after `sniff`) is load-bearing: without it, sing-box flings
+port-53 queries out the tunnel as raw packets to a dead internal resolver;
+nothing resolves and the client looks offline. With it, `*.ts.net` resolves via
+`ts-dns` (the gateway's tailnet resolver) and everything else via DoH to
+1.1.1.1 — both tunnelled.
 
 ## Tailnet over the tunnel (censorship-resistant `100.x`)
 
@@ -256,12 +266,13 @@ tailnet as `jaritanet-<name>`. Every node — primary + edges — feeds Pulumi's
 writes it to the file server (change-detected by content hash) and pushes the
 updated URL/QR to Telegram. So: edit config, push, get a working URL.
 
-The picker is nested: the top `main` selector chooses `auto-all` (fastest node
-anywhere) or a per-host group. Each host is its own selector (`helsinki`,
-`primary`, …) holding that node's `auto-<name>` + `hy2-<name>` + `reality-<name>`,
-so you pick a location and can drill in to force a transport. Leaf outbound tags
-are prefixed per host (tags must be globally unique); the grouping is what you
-navigate.
+With multiple gateways, `entry-select` becomes nested: it chooses `auto-all`
+(fastest node anywhere) or a per-host group. Each host is its own selector
+(`helsinki`, `primary`, …) holding that node's `auto-<name>` + `hy2-<name>` +
+`reality-<name>`, so you pick a location and can drill in to force a transport.
+Leaf outbound tags are prefixed per host (tags must be globally unique); the
+grouping is what you navigate. (`exit-select` — the egress axis — is separate;
+see below.)
 
 **Why edges can use an external REALITY decoy** (unlike the primary): an edge
 fronts no site of its own, so there's no own-domain to break by forwarding
@@ -322,17 +333,16 @@ multiple rathole gateways exist, `port` must be identical across them.)
 
 Live tradeoffs worth knowing, not necessarily bugs:
 
-- **The REALITY decoy is our own domain, and that's load-bearing — not a
-  weakness to "fix."** REALITY has a single `dest` fallback, and every non-proxy
-  TCP/443 connection (i.e. every real public visitor to the site) is forwarded
-  there. Because `dest` is the home Traefik backend, visitors get the genuine
-  site. Repointing `dest` at an external site (`www.microsoft.com` etc.) to
-  borrow bigger crowd cover would serve *that* site to real visitors and break
-  public access — you cannot both reverse-proxy your own domain on :443 and
-  mimic someone else's. The cover is fine as-is: a real LE cert, real organic
-  traffic, an unremarkable small HTTPS site. The only threat it doesn't beat is
-  allowlist-style censorship (block everything except known-good domains), which
-  is rare and extreme.
+- **The primary's REALITY decoy is our own domain, and that's load-bearing —
+  not a weakness to "fix."** REALITY has a single `dest` fallback, and every
+  non-proxy TCP/443 connection (i.e. every real public visitor to the site) is
+  forwarded there. Because the primary's `dest` is the home Traefik backend,
+  visitors get the genuine site. Repointing it at an external site would serve
+  *that* site to real visitors and break public access — the primary cannot both
+  reverse-proxy its own domain on :443 and mimic someone else's. The cover is
+  fine as-is: a real LE cert, real organic traffic, an unremarkable HTTPS site.
+  (Edges are different — they front no site, so they *do* use an external decoy;
+  see Edge nodes. The only threat neither beats is allowlist-style censorship.)
 - **hy2 uses `insecure=1` + a self-signed cert.** Fine in practice — Salamander
   wraps the whole handshake so the cert never appears on the wire, and the obfs
   password gates access — but there's no cert pinning.


### PR DESCRIPTION
Docs accuracy pass.

- **Oracle removed** — it was docs-only fiction (no `gateway-oci.ts`, no OCI secrets, no `main.ts` branch). Stripped from the README provider table, module list, secrets table, enabling block, and CLAUDE.md.
- **Secrets table rebuilt** — from the actual 26 repo secrets, grouped by area (deploy / tailscale / gateway / sing-box / ansible / automation). It was stale (OCI rows) *and* missing ~14 real secrets.
- **Stale diagrams fixed** — the `main` selector is gone everywhere; `Client routing` rewritten to the real `entry-select`/`exit-select` split, edge-picker prose updated, E2E exit-box de-conflated (oldboy, not 'oldboy or a Hetzner VPS'), decoy hardening note scoped to the primary.
- Also deleted the orphan `TS_CLIENT_ID` secret (unused).

Diagrams trace 1:1 to the tags `buildProfile` emits (couldn't render locally — no headless Chrome — so eyeball the GitHub-rendered mermaid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)