### PR TITLE
fix(singbox): gVisor tun stack to enable includeAllNetworks kill-switch

### DIFF
--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -300,7 +300,14 @@ export function buildProfile(
         mtu: TUN_MTU,
         auto_route: true,
         strict_route: true,
-        stack: "system",
+        // gVisor, not the kernel `system` stack. It's mandatory for Apple's
+        // `includeAllNetworks` (full-tunnel kill-switch) — sing-tun refuses to
+        // start with system/mixed under it. That lockdown is the whole point:
+        // every socket forced through the tunnel, nothing able to bypass, and it
+        // guarantees a nested AWS VPN egresses through us (its endpoint can't
+        // bind the physical NIC). Cost: a userspace stack is a bit more CPU /
+        // slightly lower peak throughput than the kernel path — worth it here.
+        stack: "gvisor",
       },
     ],
     outbounds,


### PR DESCRIPTION
Apple's `includeAllNetworks` (full-tunnel lockdown — every socket forced through the tunnel, nothing able to bypass) forces the gVisor TUN stack. sing-tun refuses to start with the kernel `system`/`mixed` stack under it ([sing-tun#25](https://github.com/SagerNet/sing-tun/issues/25)).

Switching to gvisor unblocks the lockdown, which is *also* the deterministic guarantee that a nested AWS Client VPN egresses through us — with every socket forced through the tunnel, the AWS client can't bind the physical NIC to reach its endpoint directly.

Cost: userspace stack, marginally more CPU / lower peak throughput than the kernel path. Worth it for the lockdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)