### PR TITLE
docs: accuracy pass after the VPN/DNS/stack churn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Code should be simple, elegant, and concise. Respect the "rule of three" - only 
 
 JARITANET is an infrastructure-as-code monorepo using Pulumi to expose Kubernetes services via a Hetzner VPS gateway. Rathole tunnels TCP from the VPS to an in-cluster Traefik instance that handles TLS termination (Let's Encrypt via DNS-01) and hostname routing. Cloudflare provides DNS only (no proxy/tunnel).
 
+The same gateway also fronts a censorship-resistant VPN/proxy layer: Xray VLESS-REALITY and Hysteria2 share the VPS `:443`, optional edge boxes add entry points in other locations, and selectable exit nodes control egress IP. The sing-box client profile is generated and distributed by the same Pulumi run.
+
 ## Common Commands
 
 ### Development
@@ -51,11 +53,16 @@ The project uses Lefthook for pre-commit validation:
 
 Everything deploys in one `pulumi up` from `packages/infra/`:
 
-- **`src/modules/gateway.ts`** — Hetzner VPS + firewall + Rathole server provisioning
-- **`src/modules/xray.ts`** — optional Xray VLESS-REALITY proxy sharing :443 with the gateway
+- **`src/modules/gateway.ts`** — Hetzner VPS + firewall + Rathole server; hosts the entry transports and the gateway `unbound` DNS cache
+- **`src/modules/hysteria.ts`** — Hysteria2 (QUIC/UDP) transport with Salamander obfuscation, on the gateway + edges
+- **`src/modules/xray.ts`** — optional Xray VLESS-REALITY (TCP), sharing :443 with rathole on the gateway
 - **`src/modules/ingress.ts`** — Traefik Helm chart, Rathole client, IngressRoute CRDs, IP watcher
+- **`src/modules/edge.ts`** — standalone VPN edge boxes (hy2 + REALITY + tailnet relay, no rathole/proxy)
+- **`src/modules/exit.ts`** — in-cluster ss-rust egress nodes, reached through the rathole tunnel (deterministic loopback ports)
+- **`src/modules/tailscale.ts`** — joins the gateway/edges to the tailnet as a relay (`--accept-routes=false` is load-bearing)
+- **`src/modules/singbox.ts`** — builds the sing-box client profile from all nodes and delivers it to the file server (SSH, content-hashed, Telegram notify)
 - **`src/modules/dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
-- **`src/templates/service.ts`** — K8s Deployment/Service/PV/PVC templates
+- **`src/templates/service.ts`** — K8s Deployment/Service/PV/PVC templates (schemas + tests alongside)
 - **`src/main.ts`** — Orchestrates all modules
 - **`src/conf.ts`** / **`src/conf.schemas.ts`** — Unified Zod config schema
 
@@ -73,7 +80,9 @@ Without a gateway, Traefik serves directly via hostPort 443 and DNS points at th
 ### Key Components
 
 - **Rathole** — Rust-based TCP tunnel. Server on VPS, client in K8s. Stateless relay, no TLS/routing knowledge.
+- **Hysteria2** — QUIC/UDP `:443` transport with Salamander obfuscation; the fast, loss-tolerant daily-driver entry, on the gateway and every edge. Auth + obfs passwords are minted on-box; per-node `hysteria2://` share URL.
 - **Xray (optional)** — When `gateway.xray` is set, Xray-core takes the VPS `:443` (VLESS-Vision-REALITY) and rathole's https bind moves to local `:8443`. Traffic that doesn't match a client is relayed to `dest` (rathole → Traefik); matched clients are proxied out. The keypair is minted on-box and never leaves it; the client `vless://` URL is a stack output (`xrayShareUrl`). `serverName` must be a hostname Traefik serves a real cert for.
+- **sing-box delivery** — `singbox.ts` aggregates the primary + every edge into one client profile (`buildProfile`), writes it to the file server over SSH (content-hashed, so unchanged deploys are silent), and notifies Telegram with the URL/QR on change.
 - **Traefik** — Ingress controller with built-in ACME. Handles Let's Encrypt certs via DNS-01 challenge against Cloudflare. Always binds hostPort 443 as fallback.
 - **Cloudflare** — DNS only. A records pointing at VPS or server IP, plus Fastmail MX/DKIM and Bluesky ATProto records.
 - **IP watcher** — Pod that checks external IP every 60s via Cloudflare's 1.1.1.1/cdn-cgi/trace and triggers deploy on change.
@@ -83,10 +92,14 @@ Without a gateway, Traefik serves directly via hostPort 443 and DNS points at th
 
 ### CI/CD (`ci-cd.yml`)
 
-Triggered on pushes to main branch affecting package files, or manually via workflow_dispatch:
+Triggered on pushes and pull requests affecting package files, manually via `workflow_dispatch`, or as a reusable workflow (`workflow_call`, with the Pulumi/Cloudflare/Hetzner secrets):
 
 1. **Test** - Type checks, lints, runs vitest suite
 2. **Deploy** (main branch only) - Single `pulumi up` deploying everything
+
+### Preview (`preview.yml`)
+
+Runs `pulumi preview` on infra PRs and posts the diff as a PR comment — read-only, surfaces resource **replacements** (e.g. the gateway VPS) before merge.
 
 ### Schema Generation (`generate-schemas.yml`)
 
@@ -94,7 +107,7 @@ Generates JSON schemas from Zod definitions on changes or daily schedule. Commit
 
 ### App Version Updates (`update-apps.yml`)
 
-Daily check for new releases of deployed services (currently Navidrome). Uses a GitHub App token so version bump commits trigger the CI/CD pipeline.
+Daily check for new releases of deployed services (Navidrome Docker image + Traefik Helm chart). Uses a GitHub App token so version bump commits trigger the CI/CD pipeline.
 
 ### Ansible Deployment (`run-playbook.yml`)
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Infrastructure-as-code monorepo for exposing Kubernetes services via Traefik wit
 
 ## Architecture
 
-A single Pulumi stack deploys everything: Traefik handles TLS termination (Let's Encrypt via DNS-01) and hostname routing inside the K8s cluster. An IP watcher pod monitors the server's external IP and triggers DNS updates when it changes — DIY dynamic DNS powered by Cloudflare.
+A single Pulumi stack deploys everything: Traefik handles TLS termination (Let's Encrypt via DNS-01) and hostname routing inside the K8s cluster. An optional IP-watcher pod tracks the server's external IP and dispatches a deploy to refresh Cloudflare A records when it changes.
 
-The gateway also doubles as a censorship-resistant VPN (Hysteria2 + VLESS-REALITY, sharing :443 with the reverse proxy). See [`docs/architecture.md`](docs/architecture.md) for the full topology, transport choices, and the port-multiplexing trick.
+The gateway also doubles as a censorship-resistant VPN (Hysteria2 + VLESS-REALITY), sharing `:443` with rathole — which relays any non-VPN traffic on to the in-cluster Traefik. See [`docs/architecture.md`](docs/architecture.md) for the full topology, transport choices, and the port-multiplexing trick.
 
 ```mermaid
 graph TB
@@ -64,7 +64,7 @@ User -> VPS:443 -> Rathole tunnel -> Traefik -> Service
 
 1. **Traefik** terminates TLS using Let's Encrypt certs (DNS-01 via Cloudflare API) and routes by hostname.
 2. **Cloudflare DNS** A records point service hostnames at the server's external IP.
-3. **IP watcher** (direct mode only) — a pod checks the external IP every 60s via Cloudflare's `1.1.1.1/cdn-cgi/trace` and, on change, dispatches a deploy to refresh the A records. With a gateway, DNS points at the VPS's static IP, so the watcher is a dormant fallback (gated behind `DEPLOY_TOKEN`).
+3. **IP watcher** — an optional pod (enabled by `DEPLOY_TOKEN`) checks the external IP every 60s via Cloudflare's `1.1.1.1/cdn-cgi/trace` and, on change, dispatches a deploy to refresh the A records. Most useful in direct mode; with a gateway, DNS points at the VPS's static IP so it's a dormant fallback.
 4. **Deploys** trigger on push to `main` (package changes) or manual `workflow_dispatch` — there is no scheduled/cron reconcile.
 
 ## Topology configuration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -203,9 +203,11 @@ at `127.0.0.1:53`; the client dials that loopback *at the gateway end* through
 the tunnel, hitting an unbound caching forwarder on the gateway with prefetch +
 serve-expired. So a client-cache miss is answered from a Germany-local, already-
 warm cache in one tunnel RTT rather than a round trip to the upstream from
-wherever the client happens to be. On top of that, sing-box's `cache_file`
-persists the DNS cache across restarts, so a cold app launch resolves recently-
-seen names from disk (~0ms).
+wherever the client happens to be. On top of that the client caches
+aggressively: `dns.optimistic` serves an expired entry instantly and refreshes
+it in the background (no lookup ever blocks on a stale hit), and `cache_file`
+(`store_dns`) persists that cache across restarts — so a cold app launch
+resolves recently-seen names from disk (~0ms).
 
 **No cleartext DNS anywhere in the chain.** The client↔gateway leg is plain UDP
 but rides the encrypted tunnel (DoH's per-query TLS/HTTP2 framing would be


### PR DESCRIPTION
Three-doc review (README, CLAUDE.md, architecture.md), each cross-checked against the actual source, not memory.

**CLAUDE.md** (the stalest — untouched during today's changes):
- module list documented 4 of 9 modules → adds `hysteria`/`singbox`/`edge`/`exit`/`tailscale`
- Key Components gains Hysteria2 + the sing-box delivery pipeline
- overview now notes the VPN/proxy layer, not just the reverse-proxy half
- CI/CD trigger wording corrected (push + PR + `workflow_dispatch` + `workflow_call`); adds the missing `preview.yml`; update-apps is Navidrome **and** Traefik now

**README**: fixes the "`:443` shared with the reverse proxy" mischaracterisation (it's shared with rathole, which relays to Traefik), drops the self-contradictory "(direct mode only)" on the IP watcher, de-markets the dynamic-DNS line.

**architecture.md**: held up well — only adds the client `dns.optimistic` cache to the "~0ms DNS" explanation. All 6 diagrams verified against code.

Docs only — no code/profile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)