### PR TITLE
fix(dns): revert to store_rdrc — store_dns needs sing-box 1.14

### DIFF
--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -240,7 +240,11 @@ export function buildProfile(
       // Persist the DNS cache across restarts: a cold app start resolves
       // recently-seen names from disk (~0ms) instead of paying a tunnel round
       // trip. This is what makes "1ms DNS" real for the common (warm) case.
-      cache_file: { enabled: true, store_dns: true },
+      // NB: store_rdrc, not store_dns. store_dns is a 1.14+ field and hard-fails
+      // ("unknown field") on the current 1.13.x SFM/SFI core; store_rdrc works
+      // and only earns a cosmetic deprecation warning on 1.14. Flip to store_dns
+      // once every client is on a 1.14+ core.
+      cache_file: { enabled: true, store_rdrc: true },
     },
     dns: {
       // Every resolver is pinned to entry-select (detour) so DNS egresses at the


### PR DESCRIPTION
`store_dns` is a sing-box 1.14+ field and hard-fails with `unknown field "store_dns"` on the 1.13.x core that stable SFM/brew ship. `store_rdrc` loads on 1.13 and is still accepted on 1.14 (cosmetic deprecation warning), so it's the lowest-common-denominator that keeps every client's profile loading.

Flip back to `store_dns` once all clients are on a 1.14+ core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)