### PR TITLE
ci: pulumi preview on infra PRs (posted as PR comment)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,116 @@
+name: Preview
+
+# Runs `pulumi preview` on infra PRs and posts the diff as a PR comment, so
+# changes can be reviewed against the live stack's state before merge — most
+# importantly whether a resource *replaces* (e.g. the gateway VPS) versus
+# updates in place. Read-only: preview never mutates the stack.
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/preview.yml
+      - "packages/**"
+      - "*.config.*"
+      - package.json
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Pulumi Preview
+    runs-on: ubuntu-24.04
+    env:
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Environment
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+
+      - name: Install Dependencies
+        uses: endevco/aube-action@f82ca2f6c943dbde1904945d9f0ee1a0faf8e945 # v1.0.0
+        with:
+          node-version: auto
+          run-install: true
+          install-args: --frozen-lockfile
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Detect Server External IP
+        if: env.HCLOUD_TOKEN == ''
+        env:
+          KUBE_HOST: ${{ secrets.KUBE_HOST }}
+          KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+        run: |
+          DECODED_TOKEN=$(printf '%s' "$KUBE_TOKEN" | base64 -d)
+          EXTERNAL_IP=$(kubectl \
+            --server="https://$KUBE_HOST:$KUBE_API_PORT" \
+            --token="$DECODED_TOKEN" \
+            --insecure-skip-tls-verify \
+            run detect-ip --rm -i --restart=Never --quiet \
+            --image=curlimages/curl -- -4 -s https://1.1.1.1/cdn-cgi/trace 2>/dev/null | grep '^ip=' | cut -d= -f2 | tr -d '[:space:]')
+          echo "EXTERNAL_IP=$EXTERNAL_IP" >> "$GITHUB_ENV"
+          echo "Detected server external IP: $EXTERNAL_IP"
+
+      # pulumi config lives in the (ephemeral) checked-out Pulumi.main.yaml, not
+      # the shared stack, so these injections don't leak between PRs.
+      - name: Configure Stack
+        run: |
+          pulumi stack select radiosilence/jaritanet/main
+          pulumi config set --path jaritanet:cloudflare.accountId "$CLOUDFLARE_ACCOUNT_ID"
+          pulumi config set --path jaritanet:traefik.acmeEmail "$ACME_EMAIL"
+          pulumi config set --path jaritanet:services.navidrome.hostname "$NAVIDROME_HOSTNAME"
+          pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
+          pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
+          pulumi config set --path jaritanet:gateway.xray.serverName "$BLIT_HOSTNAME"
+          if [[ -n "$EXTERNAL_IP" ]]; then
+            pulumi config set jaritanet:externalIp "$EXTERNAL_IP"
+          fi
+        working-directory: packages/infra
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
+          NAVIDROME_HOSTNAME: ${{ secrets.NAVIDROME_HOSTNAME }}
+          FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
+          BLIT_HOSTNAME: ${{ secrets.BLIT_HOSTNAME }}
+
+      - name: Preview
+        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
+        with:
+          command: preview
+          stack-name: radiosilence/jaritanet/main
+          work-dir: packages/infra
+          comment-on-pr: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          refresh: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          KUBE_HOST: ${{ secrets.KUBE_HOST }}
+          KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          OLDBOY_HOST: ${{ secrets.OLDBOY_HOST }}
+          OLDBOY_USER: ${{ secrets.OLDBOY_USER }}
+          SINGBOX_SLUG: ${{ secrets.SINGBOX_SLUG }}
+          FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
+          TAILNET_MAGICDNS_SUFFIX: ${{ secrets.TAILNET_MAGICDNS_SUFFIX }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
Adds a `pulumi preview` on every infra PR, posted as a PR comment.

## Why
No way to see a plan before merge without running Pulumi locally (creds + Tailscale + stack access). This surfaces the diff against the **live main stack's state** — most importantly whether a resource **replaces** (e.g. the gateway VPS) vs updates in place.

## How
Mirrors the `deploy` job's setup — mise (→ `pulumi`), Tailscale for k8s API reach, the same config injection — but runs `preview` instead of `up` and comments the result.

- **Read-only.** Pulumi never executes `command.*`/create steps during preview, so no SSH writes to `.sfm` and no Telegram notifications fire.
- **No cross-PR leakage.** `pulumi config set` writes the checked-out (ephemeral) `Pulumi.main.yaml`, not the shared stack.
- Path-filtered to infra (`packages/**`, config, this workflow) — a docs-only PR gets no pointless empty preview.

## Verify
This PR touches `.github/workflows/preview.yml`, so the workflow runs on itself — expect a comment showing **no infra changes** (it only adds a workflow file). That's the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)