### PR TITLE
fix(dns): store_rdrc -> store_dns (sing-box 1.14 deprecation)

### DIFF
--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -240,7 +240,7 @@ export function buildProfile(
       // Persist the DNS cache across restarts: a cold app start resolves
       // recently-seen names from disk (~0ms) instead of paying a tunnel round
       // trip. This is what makes "1ms DNS" real for the common (warm) case.
-      cache_file: { enabled: true, store_rdrc: true },
+      cache_file: { enabled: true, store_dns: true },
     },
     dns: {
       // Every resolver is pinned to entry-select (detour) so DNS egresses at the


### PR DESCRIPTION
sing-box 1.14 deprecates `cache_file.store_rdrc`. Replaced with `store_dns`, which persists the full DNS cache (not just rejected responses) — strictly better for the warm-hit latency goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)