### PR TITLE
docs(architecture): clarify e2e diagram — :443 fan-out, one rathole tunnel, un-lumped services

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,9 +9,9 @@ and secrets see the [README](../README.md).
 
 ## The whole system, end to end
 
-How a flow actually travels: the shared `:443` split by protocol, the
-classify-then-egress decisions the gateway makes, the rathole reverse-tunnel to
-home, and the three places traffic can leave for the internet.
+The path a connection takes: the shared `:443` split by protocol, the
+classification and egress decisions at the gateway, the rathole reverse-tunnel to
+home, and the three egress points.
 
 The gateway is the **hub**. The client picks how it *enters* (`entry-select` —
 a protocol today, a gateway once there's more than one) and where the gateway
@@ -23,23 +23,23 @@ flowchart TD
   CLIENT["sing-box client (VPN)"]
   VISITOR["public visitor / probe<br/>(no VLESS creds)"]
 
-  subgraph vps["Hetzner VPS — one :443, split by protocol"]
-    XR["Xray VLESS-REALITY<br/>owns TCP :443"]
-    HY["Hysteria2 + Salamander<br/>owns UDP :443"]
-    FREE["freedom → direct egress"]
+  subgraph vps["Hetzner VPS — :443, split by protocol"]
+    XR["Xray VLESS-REALITY<br/>TCP :443"]
+    HY["Hysteria2 + Salamander<br/>UDP :443"]
+    FREE["freedom — direct egress"]
   end
 
-  subgraph rh["🛢 rathole — ONE tunnel · VPS server ↔ home client · services muxed"]
-    HTTPS_P["https pipe<br/>VPS :8443"]
-    EXIT_P["exit-home pipe<br/>VPS :9000"]
-    RC["rathole client<br/>(in home k8s, dials out)"]
-    HTTPS_P -.->|"muxed over 1 conn"| RC
-    EXIT_P -.->|"muxed over 1 conn"| RC
+  subgraph rh["rathole tunnel — single connection, multiplexed services"]
+    HTTPS_P["https service<br/>VPS :8443"]
+    EXIT_P["exit-home service<br/>VPS :9000"]
+    RC["rathole client<br/>(home k8s)"]
+    HTTPS_P -.-> RC
+    EXIT_P -.-> RC
   end
 
   subgraph home["oldboy — home k8s, behind NAT"]
-    TR["Traefik · TLS + routing"]
-    subgraph apps["home services · Deployment + Service each, IngressRoute-routed"]
+    TR["Traefik — TLS + routing"]
+    subgraph apps["home services — Deployment + Service, IngressRoute"]
       ND["navidrome"]
       BL["blit"]
       FS["files"]
@@ -50,18 +50,18 @@ flowchart TD
     TR --> FS
   end
 
-  VPSIP(("internet · VPS IP"))
-  HOMEIP(("internet · home IP"))
+  VPSIP(("internet — VPS IP"))
+  HOMEIP(("internet — home IP"))
 
   CLIENT -->|reality| XR
   CLIENT -->|hy2| HY
   VISITOR -->|"HTTPS to blit.cc"| XR
 
   XR -->|"unmatched → :8443"| HTTPS_P
-  XR -->|"matched · direct"| FREE
-  XR -->|"matched · exit → :9000"| EXIT_P
-  HY -->|"authed · direct"| FREE
-  HY -->|"authed · exit → :9000"| EXIT_P
+  XR -->|"matched, direct"| FREE
+  XR -->|"matched, exit → :9000"| EXIT_P
+  HY -->|"authenticated, direct"| FREE
+  HY -->|"authenticated, exit → :9000"| EXIT_P
 
   RC -->|"https → Traefik"| TR
   RC -->|"exit-home → ss-rust"| SS
@@ -70,17 +70,16 @@ flowchart TD
   SS ==> HOMEIP
 ```
 
-Reading it: **two decisions, in two places.** First, on the shared `:443`, Xray
-(TCP) and Hysteria2 (UDP) each classify *who's* connecting — a matched VPN client
-gets proxied; an unmatched TLS connection (real visitor or active probe) is
-forwarded to `dest 127.0.0.1:8443`. Second, a matched client's `exit-select`
-decides *where* it leaves: `direct` goes straight out `freedom` at the VPS IP
-(**never touching rathole**), or a named exit makes the VPS dial
-`127.0.0.1:<port>`. rathole itself decides nothing — it's a fixed set of named
-pipes (`https → Traefik`, `exit-home → ss-rust`); the loopback port a flow lands
-on is what picks the pipe. All those pipes ride **one** rathole tunnel — a single
-outbound connection the home client dials to the VPS, multiplexing every service;
-there is no separate tunnel per pipe.
+Egress is determined in two stages. On the shared `:443`, Xray (TCP) and
+Hysteria2 (UDP) classify the connection: a valid VPN client is proxied; an
+unmatched TLS connection — a real visitor or an active probe — is forwarded to
+`dest 127.0.0.1:8443`. A proxied client's `exit-select` then determines egress:
+`direct` leaves via `freedom` at the VPS IP without entering rathole, and a named
+exit has the VPS dial `127.0.0.1:<port>`. rathole performs no routing — it
+exposes a fixed set of named services (`https → Traefik`, `exit-home → ss-rust`),
+and the loopback port a connection arrives on selects the service. All services
+share a single rathole tunnel, one outbound connection from the home client to
+the VPS, rather than one tunnel per service.
 
 Tailnet `100.x` isn't drawn here — it rides the same entry transports and the VPS
 dials it locally over `tailscale0`; see [Tailnet over the tunnel](#tailnet-over-the-tunnel-censorship-resistant-100x).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,8 +34,11 @@ flowchart TD
   end
 
   subgraph home["oldboy — home k8s, behind NAT"]
+    RC["rathole client<br/>dials out · one tunnel, services muxed"]
     TR["Traefik · TLS + routing"] --> SVC["Navidrome · blit · files"]
     SS["ss-rust exit"]
+    RC -->|"https → Traefik"| TR
+    RC -->|"exit-home → ss-rust"| SS
   end
 
   VPSIP(("internet · VPS IP"))
@@ -51,9 +54,9 @@ flowchart TD
   HY -->|"authed · egress=direct"| FREE
   HY -->|"authed · egress=exit → dials :9000"| EXIT_P
 
+  RH ==>|"ONE rathole tunnel — https + exit-home muxed"| RC
   FREE ==> VPSIP
-  HTTPS_P ==>|rathole tunnel| TR
-  EXIT_P ==>|rathole tunnel| SS ==> HOMEIP
+  SS ==> HOMEIP
 ```
 
 Reading it: **two decisions, in two places.** First, on the shared `:443`, Xray
@@ -64,7 +67,9 @@ decides *where* it leaves: `direct` goes straight out `freedom` at the VPS IP
 (**never touching rathole**), or a named exit makes the VPS dial
 `127.0.0.1:<port>`. rathole itself decides nothing — it's a fixed set of named
 pipes (`https → Traefik`, `exit-home → ss-rust`); the loopback port a flow lands
-on is what picks the pipe.
+on is what picks the pipe. All those pipes ride **one** rathole tunnel — a single
+outbound connection the home client dials to the VPS, multiplexing every service;
+there is no separate tunnel per pipe.
 
 Tailnet `100.x` isn't drawn here — it rides the same entry transports and the VPS
 dials it locally over `tailscale0`; see [Tailnet over the tunnel](#tailnet-over-the-tunnel-censorship-resistant-100x).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,18 +27,27 @@ flowchart TD
     XR["Xray VLESS-REALITY<br/>owns TCP :443"]
     HY["Hysteria2 + Salamander<br/>owns UDP :443"]
     FREE["freedom → direct egress"]
-    subgraph RH["rathole server — static port→pipe mux, no routing logic"]
-      HTTPS_P["https pipe<br/>127.0.0.1:8443"]
-      EXIT_P["exit-home pipe<br/>127.0.0.1:9000"]
-    end
+  end
+
+  subgraph rh["🛢 rathole — ONE tunnel · VPS server ↔ home client · services muxed"]
+    HTTPS_P["https pipe<br/>VPS :8443"]
+    EXIT_P["exit-home pipe<br/>VPS :9000"]
+    RC["rathole client<br/>(in home k8s, dials out)"]
+    HTTPS_P -.->|"muxed over 1 conn"| RC
+    EXIT_P -.->|"muxed over 1 conn"| RC
   end
 
   subgraph home["oldboy — home k8s, behind NAT"]
-    RC["rathole client<br/>dials out · one tunnel, services muxed"]
-    TR["Traefik · TLS + routing"] --> SVC["Navidrome · blit · files"]
+    TR["Traefik · TLS + routing"]
+    subgraph apps["home services · Deployment + Service each, IngressRoute-routed"]
+      ND["navidrome"]
+      BL["blit"]
+      FS["files"]
+    end
     SS["ss-rust exit"]
-    RC -->|"https → Traefik"| TR
-    RC -->|"exit-home → ss-rust"| SS
+    TR --> ND
+    TR --> BL
+    TR --> FS
   end
 
   VPSIP(("internet · VPS IP"))
@@ -48,13 +57,15 @@ flowchart TD
   CLIENT -->|hy2| HY
   VISITOR -->|"HTTPS to blit.cc"| XR
 
-  XR -->|"unmatched → dest :8443"| HTTPS_P
-  XR -->|"matched · egress=direct"| FREE
-  XR -->|"matched · egress=exit → dials :9000"| EXIT_P
-  HY -->|"authed · egress=direct"| FREE
-  HY -->|"authed · egress=exit → dials :9000"| EXIT_P
+  XR -->|"unmatched → :8443"| HTTPS_P
+  XR -->|"matched · direct"| FREE
+  XR -->|"matched · exit → :9000"| EXIT_P
+  HY -->|"authed · direct"| FREE
+  HY -->|"authed · exit → :9000"| EXIT_P
 
-  RH ==>|"ONE rathole tunnel — https + exit-home muxed"| RC
+  RC -->|"https → Traefik"| TR
+  RC -->|"exit-home → ss-rust"| SS
+
   FREE ==> VPSIP
   SS ==> HOMEIP
 ```


### PR DESCRIPTION
Reworks the end-to-end diagram so the `:443` mechanics are legible:

- `:443` split by protocol (Xray TCP / Hysteria2 UDP), with Xray's match-vs-decoy classification shown
- rathole drawn as one tunnel (single connection, multiplexed services) spanning the VPS↔home boundary — not a tunnel per service
- home services un-lumped into navidrome/blit/files (Deployment + Service each, IngressRoute)
- direct egress (`freedom`) shown skipping rathole entirely
- captions flattened to a plain register (no caps emphasis, emoji, or AI-ish phrasing)

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)