### PR TITLE
feat(dns): gateway DoT cache, persistent client cache, Brutal opt-in

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,7 @@ flowchart TD
     DNSQ -->|yes| HIJACK["hijack-dns"]
     HIJACK --> RES{"*.ts.net?"}
     RES -->|yes| TSDNS["ts-dns → 100.100.100.100<br/>(detour entry-select)"]
-    RES -->|no| DOH["cf-doh → 1.1.1.1"]
+    RES -->|no| GW["gw-cache → gateway unbound<br/>(127.0.0.1:53, detour entry-select)"]
     DNSQ -->|no| TN{"100.x tailnet?"}
     TN -->|yes| ENTRY["entry-select<br/>gateway → tailscale relay"]
     TN -->|no| EXIT["exit-select"]
@@ -194,8 +194,26 @@ gateway, never via an exit), and everything else → `final: exit-select`.
 `hijack-dns` (after `sniff`) is load-bearing: without it, sing-box flings
 port-53 queries out the tunnel as raw packets to a dead internal resolver;
 nothing resolves and the client looks offline. With it, `*.ts.net` resolves via
-`ts-dns` (the gateway's tailnet resolver) and everything else via DoH to
-1.1.1.1 — both tunnelled.
+`ts-dns` (the gateway's tailnet resolver) and everything else via `gw-cache`.
+
+**DNS is built for latency, not just leak-safety.** Every resolver is pinned to
+`entry-select`, so DNS egresses at the gateway and never inherits an exit hop —
+even when `exit-select` points at an exit box. `gw-cache` is a plain-UDP server
+at `127.0.0.1:53`; the client dials that loopback *at the gateway end* through
+the tunnel, hitting an unbound caching forwarder on the gateway with prefetch +
+serve-expired. So a client-cache miss is answered from a Germany-local, already-
+warm cache in one tunnel RTT rather than a round trip to the upstream from
+wherever the client happens to be. On top of that, sing-box's `cache_file`
+persists the DNS cache across restarts, so a cold app launch resolves recently-
+seen names from disk (~0ms).
+
+**No cleartext DNS anywhere in the chain.** The client↔gateway leg is plain UDP
+but rides the encrypted tunnel (DoH's per-query TLS/HTTP2 framing would be
+redundant there), and unbound forwards upstream to Cloudflare over DoT (:853), so
+the gateway's own egress is encrypted too — Hetzner never sees a domain in the
+clear. `cf-doh` (DoH → 1.1.1.1) stays in the profile as the manual-revert
+resolver: sing-box does not auto-fail between DNS servers, so if the gateway
+cache is ever down, flip `final` to it (also leak-safe, just no local cache).
 
 ## Tailnet over the tunnel (censorship-resistant `100.x`)
 
@@ -351,5 +369,10 @@ Live tradeoffs worth knowing, not necessarily bugs:
   gating SSH would shrink the attack surface but adds lockout risk on a box
   whose whole job is being reachable, so it's left open by choice. 2333 must
   stay open regardless: the home client dials in from a dynamic NATed IP.
-- **No hy2 bandwidth hints** in the client, so it runs default congestion
-  control rather than Brutal — usually the friendlier choice on variable links.
+- **hy2 defaults to adaptive congestion control (BBR), with Brutal opt-in.**
+  The daily-driver `hy2-*` outbound (and the `auto` urltest) carry no bandwidth
+  hints, so they stay adaptive and friendly on variable/metered links. A
+  separate `hy2b-*` variant carries 1G/1G hints → Brutal (fixed-rate, ignores
+  loss) and sits in the selector for manual use on a known-fat hostile pipe.
+  Brutal is deliberately *not* the default: on a slow link it blasts loss into a
+  small pipe and feels worse. Reality has no such knob — its speed is all MTU.

--- a/packages/infra/src/modules/gateway.ts
+++ b/packages/infra/src/modules/gateway.ts
@@ -142,6 +142,54 @@ sysctl --system`,
     { dependsOn: [server] },
   );
 
+  // Caching DNS forwarder on loopback. Clients dial 127.0.0.1:53 *at this box*
+  // through the tunnel (a DNS server with detour=entry-select), so unbound has
+  // zero public attack surface — reachable only from inside the tunnel. It
+  // forwards upstream to Cloudflare over DoT (:853), so there is no cleartext
+  // DNS anywhere in the chain: client→gateway is the encrypted tunnel, and
+  // gateway→resolver is TLS. Prefetch + serve-expired keep the hot set warm, so
+  // a client-cache miss is answered from this Germany-local cache in one tunnel
+  // RTT instead of a round trip to the upstream from the client's location.
+  new command.remote.Command(
+    "gateway-unbound",
+    {
+      connection,
+      create: `set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update && apt-get install -y unbound ca-certificates
+cat > /etc/unbound/unbound.conf.d/jaritanet.conf << 'EOF'
+server:
+  interface: 127.0.0.1
+  port: 53
+  do-ip6: no
+  access-control: 127.0.0.0/8 allow
+  prefetch: yes
+  prefetch-key: yes
+  serve-expired: yes
+  serve-expired-ttl: 86400
+  cache-min-ttl: 120
+  cache-max-ttl: 86400
+  msg-cache-size: 64m
+  rrset-cache-size: 128m
+  num-threads: 2
+  so-reuseport: yes
+  qname-minimisation: yes
+  hide-identity: yes
+  hide-version: yes
+  tls-cert-bundle: "/etc/ssl/certs/ca-certificates.crt"
+forward-zone:
+  name: "."
+  forward-tls-upstream: yes
+  forward-addr: 1.1.1.1@853#cloudflare-dns.com
+  forward-addr: 1.0.0.1@853#cloudflare-dns.com
+EOF
+systemctl enable unbound
+systemctl restart unbound`,
+      triggers: ["unbound-v2"],
+    },
+    { dependsOn: [server] },
+  );
+
   // When Xray is enabled it owns the public :443 and uses rathole as its
   // decoy backend, so rathole's https bind moves to a local-only port.
   const httpsBind = gateway.xray ? "127.0.0.1:8443" : "0.0.0.0:443";

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -53,13 +53,14 @@ type ResolvedExit = {
   password: string;
 };
 
-// hy2's "fun/fast" personality: setting bandwidth switches Hysteria2 from BBR
-// to the Brutal congestion control, which paces to a fixed rate and ignores
-// loss — it stomps through lossy/censored links where BBR backs off. Set to the
-// gigabit line; Brutal will use up to this and no more. The only footgun is a
-// client network genuinely slower than this (blasting a slow link wastes it on
-// loss), but on real broadband it's the fastest option we've got. Tune down if
-// you're routinely on a capped link.
+// Brutal is opt-in, not the default. Setting bandwidth switches Hysteria2 from
+// adaptive BBR to the Brutal congestion control, which paces to a fixed rate and
+// ignores loss — it stomps through lossy/censored *fat* links where BBR backs
+// off, but on a genuinely slow or metered link (mid-tier LTE, hotel wifi) it
+// blasts loss into a small pipe and feels *worse*. So the daily driver (`hy2-*`,
+// and `auto`) stays adaptive and safe on every link; a separate `hy2b-*` variant
+// carries these bandwidth hints and lives in the selector for manual use when
+// you know you're on a fat hostile pipe. Tune to your actual line.
 // (Reality has no such knob — it stays adaptive TCP; its speed comes from MTU.)
 const HY2_UP_MBPS = 1000;
 const HY2_DOWN_MBPS = 1000;
@@ -78,11 +79,16 @@ const hy2 = (n: ResolvedNode) => ({
   tag: `hy2-${n.name}`,
   server: n.server,
   server_port: n.hysteria.port,
-  up_mbps: HY2_UP_MBPS,
-  down_mbps: HY2_DOWN_MBPS,
   password: n.hysteria.authPassword,
   obfs: { type: "salamander", password: n.hysteria.obfsPassword },
   tls: { enabled: true, server_name: n.hysteria.sni, insecure: true },
+});
+// Same endpoint, but with bandwidth hints → Brutal. Manual-pick only.
+const hy2Brutal = (n: ResolvedNode) => ({
+  ...hy2(n),
+  tag: `hy2b-${n.name}`,
+  up_mbps: HY2_UP_MBPS,
+  down_mbps: HY2_DOWN_MBPS,
 });
 const reality = (n: ResolvedNode) => ({
   type: "vless",
@@ -107,7 +113,7 @@ const urltest = (tag: string, outbounds: string[]) => ({
   tag,
   outbounds,
   url: "https://www.gstatic.com/generate_204",
-  interval: "3m",
+  interval: "1m",
   tolerance: 100,
 });
 const selector = (tag: string, outbounds: string[], def: string) => ({
@@ -143,13 +149,17 @@ export function buildProfile(
 ) {
   const outbounds: Record<string, unknown>[] = [];
   for (const n of nodes) {
-    outbounds.push(hy2(n), reality(n));
+    outbounds.push(hy2(n), reality(n), hy2Brutal(n));
   }
   if (nodes.length === 1) {
     const t = nodes[0].name;
     outbounds.push(urltest("auto", [`hy2-${t}`, `reality-${t}`]));
     outbounds.push(
-      selector("entry-select", ["auto", `hy2-${t}`, `reality-${t}`], "auto"),
+      selector(
+        "entry-select",
+        ["auto", `hy2-${t}`, `hy2b-${t}`, `reality-${t}`],
+        "auto",
+      ),
     );
   } else {
     for (const n of nodes) {
@@ -159,7 +169,12 @@ export function buildProfile(
       outbounds.push(
         selector(
           n.name,
-          [`auto-${n.name}`, `hy2-${n.name}`, `reality-${n.name}`],
+          [
+            `auto-${n.name}`,
+            `hy2-${n.name}`,
+            `hy2b-${n.name}`,
+            `reality-${n.name}`,
+          ],
           `auto-${n.name}`,
         ),
       );
@@ -221,9 +236,36 @@ export function buildProfile(
 
   return {
     log: { level: "info", timestamp: true },
+    experimental: {
+      // Persist the DNS cache across restarts: a cold app start resolves
+      // recently-seen names from disk (~0ms) instead of paying a tunnel round
+      // trip. This is what makes "1ms DNS" real for the common (warm) case.
+      cache_file: { enabled: true, store_rdrc: true },
+    },
     dns: {
+      // Every resolver is pinned to entry-select (detour) so DNS egresses at the
+      // gateway and NEVER inherits an exit hop, even when exit-select points at
+      // an exit. default_domain_resolver (route) is set to match.
       servers: [
-        { type: "https", tag: "cf-doh", server: "1.1.1.1" },
+        // Primary: the gateway's own unbound cache, reached by dialing
+        // 127.0.0.1:53 *at the gateway end* through the tunnel. Prefetch +
+        // serve-expired keep the hot set warm, so even a client-cache miss is
+        // answered from a Germany-local cache in one tunnel RTT — not a fresh
+        // recursion from the client's location.
+        {
+          type: "udp",
+          tag: "gw-cache",
+          server: "127.0.0.1",
+          detour: "entry-select",
+        },
+        // Manual-revert fallback: flip `final` to this if the gateway cache is
+        // ever unreachable (sing-box does not auto-failover between servers).
+        {
+          type: "https",
+          tag: "cf-doh",
+          server: "1.1.1.1",
+          detour: "entry-select",
+        },
         {
           type: "udp",
           tag: "ts-dns",
@@ -232,7 +274,7 @@ export function buildProfile(
         },
       ],
       rules: [{ domain_suffix: [magicdnsSuffix], server: "ts-dns" }],
-      final: "cf-doh",
+      final: "gw-cache",
       strategy: "ipv4_only",
     },
     inbounds: [
@@ -248,7 +290,7 @@ export function buildProfile(
     ],
     outbounds,
     route: {
-      default_domain_resolver: "cf-doh",
+      default_domain_resolver: "gw-cache",
       rules: [
         { action: "sniff" },
         { protocol: "dns", action: "hijack-dns" },


### PR DESCRIPTION
Whole-chain VPN tuning for fast DNS, low latency, speed, and reliability — leak-safety preserved.

## What it does
- **DNS 1ms push:** gateway `unbound` caching forwarder (loopback-only) over **DoT** to Cloudflare; client dials `127.0.0.1:53` at the gateway end through the tunnel. Prefetch + serve-expired keep a Germany-local cache warm; `cache_file` persists the client cache (~0ms warm hits).
- **Pinned DNS:** every resolver on `entry-select` — DNS never inherits an exit hop.
- **Leak-safe end to end:** client→gw is the encrypted tunnel, gw→CF is DoT. No cleartext DNS anywhere. `cf-doh` stays as the manual-revert `final` (sing-box has no auto-failover between DNS servers).
- **Brutal opt-in:** hy2 defaults to adaptive BBR; 1G/1G Brutal hints move to a manual `hy2b-*` selector entry (Brutal wrecks slow/metered links).
- urltest 3m→1m; MTU stays 1280.

## Verify
- `dig`/browse after deploy: names resolve, warm lookups ~instant.
- **First-deploy check:** `final: gw-cache` means DNS is dead if unbound fails to start on the first `pulumi up` — confirm `systemctl status unbound` on the box, or flip `final` to `cf-doh` to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)