### PR TITLE
docs(singbox): explain why the tun stack must be mixed/gvisor (nesting)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -376,3 +376,15 @@ Live tradeoffs worth knowing, not necessarily bugs:
   loss) and sits in the selector for manual use on a known-fat hostile pipe.
   Brutal is deliberately *not* the default: on a slow link it blasts loss into a
   small pipe and feels worse. Reality has no such knob — its speed is all MTU.
+- **The tun stack is `mixed` (kernel TCP + gVisor UDP), and that's load-bearing
+  for nesting another VPN inside this one.** A common use is nesting a UDP-based
+  corporate VPN (e.g. AWS Client VPN, OpenVPN/UDP) inside the tunnel to shield
+  its first hop from local DPI: the nested VPN's *endpoint* has no specific route
+  so it falls to sing-box's default and egresses at the gateway (DPI sees only
+  hy2/reality), while the routes the nested VPN pushes (its VPC CIDR) are more
+  specific and send that traffic down its own tun. The catch: the kernel
+  `system` stack silently drops the *nested UDP* even when routing is provably
+  correct — only gVisor's UDP stack reassembles it and does endpoint-independent
+  NAT. So `mixed`/`gvisor`, never `system`, if nesting is in play. Operational
+  gotcha: reconnecting/updating sing-box tears down anything nested on top of it,
+  so the order is always **sing-box first, then (re)dial the inner VPN**.

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -300,7 +300,16 @@ export function buildProfile(
         mtu: TUN_MTU,
         auto_route: true,
         strict_route: true,
-        // gVisor for UDP, kernel for TCP
+        // `mixed` = kernel TCP stack (fast) + gVisor's userspace UDP stack. The
+        // gVisor UDP path is LOAD-BEARING, not a perf knob: this client nests a
+        // UDP-based corporate VPN (AWS Client VPN = OpenVPN/UDP) inside our
+        // tunnel. The kernel `system` stack silently DROPS that nested UDP even
+        // with perfect routing (endpoint→sing-box, VPC→AWS tun, all verified) —
+        // gVisor reassembles it + does endpoint-independent NAT. Proven the hard
+        // way: `system` broke the nested DB path with correct routing; switching
+        // to gvisor/mixed fixed it instantly. DO NOT "optimise" back to `system`.
+        // `mixed` keeps kernel TCP for everything else; pure `gvisor` also works
+        // but costs more CPU.
         stack: "mixed",
       },
     ],


### PR DESCRIPTION
Hardens the terse `try mixed` commit so the reasoning survives — this is the exact gap that caused a gvisor→system revert earlier and an hour of debugging.

**Why `mixed` (kernel TCP + gVisor UDP) is load-bearing, not a perf tweak:** the client nests a UDP-based corporate VPN (AWS Client VPN, OpenVPN/UDP) inside the tunnel to DPI-shield its first hop. The kernel `system` stack silently drops that nested UDP *even with provably correct routing* — only gVisor's UDP stack reassembles it and does endpoint-independent NAT. `mixed` keeps kernel TCP for everything else.

Comment + `architecture.md` only. The rendered client profile is byte-identical, so the deploy is a no-op for connected clients (no re-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)