### PR TITLE
feat(tunnel): replace rathole with frp (TCP + UDP everywhere)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Code should be simple, elegant, and concise. Respect the "rule of three" - only 
 
 ## Overview
 
-JARITANET is an infrastructure-as-code monorepo using Pulumi to expose Kubernetes services via a Hetzner VPS gateway. Rathole tunnels TCP from the VPS to an in-cluster Traefik instance that handles TLS termination (Let's Encrypt via DNS-01) and hostname routing. Cloudflare provides DNS only (no proxy/tunnel).
+JARITANET is an infrastructure-as-code monorepo using Pulumi to expose Kubernetes services via a Hetzner VPS gateway. frp (fatedier/frp) tunnels traffic from the VPS to an in-cluster Traefik instance that handles TLS termination (Let's Encrypt via DNS-01) and hostname routing. Cloudflare provides DNS only (no proxy/tunnel).
 
 ## Common Commands
 
@@ -51,9 +51,9 @@ The project uses Lefthook for pre-commit validation:
 
 Everything deploys in one `pulumi up` from `packages/infra/`:
 
-- **`src/modules/gateway.ts`** — Hetzner VPS + firewall + Rathole server provisioning
+- **`src/modules/gateway.ts`** — Hetzner VPS + firewall + frp server (frps) provisioning
 - **`src/modules/xray.ts`** — optional Xray VLESS-REALITY proxy sharing :443 with the gateway
-- **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoute CRDs, IP watcher
+- **`src/modules/ingress.ts`** — Traefik Helm chart, frp client (frpc), IngressRoute CRDs, IP watcher
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
 - **`src/templates/service.ts`** — K8s Deployment/Service/PV/PVC templates
 - **`src/main.ts`** — Orchestrates all modules
@@ -66,14 +66,14 @@ All config uses Zod V4 schemas for runtime validation. Configuration lives in `P
 ### Service Flow
 
 External traffic follows this path:
-`https://hostname` -> Gateway VPS (Rathole) -> K8s cluster (Rathole client) -> Traefik (TLS + routing) -> service
+`https://hostname` -> Gateway VPS (frps) -> K8s cluster (frpc) -> Traefik (TLS + routing) -> service
 
 Without a gateway, Traefik serves directly via hostPort 443 and DNS points at the server's detected external IP.
 
 ### Key Components
 
-- **Rathole** — Rust-based TCP tunnel. Server on VPS, client in K8s. Stateless relay, no TLS/routing knowledge.
-- **Xray (optional)** — When `gateway.xray` is set, Xray-core takes the VPS `:443` (VLESS-Vision-REALITY) and rathole's https bind moves to local `:8443`. Traffic that doesn't match a client is relayed to `dest` (rathole → Traefik); matched clients are proxied out. The keypair is minted on-box and never leaves it; the client `vless://` URL is a stack output (`xrayShareUrl`). `serverName` must be a hostname Traefik serves a real cert for.
+- **frp** — reverse tunnel carrying TCP + UDP. frps on the VPS (dumb: bind port + token), frpc in K8s (declares every proxy). Stateless relay, no TLS/routing knowledge.
+- **Xray (optional)** — When `gateway.xray` is set, Xray-core takes the VPS `:443` (VLESS-Vision-REALITY) and frp's https proxy moves to local `:8443`. Traffic that doesn't match a client is relayed to `dest` (frps → Traefik); matched clients are proxied out. The keypair is minted on-box and never leaves it; the client `vless://` URL is a stack output (`xrayShareUrl`). `serverName` must be a hostname Traefik serves a real cert for.
 - **Traefik** — Ingress controller with built-in ACME. Handles Let's Encrypt certs via DNS-01 challenge against Cloudflare. Always binds hostPort 443 as fallback.
 - **Cloudflare** — DNS only. A records pointing at VPS or server IP, plus Fastmail MX/DKIM and Bluesky ATProto records.
 - **IP watcher** — Pod that checks external IP every 60s via Cloudflare's 1.1.1.1/cdn-cgi/trace and triggers deploy on change.
@@ -163,6 +163,6 @@ Three-stage deployment targeting different host groups:
 - Type checking must pass before commits (Lefthook)
 - oxlint handles linting, oxfmt handles code formatting
 - The system runs on minimal hardware (2014 MacBook Pro)
-- No direct firewall port exposure on home network — Rathole client connects outbound
+- No direct firewall port exposure on home network — frp client (frpc) connects outbound
 - Tailscale provides secure access to internal Kubernetes cluster for CI/CD
 - Secrets managed through GitHub repository secrets and Pulumi configuration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI/CD](https://github.com/radiosilence/jaritanet/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/radiosilence/jaritanet/actions/workflows/ci-cd.yml)
 
-Infrastructure-as-code monorepo for exposing Kubernetes services via Traefik with automatic TLS. Optionally fronted by a Hetzner VPS gateway with Rathole tunnelling.
+Infrastructure-as-code monorepo for exposing Kubernetes services via Traefik with automatic TLS. Optionally fronted by a Hetzner VPS gateway with frp tunnelling.
 
 ## Architecture
 
@@ -44,7 +44,7 @@ graph TB
 
 ### Optional: VPS Gateway
 
-When gateway credentials are configured, a VPS running Rathole acts as a stateless TCP relay. Your home IP disappears from DNS and all traffic routes through the VPS. Traefik keeps hostPort 443 as a fallback regardless — if the relay dies, port-forwarding still works.
+When gateway credentials are configured, a VPS running frp acts as a stateless relay (TCP + UDP). Your home IP disappears from DNS and all traffic routes through the VPS. Traefik keeps hostPort 443 as a fallback regardless — if the relay dies, port-forwarding still works.
 
 Set `HCLOUD_TOKEN` and the deploy provisions a Hetzner VPS gateway; leave it
 unset for direct mode (DNS points at the home IP, Traefik serves on hostPort
@@ -57,7 +57,7 @@ unset for direct mode (DNS points at the home IP, Traefik serves on hostPort
 | Direct | unset | free (home IP) |
 
 ```
-User -> VPS:443 -> Rathole tunnel -> Traefik -> Service
+User -> VPS:443 -> frp tunnel -> Traefik -> Service
 ```
 
 ## How It Works
@@ -72,11 +72,11 @@ User -> VPS:443 -> Rathole tunnel -> Traefik -> Service
 The VPN topology is three config lists in `packages/infra/Pulumi.main.yaml`.
 
 **`gateway`** — the single entry hub (a Hetzner VPS). Runs Xray (VLESS-REALITY,
-`:443/tcp`), Hysteria2 (`:443/udp`), rathole, and the tailnet relay. This is
+`:443/tcp`), Hysteria2 (`:443/udp`), frp, and the tailnet relay. This is
 what clients connect *through*; `entry-select` picks the protocol.
 
 **`exits`** — where the gateway *egresses* your traffic (`exit-select`). An exit
-is just `ss-rust + rathole`, reached over the gateway's rathole tunnel.
+is just `ss-rust + frpc`, reached over the gateway's frp tunnel (TCP + UDP).
 
 ```yaml
 jaritanet:exits:
@@ -100,12 +100,12 @@ jaritanet:exits:
 
 Everything lives in a single Pulumi package at `packages/infra/`:
 
-- **`src/modules/gateway.ts`** — Hetzner VPS gateway: Xray/Hysteria2 entry + rathole + tailnet relay (optional)
+- **`src/modules/gateway.ts`** — Hetzner VPS gateway: Xray/Hysteria2 entry + frp server + tailnet relay (optional)
 - **`src/modules/edge.ts`** — standalone VPN edge boxes in other locations (hy2 + REALITY + tailnet relay); add via `edges` in config. See [`docs/architecture.md`](docs/architecture.md#edge-nodes-multi-location)
-- **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoutes, IP watcher
+- **`src/modules/ingress.ts`** — Traefik Helm chart, frp client (frpc), IngressRoutes, IP watcher
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
 - **`src/modules/singbox.ts`** — builds the sing-box client profile from the nodes and delivers it to the file server over SSH (change-detected, Telegram notify)
-- **`src/modules/exit.ts`** — selectable egress exit node (ss-rust in-cluster), reached via the rathole tunnel, egressing its own IP. Add via `exits` in config
+- **`src/modules/exit.ts`** — selectable egress exit node (ss-rust in-cluster), reached via the frp tunnel, egressing its own IP. Add via `exits` in config
 - **`src/templates/service.ts`** — K8s Deployment/Service/PV/PVC templates
 
 ## Secrets
@@ -168,7 +168,7 @@ Everything lives in a single Pulumi package at `packages/infra/`:
 gh secret set HCLOUD_TOKEN
 ```
 
-Next deploy provisions the VPS, deploys rathole, and flips DNS to the VPS IP. Remove the secret to fall back to direct mode.
+Next deploy provisions the VPS, deploys frp, and flips DNS to the VPS IP. Remove the secret to fall back to direct mode.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,13 +10,13 @@ and secrets see the [README](../README.md).
 ## The whole system, end to end
 
 Every moving part and how a flow travels through it — client selection, the two
-entry transports, the gateway's shared `:443`, the rathole reverse-tunnel, the
+entry transports, the gateway's shared `:443`, the frp reverse-tunnel, the
 in-cluster exit, tailnet relay, and home services.
 
 The gateway is the **hub**. The client picks how it *enters* (`entry-select` —
 a protocol today, a gateway once there's more than one) and where the gateway
 *egresses* it (`exit-select` — direct, or forwarded to an exit box). Everything
-transits the gateway; exits are just `ss-rust + rathole` boxes it forwards to.
+transits the gateway; exits are just `ss-rust + frpc` boxes it forwards to.
 
 ```mermaid
 flowchart LR
@@ -25,12 +25,12 @@ flowchart LR
   subgraph GW["Primary gateway · Hetzner VPS — the entry hub"]
     IN["Xray REALITY (tcp) + Hysteria2 (udp)<br/>shared :443"]
     FR["freedom · direct egress"]
-    RS["rathole server"]
+    RS["frp server (frps)"]
     TSG["tailscale"]
   end
 
   subgraph EX["oldboy · home MicroK8s (behind NAT)"]
-    RC["rathole client"]
+    RC["frp client (frpc)"]
     SS["ss-rust exit"]
     TSH["tailscale"]
     SV["Traefik + home services"]
@@ -42,7 +42,7 @@ flowchart LR
   CLIENT ==>|"entry: hy2 or reality"| IN
   IN -->|"exit = direct"| FR ==> NET
   IN -->|"exit = a named exit → 127.0.0.1:port"| RS
-  RS <==>|"rathole tunnel"| RC --> SS ==> EIP
+  RS <==>|"frp tunnel · tcp+udp"| RC --> SS ==> EIP
   RS -.->|"home services"| RC
   RC -.-> SV
   IN -.->|"tailnet 100.x · any protocol"| TSG <-.-> TSH
@@ -50,12 +50,12 @@ flowchart LR
 
 Reading it: the client always reaches the **gateway** first (via the chosen
 protocol). Then `exit-select` decides what the gateway does — egress directly
-(gateway's own IP), or dial `127.0.0.1:<port>`, which is that exit's rathole
+(gateway's own IP), or dial `127.0.0.1:<port>`, which is that exit's frps
 loopback → the exit's ss-rust → egress at *its* IP (here, the home link).
 Tailnet `100.x` and DNS ride the gateway's tailscale regardless of protocol.
 
 The exit shown is oldboy (which also hosts the reverse-proxied home services),
-but an exit is just `ss-rust + rathole` — a future Hetzner VPS exit is the same
+but an exit is just `ss-rust + frpc` — a future Hetzner VPS exit is the same
 two daemons via cloud-init, minus the services/tailnet-home roles. The sections
 below zoom into each part.
 
@@ -65,8 +65,8 @@ The VPS wears two hats at once:
 
 1. **Reverse proxy** for public home-hosted services (`blit.cc`, Navidrome,
    files). Public visitors hit the VPS; their traffic is tunnelled down to the
-   home cluster over rathole. The home IP never appears in DNS and no home port
-   is ever opened — the rathole client dials *out*.
+   home cluster over frp. The home IP never appears in DNS and no home port
+   is ever opened — the frp client dials *out*.
 2. **Censorship-resistant VPN egress** for the owner's devices. sing-box
    clients connect over Hysteria2 or VLESS-REALITY and egress to the open
    internet directly from the VPS.
@@ -89,12 +89,12 @@ flowchart LR
     subgraph vps["Hetzner VPS gateway"]
         XR["Xray VLESS-REALITY<br/>TCP 443"]
         HY["Hysteria2 + Salamander<br/>UDP 443"]
-        RH["rathole server<br/>ctrl 2333 / http 80 / https 127.0.0.1:8443"]
+        RH["frp server (frps)<br/>ctrl 7000 · proxies: http 80, https 127.0.0.1:8443"]
         FREE["freedom outbound<br/>direct egress"]
     end
 
     subgraph home["oldboy — home, behind NAT"]
-        RHC["rathole client<br/>dials out"]
+        RHC["frp client (frpc)<br/>dials out, declares proxies"]
         TR["Traefik<br/>TLS termination + routing"]
         SVC["Navidrome · Blit · files"]
     end
@@ -114,6 +114,12 @@ flowchart LR
     RH --> RHC --> TR --> SVC
 ```
 
+frps is deliberately dumb — a bind port (7000) and a shared token, nothing else.
+Every proxy (home Traefik's 80/443, each exit's loopback) is declared by the
+*client* (frpc), so the server needs no per-service config and a new exit needs
+no gateway change. frp carries UDP as well as TCP, so exits egress QUIC/HTTP3
+end-to-end rather than falling back to TCP.
+
 ## How `:443` is multiplexed
 
 TCP and UDP `:443` are independent, so Hysteria2 (UDP) and Xray (TCP) never
@@ -128,7 +134,7 @@ flowchart TD
     XR --> MATCH{"valid VLESS<br/>uuid + shortId?"}
     MATCH -->|yes| OUT
     MATCH -->|"no / active probe"| DEST["dest = 127.0.0.1:8443"]
-    DEST --> RH["rathole https"] --> TUN["tunnel to home"] --> TR["Traefik TLS + route"] --> SVC["service"]
+    DEST --> RH["frps https proxy"] --> TUN["tunnel to home"] --> TR["Traefik TLS + route"] --> SVC["service"]
 ```
 
 A censor's active probe lands in the `no` branch: it gets a real TLS session to
@@ -248,7 +254,7 @@ and notifies Telegram. Ansible is not involved; it only provisions the boxes.
 
 Beyond the primary gateway, `edges` in config spins up standalone VPN boxes in
 other locations — each a Hetzner VPS running hy2 + REALITY + a tailnet relay,
-and nothing else (no rathole, no reverse proxy). Adding one is a config change:
+and nothing else (no frp, no reverse proxy). Adding one is a config change:
 
 ```yaml
 jaritanet:edges:
@@ -291,9 +297,10 @@ through (`entry-select`). Egress = where your traffic leaves the internet
 (`exit-select`): either **direct** (at the gateway) or via an **exit node** that
 NATs out its own IP — e.g. the home cluster, egressing the residential IP.
 
-An exit is a substrate-agnostic unit — **rathole client + ss-rust** — as a k8s
-Deployment (`modules/exit.ts`) today, or a cloud-init VPS later. Add one via the
-`exits` config list:
+An exit is a substrate-agnostic unit — **frpc + ss-rust** — as a k8s
+Deployment (`modules/exit.ts`) today, or a cloud-init VPS later. ss runs in
+`tcp_and_udp` mode and frp carries both, so the exit egresses UDP (QUIC/HTTP3)
+as well as TCP. Add one via the `exits` config list:
 
 ```yaml
 jaritanet:exits:
@@ -301,23 +308,23 @@ jaritanet:exits:
     port: 9000
 ```
 
-It's reached through the **existing rathole tunnel**, not the tailnet. Each
+It's reached through the **existing frp tunnel**, not the tailnet. Each
 exit's ss-rust port is surfaced on the **primary gateway's loopback**
-(`127.0.0.1:<port>`) via a rathole service entry — the same pattern as the
-Reality decoy `dest`:
+(`127.0.0.1:<port>`) via a pair of frpc proxies (tcp + udp) — the same pattern
+as the Reality decoy `dest`:
 
 ```mermaid
 flowchart LR
     DEV["device"] -->|"detour: primary (hy2/reality)"| GW["primary gateway"]
-    GW -->|"127.0.0.1:<port> → rathole"| SS["ss-rust exit (k8s)"]
+    GW -->|"127.0.0.1:<port> → frp"| SS["ss-rust exit (k8s)"]
     SS -->|"pod egress, CNI SNAT → node IP"| INET(("Internet"))
 ```
 
 The client's `exit-<name>` outbound is Shadowsocks to `127.0.0.1:<port>`,
 detouring through the **primary** gateway. In a detour chain the inner address
-resolves at the gateway end, so `127.0.0.1:<port>` means "this exit's rathole
+resolves at the gateway end, so `127.0.0.1:<port>` means "this exit's frps
 loopback on the primary." Exits pin to the primary because **it's the only node
-running rathole** — edges (also in `entry-select`) serve hy2/reality only, so
+running frp** — edges (also in `entry-select`) serve hy2/reality only, so
 routing an exit through an edge would dial a dead loopback. `entry-select` still
 governs *direct* egress across all gateways; exits transit the primary.
 
@@ -326,8 +333,8 @@ No kernel IP forwarding anywhere — ss-rust owns both ends of each flow
 remote box. The exit pod egresses normally; microk8s' CNI SNATs to the node IP,
 which is the home link. Topology is a pure function of the config lists,
 expanded at `pulumi up`. (Making exits reachable via *any* gateway — the full
-entry × exit cross-product — needs edges to also run rathole; deferred. When
-multiple rathole gateways exist, `port` must be identical across them.)
+entry × exit cross-product — needs edges to also run frp; deferred. When
+multiple frp gateways exist, `port` must be identical across them.)
 
 ## Hardening notes
 
@@ -346,10 +353,13 @@ Live tradeoffs worth knowing, not necessarily bugs:
 - **hy2 uses `insecure=1` + a self-signed cert.** Fine in practice — Salamander
   wraps the whole handshake so the cert never appears on the wire, and the obfs
   password gates access — but there's no cert pinning.
-- **SSH (22) and rathole control (2333) are open to the world.** Both are
-  authenticated (SSH is key-only ED25519; rathole is 64-char token). Tailnet-
+- **SSH (22) and frp control (7000) are open to the world.** Both are
+  authenticated (SSH is key-only ED25519; frp is a 64-char token). Tailnet-
   gating SSH would shrink the attack surface but adds lockout risk on a box
-  whose whole job is being reachable, so it's left open by choice. 2333 must
-  stay open regardless: the home client dials in from a dynamic NATed IP.
+  whose whole job is being reachable, so it's left open by choice. 7000 must
+  stay open regardless: the home client dials in from a dynamic NATed IP. The
+  proxy remotePorts (8443, exit loopbacks) bind `0.0.0.0` but the firewall
+  admits only 22/80/443/7000 + the hy2 port, so they're reachable only via the
+  gateway's own loopback (Xray/detour), never the public internet.
 - **No hy2 bandwidth hints** in the client, so it runs default congestion
   control rather than Brutal — usually the friendlier choice on variable links.

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -10,7 +10,7 @@ config:
     chartVersion: "41.0.2"
   jaritanet:gateway:
     # xray shares :443; traffic that doesn't match a client falls back to
-    # dest (local rathole https). serverName is injected from BLIT_HOSTNAME
+    # dest (local frps https proxy). serverName is injected from BLIT_HOSTNAME
     # in CI, so it stays out of plain config.
     xray:
       serverName: ''
@@ -21,11 +21,9 @@ config:
     # over the tunnel. Provisioned only when TS_AUTHKEY is set, so this is a
     # no-op until the secret exists.
     tailnet: {}
-  # Egress exit nodes — ss-rust in the home cluster, reached via the rathole
-  # tunnel, egressing the home residential IP. Selectable in the client as
-  # exit-<name>; exits transit the primary gateway.
   # Egress exit nodes — where the gateway forwards your traffic out. Each is
-  # just ss-rust + rathole; the gateway reaches it over the rathole tunnel.
+  # just ss-rust + frpc; the gateway reaches it over the frp tunnel (tcp+udp).
+  # Selectable in the client as exit-<name>; exits transit the primary gateway.
   # `name` is all you set (drives the picker tag exit-<name> + resource names);
   # the loopback port is auto-derived from the name.
   jaritanet:exits:

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -7,11 +7,11 @@ export const CloudflareConfSchema = z.object({
 
 /**
  * Xray-core (VLESS-Vision-REALITY) on the gateway VPS, sharing :443 with
- * rathole. Traffic that doesn't match a client is relayed to `dest`;
+ * frps. Traffic that doesn't match a client is relayed to `dest`;
  * matched clients are proxied out.
  *
  * `serverName` is the SNI clients present and must match the TLS cert served
- * at `dest`. `dest` defaults to the local rathole https port; point it at an
+ * at `dest`. `dest` defaults to the local frps https proxy; point it at an
  * external "host:port" to use a different backend.
  */
 export const XrayConfSchema = z.object({
@@ -47,8 +47,8 @@ export const TailnetConfSchema = z.object({
 export const GatewayConfSchema = z.object({
   hysteria: HysteriaConfSchema.optional(),
   image: z.string().default("ubuntu-24.04"),
+  frpVersion: z.string().default("v0.70.0"),
   location: z.string().default("nbg1"),
-  ratholeVersion: z.string().default("v0.5.0"),
   serverType: z.string().default("cx23"),
   tailnet: TailnetConfSchema.optional(),
   xray: XrayConfSchema.optional(),
@@ -82,21 +82,21 @@ export const EdgeConfSchema = z.object({
 });
 
 /**
- * A selectable egress exit node: rathole client + ss-rust, substrate-agnostic
+ * A selectable egress exit node: frpc + ss-rust, substrate-agnostic
  * (k8s in the home cluster now; a cloud-init VPS later). Traffic egresses via
- * the exit's own IP.
+ * the exit's own IP, and frp carries UDP so the exit isn't TCP-only.
  *
- * Reached through the EXISTING rathole tunnel, not the tailnet: the exit's
- * ss-rust port is surfaced on the rathole gateway's loopback (`127.0.0.1:<port>`)
- * via a rathole service entry, exactly like the Reality decoy `dest`. The
- * client's ss outbound dials `127.0.0.1:<port>` through that gateway (detour),
- * and because a detour resolves the inner address at the gateway end, it hits
- * the gateway's rathole loopback for this exit.
+ * Reached through the EXISTING frp tunnel, not the tailnet: the exit's
+ * ss-rust port is surfaced on the frps gateway's loopback (`127.0.0.1:<port>`)
+ * via a frpc proxy, exactly like the Reality decoy `dest`. The client's ss
+ * outbound dials `127.0.0.1:<port>` through that gateway (detour), and because
+ * a detour resolves the inner address at the gateway end, it hits the
+ * gateway's frps loopback for this exit.
  *
  * Exits route via the **primary** gateway specifically — it's the only node
- * that runs rathole (edges run hy2/reality only). So the exit detour is pinned
+ * that runs frp (edges run hy2/reality only). So the exit detour is pinned
  * to the primary, independent of which entry `entry-select` picks for direct
- * traffic. When more rathole-running gateways exist, `port` must be identical
+ * traffic. When more frp-running gateways exist, `port` must be identical
  * across them so one exit outbound works via any of them.
  *
  * `name` is the only field you normally set — it drives the picker tag

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -29,7 +29,10 @@ const dnsModules = {
 export default async function () {
   const { namespace } = conf;
   let dnsTarget: pulumi.Output<string> | undefined;
-  let ratholeToken: pulumi.Output<string> | undefined;
+  let frpToken: pulumi.Output<string> | undefined;
+  // Where the gateway surfaces Traefik's 443: behind Xray it's a loopback decoy
+  // backend (8443), else the public 443. Unused without a gateway.
+  let httpsRemotePort = 443;
   let gatewayProvider: string | undefined;
   let xray: ReturnType<typeof createGateway>["xray"];
   let hysteria: ReturnType<typeof createGateway>["hysteria"];
@@ -39,7 +42,7 @@ export default async function () {
   const nodes: SingboxNode[] = [];
 
   // Resolve each exit's loopback port once (derived from the name unless set),
-  // so the identical port is used at the gateway bind, ss server, rathole
+  // so the identical port is used at the gateway loopback, ss server, frp
   // client, and client outbound. Assert uniqueness — a clash means the user
   // should set an explicit `port` on one of the exits.
   const resolvedExits = conf.exits.map((e) => ({
@@ -56,10 +59,11 @@ export default async function () {
 
   if (env.HCLOUD_TOKEN) {
     const gatewayConf = conf.gateway ?? GatewayConfSchema.parse({});
-    // Exits surface on the gateway's rathole loopback (name + port).
-    const gw = createGateway(gatewayConf, resolvedExits);
+    // frps is dumb (bind port + token only); every proxy is client-declared.
+    const gw = createGateway(gatewayConf);
     dnsTarget = gw.vpsIp;
-    ratholeToken = gw.ratholeToken.result;
+    frpToken = gw.frpToken.result;
+    httpsRemotePort = gatewayConf.xray ? 8443 : 443;
     gatewayProvider = "hetzner";
     xray = gw.xray;
     hysteria = gw.hysteria;
@@ -167,17 +171,18 @@ export default async function () {
     { provider },
   );
 
-  // Egress exit nodes: ss-rust in-cluster. The rathole client (in createIngress)
+  // Egress exit nodes: ss-rust in-cluster. The frp client (in createIngress)
   // punches each one's port out to the gateway loopback.
   const exits = resolvedExits.map((e) => createExit(provider, namespace, e));
 
-  // --- Ingress: Traefik always on hostPort 443 + rathole client if gateway exists ---
+  // --- Ingress: Traefik always on hostPort 443 + frp client if gateway exists ---
   createIngress(
     provider,
     namespace,
     conf.traefik,
     dnsTarget,
-    ratholeToken,
+    frpToken,
+    httpsRemotePort,
     env.CLOUDFLARE_API_TOKEN,
     resolvedExits,
   );

--- a/packages/infra/src/modules/edge.ts
+++ b/packages/infra/src/modules/edge.ts
@@ -11,7 +11,7 @@ import { createXray } from "./xray.ts";
 
 /**
  * Provisions a standalone VPN edge box: a Hetzner VPS running hy2 + REALITY +
- * a tailnet relay, and nothing else — no rathole, no reverse proxy, no TLS
+ * a tailnet relay, and nothing else — no frp, no reverse proxy, no TLS
  * services of its own.
  *
  * Because it fronts no home site, REALITY points its decoy at a real external

--- a/packages/infra/src/modules/exit.ts
+++ b/packages/infra/src/modules/exit.ts
@@ -24,14 +24,14 @@ export function deriveExitPort(name: string): number {
 
 /**
  * A k8s egress exit: ss-rust in the home cluster. Traffic reaches it through
- * the rathole tunnel (a rathole client entry punches its port out to the
- * gateways — see ingress + gateway), and it NATs out via the pod's normal
- * egress — which the CNI SNATs to the node IP, i.e. the home link. No
- * `hostNetwork`, no kernel forwarding: ss-rust owns both ends of each flow.
+ * the frp tunnel (a frpc proxy punches its port out to the gateway — see
+ * ingress + gateway), and it NATs out via the pod's normal egress — which the
+ * CNI SNATs to the node IP, i.e. the home link. No `hostNetwork`, no kernel
+ * forwarding: ss-rust owns both ends of each flow.
  *
  * The ss password is a single Pulumi secret consumed here (server Secret) and
  * by the client outbound (see singbox) — one source, no drift. Returns the
- * exit's coordinates for the rathole entries and the client profile.
+ * exit's coordinates for the frp proxies and the client profile.
  */
 export function createExit(
   provider: k8s.Provider,
@@ -50,9 +50,9 @@ export function createExit(
       server_port: exit.port,
       method: exit.method,
       password: pw,
-      // TCP only: the rathole tunnel that reaches this server is TCP, so UDP
-      // associations can't traverse the exit path (UDP goes direct instead).
-      mode: "tcp_only",
+      // frp carries UDP as well as TCP, so ss UDP associations traverse the
+      // exit path — QUIC/HTTP3 and the like egress at the exit, not direct.
+      mode: "tcp_and_udp",
     }),
   );
   const configHash = config.apply((c) =>
@@ -114,7 +114,10 @@ export function createExit(
       metadata: { name, namespace },
       spec: {
         selector: { app: name },
-        ports: [{ name: "ss-tcp", port: exit.port, protocol: "TCP" }],
+        ports: [
+          { name: "ss-tcp", port: exit.port, protocol: "TCP" },
+          { name: "ss-udp", port: exit.port, protocol: "UDP" },
+        ],
       },
     },
     { provider },

--- a/packages/infra/src/modules/gateway.ts
+++ b/packages/infra/src/modules/gateway.ts
@@ -11,18 +11,19 @@ import { createTailscale } from "./tailscale.ts";
 import { createXray } from "./xray.ts";
 
 /**
- * Provisions a Hetzner VPS running rathole as a TCP relay.
- * The VPS is completely stateless — no certs, no proxy config.
- * It just tunnels ports 80/443 from the public internet to
- * the rathole client running inside the K8s cluster.
+ * Provisions a Hetzner VPS running frp (fatedier/frp) as the relay server.
+ *
+ * frps is deliberately dumb — just a bind port + auth token. Every proxy (home
+ * Traefik, the exit loopbacks) is declared by the *clients* (frpc), so the
+ * server needs no per-service config and a new exit needs no gateway change.
+ * frp carries UDP as well as TCP, so exits are no longer TCP-only.
+ *
+ * frps is installed over SSH (not cloud-init) so it can land on the *existing*
+ * box; `userData` is ignored to keep a config change from replacing the VPS
+ * (which would lose the on-box REALITY keys and rotate the IP).
  */
-export function createGateway(
-  gateway: z.infer<typeof GatewayConfSchema>,
-  exits: { name: string; port: number }[] = [],
-) {
-  const ratholeToken = new random.RandomPassword("rathole-token", {
-    length: 64,
-  });
+export function createGateway(gateway: z.infer<typeof GatewayConfSchema>) {
+  const frpToken = new random.RandomPassword("frp-token", { length: 64 });
 
   const sshKey = new tls.PrivateKey("gateway-ssh-key", {
     algorithm: "ED25519",
@@ -56,9 +57,9 @@ export function createGateway(
         sourceIps: ["0.0.0.0/0", "::/0"],
       },
       {
-        description: "Rathole control channel",
+        description: "frp control channel",
         direction: "in",
-        port: "2333",
+        port: "7000",
         protocol: "tcp",
         sourceIps: ["0.0.0.0/0", "::/0"],
       },
@@ -76,47 +77,27 @@ export function createGateway(
     ],
   });
 
-  const serverConfig = pulumi.interpolate`#!/bin/bash
+  // Base image only — frp is installed over SSH below, so a change here never
+  // needs to rebuild the box (see ignoreChanges).
+  const serverConfig = `#!/bin/bash
 set -euo pipefail
-
-# Install rathole
-curl -fsSL "https://github.com/rapiz1/rathole/releases/download/${gateway.ratholeVersion}/rathole-x86_64-unknown-linux-gnu.zip" -o /tmp/rathole.zip
-apt-get update && apt-get install -y unzip
-unzip /tmp/rathole.zip -d /usr/local/bin/
-chmod +x /usr/local/bin/rathole
-rm /tmp/rathole.zip
-
-# Write config (token will be updated via remote command)
-mkdir -p /etc/rathole
-
-# Systemd unit
-cat > /etc/systemd/system/rathole.service << 'UNIT'
-[Unit]
-Description=Rathole Server
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-ExecStart=/usr/local/bin/rathole --server /etc/rathole/server.toml
-Restart=always
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-systemctl daemon-reload
-systemctl enable rathole
+apt-get update -y || true
 `;
 
-  const server = new hcloud.Server("gateway", {
-    firewallIds: [firewall.id.apply((id) => Number(id))],
-    image: gateway.image,
-    location: gateway.location,
-    serverType: gateway.serverType,
-    sshKeys: [hcloudSshKey.id.apply((id) => id.toString())],
-    userData: serverConfig,
-  });
+  const server = new hcloud.Server(
+    "gateway",
+    {
+      firewallIds: [firewall.id.apply((id) => Number(id))],
+      image: gateway.image,
+      location: gateway.location,
+      serverType: gateway.serverType,
+      sshKeys: [hcloudSshKey.id.apply((id) => id.toString())],
+      userData: serverConfig,
+    },
+    // userData only runs at first boot; keep changes to it from replacing the
+    // live VPS (which holds the on-box REALITY private key).
+    { ignoreChanges: ["userData"] },
+  );
 
   const connection = {
     host: server.ipv4Address,
@@ -125,9 +106,7 @@ systemctl enable rathole
   };
 
   // Enable BBR congestion control + fq qdisc. Default (cubic) collapses
-  // throughput on packet loss; BBR holds the pipe open across lossy links,
-  // which is what the relayed traffic rides over. Applied over SSH so the
-  // server is never rebuilt.
+  // throughput on packet loss; BBR holds the pipe open across lossy links.
   new command.remote.Command(
     "gateway-network-tuning",
     {
@@ -142,54 +121,60 @@ sysctl --system`,
     { dependsOn: [server] },
   );
 
-  // When Xray is enabled it owns the public :443 and uses rathole as its
-  // decoy backend, so rathole's https bind moves to a local-only port.
-  const httpsBind = gateway.xray ? "127.0.0.1:8443" : "0.0.0.0:443";
-
-  // Each exit's ss-rust port, surfaced on this gateway's loopback via rathole —
-  // same pattern as the Reality decoy dest. The port is stable + identical
-  // across gateways, so one client ss outbound reaches this exit via any entry.
-  const exitServices = exits
-    .map(
-      (e) =>
-        `\n[server.services.exit-${e.name}]\ntype = "tcp"\nbind_addr = "127.0.0.1:${e.port}"\n`,
-    )
-    .join("");
-
-  // Write rathole config via SSH (supports updates without replacing the server)
-  const ratholeConfig = pulumi.interpolate`[server]
-bind_addr = "0.0.0.0:2333"
-default_token = "${ratholeToken.result}"
-
-[server.services.https]
-type = "tcp"
-bind_addr = "${httpsBind}"
-
-[server.services.http]
-type = "tcp"
-bind_addr = "0.0.0.0:80"
-${exitServices}`;
-
-  const configUpload = new command.remote.Command(
-    "rathole-config",
+  // Install frps over SSH (idempotent) so it lands on the existing box, and
+  // retire the old rathole unit. Keyed on the version.
+  const frpVer = gateway.frpVersion.replace(/^v/, "");
+  const install = new command.remote.Command(
+    "frp-install",
     {
       connection,
-      create: pulumi.interpolate`cat > /etc/rathole/server.toml << 'RATHOLE_EOF'
-${ratholeConfig}
-RATHOLE_EOF`,
-      triggers: [ratholeToken.result, httpsBind, exitServices],
+      create: pulumi.interpolate`set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+FRP_VER="${frpVer}"
+if ! /usr/local/bin/frps --version 2>/dev/null | grep -q "$FRP_VER"; then
+  curl -fsSL "https://github.com/fatedier/frp/releases/download/v$FRP_VER/frp_${"$"}{FRP_VER}_linux_amd64.tar.gz" -o /tmp/frp.tgz
+  tar -xzf /tmp/frp.tgz -C /tmp
+  install -m 0755 "/tmp/frp_${"$"}{FRP_VER}_linux_amd64/frps" /usr/local/bin/frps
+  rm -rf /tmp/frp.tgz "/tmp/frp_${"$"}{FRP_VER}_linux_amd64"
+fi
+mkdir -p /etc/frp
+cat > /etc/systemd/system/frps.service << 'UNIT'
+[Unit]
+Description=frp server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/frps -c /etc/frp/frps.toml
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable frps
+# retire rathole (migrated to frp)
+systemctl disable --now rathole 2>/dev/null || true`,
+      triggers: [frpVer],
     },
     { dependsOn: [server] },
   );
 
-  new command.remote.Command(
-    "rathole-restart",
+  // frps config: just bind port + token. All proxies are client-declared.
+  const configUpload = new command.remote.Command(
+    "frp-config",
     {
       connection,
-      create: "systemctl restart rathole",
-      triggers: [configUpload.id],
+      create: pulumi.interpolate`cat > /etc/frp/frps.toml << 'FRP_EOF'
+bindPort = 7000
+auth.method = "token"
+auth.token = "${frpToken.result}"
+FRP_EOF
+systemctl restart frps`,
+      triggers: [frpToken.result],
     },
-    { dependsOn: [configUpload] },
+    { dependsOn: [install] },
   );
 
   const xray = gateway.xray
@@ -213,8 +198,9 @@ RATHOLE_EOF`,
       : undefined;
 
   return {
+    configUpload,
+    frpToken,
     hysteria,
-    ratholeToken,
     server,
     sshKey,
     tailscale,

--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -7,17 +7,21 @@ import type { TraefikConfSchema } from "../conf.schemas.ts";
 /**
  * Deploys the ingress stack into the K8s cluster:
  * - Traefik as the ingress controller with built-in ACME (Let's Encrypt via DNS-01)
- * - Rathole client connecting back to the Hetzner gateway VPS
+ * - frp client (frpc) connecting back to the Hetzner gateway VPS
  *
- * Traefik handles TLS termination and hostname routing. Rathole tunnels
+ * Traefik handles TLS termination and hostname routing. frpc tunnels
  * ports 80+443 from the VPS to Traefik's service. No certs on the VPS.
+ *
+ * `httpsRemotePort` is where the gateway surfaces Traefik's 443: 8443 when Xray
+ * owns the public :443 and uses frp as its decoy backend, else 443 directly.
  */
 export function createIngress(
   provider: k8s.Provider,
   namespace: string,
   traefik: z.infer<typeof TraefikConfSchema>,
   vpsIp: pulumi.Output<string> | undefined,
-  ratholeToken: pulumi.Output<string> | undefined,
+  frpToken: pulumi.Output<string> | undefined,
+  httpsRemotePort: number,
   cloudflareApiToken: string,
   exits: { name: string; port: number }[] = [],
 ) {
@@ -97,75 +101,94 @@ export function createIngress(
     { provider },
   );
 
-  // Rathole client — only deployed when a gateway VPS exists.
+  // frp client — only deployed when a gateway VPS exists.
   // Without it, traffic reaches Traefik directly (e.g. via port forwarding).
-  if (vpsIp && ratholeToken) {
+  if (vpsIp && frpToken) {
     // Use the Helm release's generated service name and service ports (not container ports)
     const traefikSvc = pulumi.interpolate`${traefikRelease.name}.${namespace}.svc.cluster.local`;
 
-    // Punch each k8s exit's ss-rust port out to the gateway (matched by name to
-    // the gateway's [server.services.exit-*] loopback bind). Same rathole tunnel
-    // that already carries Traefik — an exit is just another service on it.
-    const exitClientEntries = exits
-      .map(
-        (e) =>
-          `\n[client.services.exit-${e.name}]\ntype = "tcp"\nlocal_addr = "exit-${e.name}.${namespace}.svc.cluster.local:${e.port}"\n`,
-      )
+    // Punch each k8s exit's ss-rust port out to the gateway loopback (frps binds
+    // remotePort; xray/detour reaches it at 127.0.0.1:<port>). Both tcp and udp
+    // so the exit carries QUIC/HTTP3 — the whole point of frp over rathole.
+    const exitProxies = exits
+      .map((e) => {
+        const addr = `exit-${e.name}.${namespace}.svc.cluster.local`;
+        return ["tcp", "udp"]
+          .map(
+            (proto) => `
+[[proxies]]
+name = "exit-${e.name}-${proto}"
+type = "${proto}"
+localIP = "${addr}"
+localPort = ${e.port}
+remotePort = ${e.port}
+`,
+          )
+          .join("");
+      })
       .join("");
 
-    const ratholeConfig = pulumi.interpolate`[client]
-remote_addr = "${vpsIp}:2333"
-default_token = "${ratholeToken}"
+    const frpcConfig = pulumi.interpolate`serverAddr = "${vpsIp}"
+serverPort = 7000
+auth.method = "token"
+auth.token = "${frpToken}"
 
-[client.services.https]
+[[proxies]]
+name = "https"
 type = "tcp"
-local_addr = "${traefikSvc}:443"
+localIP = "${traefikSvc}"
+localPort = 443
+remotePort = ${httpsRemotePort}
 
-[client.services.http]
+[[proxies]]
+name = "http"
 type = "tcp"
-local_addr = "${traefikSvc}:80"
-${exitClientEntries}`;
+localIP = "${traefikSvc}"
+localPort = 80
+remotePort = 80
+${exitProxies}`;
 
-    const ratholeConfigHash = ratholeConfig.apply((c) =>
+    const frpcConfigHash = frpcConfig.apply((c) =>
       crypto.createHash("sha256").update(c).digest("hex"),
     );
 
-    const ratholeConfigMap = new k8s.core.v1.ConfigMap(
-      "rathole-client-config",
+    const frpcConfigMap = new k8s.core.v1.ConfigMap(
+      "frpc-config",
       {
-        metadata: { name: "rathole-client" },
+        metadata: { name: "frpc" },
         data: {
-          "client.toml": ratholeConfig,
+          "frpc.toml": frpcConfig,
         },
       },
       { provider },
     );
 
     new k8s.apps.v1.Deployment(
-      "rathole-client",
+      "frpc",
       {
         metadata: {
-          labels: { app: "rathole-client" },
+          labels: { app: "frpc" },
         },
         spec: {
           replicas: 1,
           selector: {
-            matchLabels: { app: "rathole-client" },
+            matchLabels: { app: "frpc" },
           },
           template: {
             metadata: {
               // Roll the client when the config changes (new/removed exit) —
-              // mounted ConfigMaps don't restart rathole on their own.
-              annotations: { "jaritanet/config-hash": ratholeConfigHash },
-              labels: { app: "rathole-client" },
+              // mounted ConfigMaps don't restart frpc on their own.
+              annotations: { "jaritanet/config-hash": frpcConfigHash },
+              labels: { app: "frpc" },
             },
             spec: {
               containers: [
                 {
-                  args: ["--client", "/etc/rathole/client.toml"],
-                  command: ["/app/rathole"],
-                  image: "rapiz1/rathole:latest",
-                  name: "rathole",
+                  // Official upstream image (ENTRYPOINT frpc, no default CMD).
+                  // Keep the tag in lockstep with gateway `frpVersion`.
+                  args: ["-c", "/etc/frp/frpc.toml"],
+                  image: "fatedier/frpc:v0.70.0",
+                  name: "frpc",
                   resources: {
                     limits: {
                       cpu: "100m",
@@ -174,7 +197,7 @@ ${exitClientEntries}`;
                   },
                   volumeMounts: [
                     {
-                      mountPath: "/etc/rathole",
+                      mountPath: "/etc/frp",
                       name: "config",
                     },
                   ],
@@ -183,7 +206,7 @@ ${exitClientEntries}`;
               volumes: [
                 {
                   configMap: {
-                    name: ratholeConfigMap.metadata.name,
+                    name: frpcConfigMap.metadata.name,
                   },
                   name: "config",
                 },

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -110,8 +110,8 @@ const selector = (tag: string, outbounds: string[], def: string) => ({
  *     `entry-select` so they egress at the gateway, never via an exit.
  *
  * Each exit outbound targets `127.0.0.1:<port>` and detours through the
- * **primary** gateway (the only rathole node) — the inner address resolves at
- * the primary end, hitting that exit's rathole loopback. Exits therefore always
+ * **primary** gateway (the only frp node) — the inner address resolves at
+ * the primary end, hitting that exit's frps loopback. Exits therefore always
  * transit the primary, regardless of the `entry-select` pick for direct egress.
  */
 export function buildProfile(
@@ -161,13 +161,13 @@ export function buildProfile(
   // straight at entry-select (direct egress, no extra groups).
   if (exits.length) {
     // Exits pin to the PRIMARY gateway (nodes[0]) — the only node running
-    // rathole, so the only one exposing the exit loopbacks. Edges (also in
+    // frp, so the only one exposing the exit loopbacks. Edges (also in
     // entry-select) run hy2/reality only; detouring an exit through an edge
     // would dial 127.0.0.1:<port> where nothing listens.
-    const ratholeEntry = nodes.length === 1 ? "auto" : `auto-${nodes[0].name}`;
+    const frpEntry = nodes.length === 1 ? "auto" : `auto-${nodes[0].name}`;
 
     // Each exit: a Shadowsocks outbound dialled through the primary. The
-    // 127.0.0.1:<port> resolves at the primary → its rathole loopback → the
+    // 127.0.0.1:<port> resolves at the primary → its frps loopback → the
     // exit's ss-rust → egress at the exit's own IP.
     for (const e of exits) {
       outbounds.push({
@@ -177,7 +177,7 @@ export function buildProfile(
         server_port: e.port,
         method: e.method,
         password: e.password,
-        detour: ratholeEntry,
+        detour: frpEntry,
       });
     }
 

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -15,7 +15,7 @@ type Connection = {
  * Provisions Xray-core (VLESS-Vision-REALITY) on the gateway VPS.
  *
  * Xray takes :443; traffic that doesn't match a client is relayed to `dest`
- * (the local rathole https port → in-cluster Traefik), matched clients are
+ * (the local frps https proxy → in-cluster Traefik), matched clients are
  * proxied out. Keys are minted on first boot and never leave the box: the
  * x25519 private key stays in /usr/local/etc/xray and the UUID + shortId
  * are Pulumi secrets. Returns a vless:// share URL for client import.

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -112,12 +112,12 @@
               "default": "ubuntu-24.04",
               "type": "string"
             },
-            "location": {
-              "default": "nbg1",
+            "frpVersion": {
+              "default": "v0.70.0",
               "type": "string"
             },
-            "ratholeVersion": {
-              "default": "v0.5.0",
+            "location": {
+              "default": "nbg1",
               "type": "string"
             },
             "serverType": {


### PR DESCRIPTION
Swaps rathole → frp (fatedier/frp) for **every** tunnel: the gateway relay, the k8s reverse tunnel, and the exit hops.

## Why
rathole is TCP-only. Egress via an exit node therefore dropped UDP — QUIC/HTTP3 fell back to TCP, a degraded experience vs direct egress. frp carries TCP **and** UDP, so exits stop being second-class. Bonus: one tunnel tool everywhere instead of reasoning about rathole's limits per-path.

## What it does
- **frps is dumb** — bind port `7000` + auth token, no per-service config. Every proxy is declared **client-side** by frpc. Consequence: `createGateway` no longer takes an exit list, and adding an exit needs **no gateway change** (its frpc declares its own `remotePort`).
- **https bind moves server→client** — `httpsRemotePort` is `8443` when Xray owns `:443` (frp = its decoy backend) else `443`. Computed in `main.ts`, passed to `createIngress`.
- **Exits gain UDP** — ss-rust flips `tcp_only` → `tcp_and_udp`, each exit gets a **tcp+udp proxy pair**, and the exit Service exposes both. QUIC/HTTP3 egresses at the exit end-to-end.
- Firewall `2333` → `7000`. `ratholeVersion` → `frpVersion` (`v0.70.0`). k8s client image `rapiz1/rathole` → `the official fatedier/frpc:v0.70.0`.

## Load-bearing decision: no VPS replacement
frps installs over **SSH** (`command.remote`, idempotent) rather than cloud-init, and the server's `userData` is `ignoreChanges`'d. A tunnel swap must **not** replace the live VPS — that would rotate the public IP and destroy the on-box REALITY private key (breaking every client profile). The install also `systemctl disable --now rathole`.

## How to verify
1. **`pulumi preview` first** — confirm the `gateway` hcloud.Server shows **no replacement** (only the new `frp-install`/`frp-config` commands + the frpc Deployment replacing the rathole one). This is the one thing to eyeball before deploying.
2. Deploy. Home services (`blit.cc`, Navidrome, files) still served → reverse tunnel works.
3. Pick `exit-oldboy`, `curl ifconfig.me` → home IP (TCP path).
4. Hit a QUIC/HTTP3 site through the exit → UDP now traverses (was impossible on rathole).

## Runtime-untested (hence draft)
Config correctness (frps.toml/frpc.toml schema, the snowdreamtech entrypoint reading `/etc/frp/frpc.toml`) and the UDP-over-frp exit path can't be checked without a deploy. Shell escaping in the frps installer was rendered + `bash -n`'d. Typecheck/lint/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)