### PR TITLE
fix(singbox): move tun off 172.19 — collided with a work AWS VPC

### DIFF
--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -288,7 +288,15 @@ export function buildProfile(
       {
         type: "tun",
         tag: "tun-in",
-        address: ["172.19.0.1/30", "fdfe:dcba:9876::1/126"],
+        // Point-to-point tun endpoints. Deliberately NOT in 172.16/12 — that
+        // whole range is a collision minefield: Docker bridges live at 172.17/18
+        // and, worse, corporate AWS VPCs sit in 172.x. We were on 172.19.0.1/30,
+        // which overlaps a work VPC (172.19.0.0/16) whose DNS resolver is at
+        // VPC_base+2 = 172.19.0.2 — *exactly* our tun peer, so the tun silently
+        // hijacked the VPC resolver whenever both VPNs were up. 198.18.0.0/15 is
+        // IANA benchmarking space (RFC 2544): never a real destination, so it
+        // can't collide with any VPC, Docker bridge, corp VPN, or home LAN.
+        address: ["198.18.0.1/30", "fdfe:dcba:9876::1/126"],
         mtu: TUN_MTU,
         auto_route: true,
         strict_route: true,


### PR DESCRIPTION
The sing-box tun was on `172.19.0.1/30`, inside `172.19.0.0/16` — a corporate AWS VPC's CIDR. An AWS VPC's DNS resolver sits at `CIDR_base+2` = `172.19.0.2`, which was *exactly* our tun peer address. So with both VPNs up, our tun silently swallowed the VPC's resolver. The whole `172.16/12` range is a minefield anyway (Docker bridges at 172.17/18).

Moved to `198.18.0.0/15` (IANA benchmarking, RFC 2544) — never a real destination, so it can't collide with any VPC, Docker bridge, corp VPN, or home LAN.

## Verify
After deploy + profile Update: reconnect, `ifconfig` shows the tun at `198.18.0.1`, and `netstat -rn | grep 172.19` no longer shows our tun stealing `172.19.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)