### PR TITLE
fix(common): manage base Ubuntu apt repos

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,3 +1,36 @@
+# The installer left the base repos as a bare `noble` pocket (release snapshot),
+# so no security/update fixes were ever seen — dist-upgrade ran against a frozen
+# April-2024 tree. Manage the base sources here so it can't drift again.
+- name: Configure Ubuntu base apt repositories
+  ansible.builtin.deb822_repository:
+    name: ubuntu
+    types: [deb]
+    uris: http://archive.ubuntu.com/ubuntu
+    suites:
+      - "{{ ansible_distribution_release }}"
+      - "{{ ansible_distribution_release }}-updates"
+      - "{{ ansible_distribution_release }}-backports"
+    components: [main, restricted, universe, multiverse]
+    signed_by: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+    state: present
+    enabled: true
+
+- name: Configure Ubuntu security apt repository
+  ansible.builtin.deb822_repository:
+    name: ubuntu-security
+    types: [deb]
+    uris: http://security.ubuntu.com/ubuntu
+    suites: ["{{ ansible_distribution_release }}-security"]
+    components: [main, restricted, universe, multiverse]
+    signed_by: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+    state: present
+    enabled: true
+
+- name: Remove stale single-file apt sources.list
+  ansible.builtin.file:
+    path: /etc/apt/sources.list
+    state: absent
+
 - name: Update all packages to the latest version (dist-upgrade)
   ansible.builtin.apt:
     upgrade: dist


### PR DESCRIPTION
## What

Manages the base Ubuntu apt sources (`archive` main/updates/backports + `security`) via `deb822_repository` in the `common` role, and removes the stale single-file `/etc/apt/sources.list`.

## Why

The installer left oldboy's base sources as a bare `noble` pocket — the frozen release snapshot, no `noble-updates`/`noble-security`. So `dist-upgrade` reported 0 upgrades every run while the box sat ~2 years behind on security fixes, kernel stuck at `6.8.0-31` (Apr 2024). Ansible managed every PPA but not the base repos, so nothing caught it.

## Verify

After merge, `run-playbook` runs the `common` role. On oldboy:
- `apt update` should now `Hit` `noble-updates` and `noble-security`
- `apt-cache policy linux-generic` candidate advances past `6.8.0-31.31`
- the `dist-upgrade` task pulls the full backlog

## ⚠️ Reboot is manual and out of scope

Merging installs the new kernel but does **not** reboot — the role has no reboot handler by design (auto-rebooting a remote tailscale exit node = bricking a box you can't reach). Reboot only with console access confirmed.