### PR TITLE
feat(tune): UDP exits, MTU-for-the-chain, hy2 Brutal, home-box BBR

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -18,5 +18,23 @@
       - ffmpeg
     state: present
 
+- name: Enable BBR congestion control + fq qdisc
+  # Matches the gateway VPS. Default cubic collapses on loss; BBR holds the pipe
+  # open — helps the rathole client→gateway leg and the exit's own egress.
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/99-network-tuning.conf
+    content: |
+      net.core.default_qdisc = fq
+      net.ipv4.tcp_congestion_control = bbr
+    owner: root
+    group: root
+    mode: "0644"
+  register: bbr_sysctl
+
+- name: Apply sysctl settings
+  ansible.builtin.command: sysctl --system
+  when: bbr_sysctl.changed
+  changed_when: true
+
 - name: Include SSH hardening tasks
   ansible.builtin.include_tasks: ssh_hardening.yml

--- a/packages/infra/src/modules/exit.ts
+++ b/packages/infra/src/modules/exit.ts
@@ -50,9 +50,9 @@ export function createExit(
       server_port: exit.port,
       method: exit.method,
       password: pw,
-      // TCP only: the rathole tunnel that reaches this server is TCP, so UDP
-      // associations can't traverse the exit path (UDP goes direct instead).
-      mode: "tcp_only",
+      // TCP + UDP: rathole forwards both (a udp service per exit), so ss UDP
+      // associations traverse the exit — QUIC/HTTP3 egress at the exit, not direct.
+      mode: "tcp_and_udp",
     }),
   );
   const configHash = config.apply((c) =>
@@ -114,7 +114,10 @@ export function createExit(
       metadata: { name, namespace },
       spec: {
         selector: { app: name },
-        ports: [{ name: "ss-tcp", port: exit.port, protocol: "TCP" }],
+        ports: [
+          { name: "ss-tcp", port: exit.port, protocol: "TCP" },
+          { name: "ss-udp", port: exit.port, protocol: "UDP" },
+        ],
       },
     },
     { provider },

--- a/packages/infra/src/modules/gateway.ts
+++ b/packages/infra/src/modules/gateway.ts
@@ -149,10 +149,14 @@ sysctl --system`,
   // Each exit's ss-rust port, surfaced on this gateway's loopback via rathole —
   // same pattern as the Reality decoy dest. The port is stable + identical
   // across gateways, so one client ss outbound reaches this exit via any entry.
+  // A tcp *and* udp service on the same port so ss carries UDP (rathole muxes
+  // udp datagrams over the control channel — no extra public port).
   const exitServices = exits
-    .map(
-      (e) =>
-        `\n[server.services.exit-${e.name}]\ntype = "tcp"\nbind_addr = "127.0.0.1:${e.port}"\n`,
+    .flatMap((e) =>
+      ["tcp", "udp"].map(
+        (proto) =>
+          `\n[server.services.exit-${e.name}-${proto}]\ntype = "${proto}"\nbind_addr = "127.0.0.1:${e.port}"\n`,
+      ),
     )
     .join("");
 

--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -107,10 +107,13 @@ export function createIngress(
     // the gateway's [server.services.exit-*] loopback bind). Same rathole tunnel
     // that already carries Traefik — an exit is just another service on it.
     const exitClientEntries = exits
-      .map(
-        (e) =>
-          `\n[client.services.exit-${e.name}]\ntype = "tcp"\nlocal_addr = "exit-${e.name}.${namespace}.svc.cluster.local:${e.port}"\n`,
-      )
+      .flatMap((e) => {
+        const addr = `exit-${e.name}.${namespace}.svc.cluster.local:${e.port}`;
+        return ["tcp", "udp"].map(
+          (proto) =>
+            `\n[client.services.exit-${e.name}-${proto}]\ntype = "${proto}"\nlocal_addr = "${addr}"\n`,
+        );
+      })
       .join("");
 
     const ratholeConfig = pulumi.interpolate`[client]

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -53,11 +53,33 @@ type ResolvedExit = {
   password: string;
 };
 
+// hy2's "fun/fast" personality: setting bandwidth switches Hysteria2 from BBR
+// to the Brutal congestion control, which paces to a fixed rate and ignores
+// loss — it stomps through lossy/censored links where BBR backs off. Set to the
+// gigabit line; Brutal will use up to this and no more. The only footgun is a
+// client network genuinely slower than this (blasting a slow link wastes it on
+// loss), but on real broadband it's the fastest option we've got. Tune down if
+// you're routinely on a capped link.
+// (Reality has no such knob — it stays adaptive TCP; its speed comes from MTU.)
+const HY2_UP_MBPS = 1000;
+const HY2_DOWN_MBPS = 1000;
+
+// Innermost tun MTU for the whole chain. Sized so a packet survives the worst
+// entry path — hy2 (QUIC/UDP) over a reduced-MTU hostile/mobile net (~1400):
+// IPv4 20 + UDP 8 + QUIC/AEAD/Salamander ~70 of overhead, so inner ≤ ~1330.
+// 1280 (the IPv6 floor, and QUIC's no-fragment floor) sits safely under that
+// and never fragments on a roaming link; Reality's TCP MSS clamps to 1240.
+// Fragmentation stalls cost far more throughput than 1280's slightly smaller
+// packets, so on unknown networks this maximises *real* throughput + latency.
+const TUN_MTU = 1280;
+
 const hy2 = (n: ResolvedNode) => ({
   type: "hysteria2",
   tag: `hy2-${n.name}`,
   server: n.server,
   server_port: n.hysteria.port,
+  up_mbps: HY2_UP_MBPS,
+  down_mbps: HY2_DOWN_MBPS,
   password: n.hysteria.authPassword,
   obfs: { type: "salamander", password: n.hysteria.obfsPassword },
   tls: { enabled: true, server_name: n.hysteria.sni, insecure: true },
@@ -218,7 +240,7 @@ export function buildProfile(
         type: "tun",
         tag: "tun-in",
         address: ["172.19.0.1/30", "fdfe:dcba:9876::1/126"],
-        mtu: 1400,
+        mtu: TUN_MTU,
         auto_route: true,
         strict_route: true,
         stack: "system",


### PR DESCRIPTION
Whole-chain tuning for throughput + latency, on rathole (which forwards UDP — the frp detour was never needed).

## Levers (each with the reasoning)
- **Exits carry UDP.** ss → `tcp_and_udp`, and each exit gets a **tcp+udp rathole service pair** (muxed over the control channel — no new public port). QUIC/HTTP3 now egresses *at the exit* instead of dropping to direct. This is the thing the whole frp saga was chasing; rathole did it all along.
- **MTU sized for the chain: tun `1400 → 1280`.** Worst entry path is hy2 (QUIC/UDP) over a reduced-MTU hostile/mobile net; ~70 B of outer overhead (IP+UDP+QUIC+AEAD+Salamander) means the inner packet must stay under ~1330 to avoid fragmenting. **1280** is the IPv6 + QUIC no-fragment floor — never fragments while roaming — and Reality's TCP MSS clamps to 1240. On unknown links, dodging fragmentation stalls beats bigger packets for *real* throughput. (This is why "Reality is fast due to good MTU" — no TCP-in-TCP fragment meltdown.)
- **hy2 Brutal (1G/1G).** Bandwidth hints switch Hysteria2 from BBR to Brutal — paces to a fixed rate, ignores loss, stomps through lossy/censored links. hy2 = the fast/fun path; Reality stays adaptive + safe. Tune the constants down if you're routinely on a capped link (Brutal floods a link slower than its setting).
- **BBR + fq on the home box** (`ansible/common`), matching the gateway. Helps the rathole client→gateway leg *and* the exit's residential egress. Deploys via the ansible workflow.

## What's deliberately NOT touched
- The `hcloud.Server` — no property changes, so **no box replacement** (the preview should confirm; REALITY keys + IP stay put).
- rathole `nodelay` — left default `true`. It's latency-friendly and, since Nagle doesn't engage on bulk writes, costs ~nothing on throughput.

## Verify
- Preview: expect exit `Service`/`Secret`/`Deployment` updates, the rathole config command re-running (new udp services), the frpc→rathole resources already reverted — **`Server` unchanged**.
- Post-deploy: `stunclient stun.l.google.com 19302` under exit-oldboy → home IP (UDP through the exit). Speed-test hy2 vs reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)