### PR TITLE
chore(infra): de-slop — shared helpers, drop dead config

### DIFF
--- a/packages/infra/src/kubeconfig.ts
+++ b/packages/infra/src/kubeconfig.ts
@@ -2,7 +2,6 @@ interface KubeConfigArgs {
   host: string;
   port?: string | number;
   token: string;
-  caCert?: string;
 }
 
 export const getKubeconfig = ({

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -21,11 +21,6 @@ import {
 import { createSingboxDelivery, type SingboxNode } from "./modules/singbox.ts";
 import { createService } from "./templates/service.ts";
 
-const dnsModules = {
-  bluesky: createBlueskyRecords,
-  fastmail: createFastmailRecords,
-} as const;
-
 export default async function () {
   const { namespace } = conf;
   let dnsTarget: pulumi.Output<string> | undefined;
@@ -122,9 +117,9 @@ export default async function () {
   for (const zone of conf.zones) {
     for (const mod of zone.modules) {
       if (mod === "fastmail") {
-        dnsModules[mod](zone, conf.fastmail);
+        createFastmailRecords(zone, conf.fastmail);
       } else {
-        dnsModules[mod](zone, conf.bluesky);
+        createBlueskyRecords(zone, conf.bluesky);
       }
     }
   }

--- a/packages/infra/src/modules/edge.ts
+++ b/packages/infra/src/modules/edge.ts
@@ -1,4 +1,3 @@
-import * as command from "@pulumi/command";
 import * as hcloud from "@pulumi/hcloud";
 import type * as pulumi from "@pulumi/pulumi";
 import * as tls from "@pulumi/tls";
@@ -7,6 +6,7 @@ import type { EdgeConfSchema } from "../conf.schemas.ts";
 import { XrayConfSchema } from "../conf.schemas.ts";
 import { createHysteria } from "./hysteria.ts";
 import { createTailscale } from "./tailscale.ts";
+import { createNetworkTuning, inboundRule } from "./vps.ts";
 import { createXray } from "./xray.ts";
 
 /**
@@ -40,27 +40,9 @@ export function createEdge(
 
   const firewall = new hcloud.Firewall(name, {
     rules: [
-      {
-        description: "SSH",
-        direction: "in",
-        port: "22",
-        protocol: "tcp",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-      },
-      {
-        description: "HTTPS / REALITY",
-        direction: "in",
-        port: "443",
-        protocol: "tcp",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-      },
-      {
-        description: "Hysteria2 QUIC",
-        direction: "in",
-        port: String(edge.hysteria.port),
-        protocol: "udp",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-      },
+      inboundRule("SSH", 22),
+      inboundRule("HTTPS / REALITY", 443),
+      inboundRule("Hysteria2 QUIC", edge.hysteria.port, "udp"),
     ],
   });
 
@@ -78,21 +60,7 @@ export function createEdge(
     user: "root",
   };
 
-  // BBR + fq: cubic collapses on packet loss; BBR holds the pipe open, which
-  // is what the hy2/reality traffic rides over. Same tuning as the gateway.
-  new command.remote.Command(
-    `${name}-network-tuning`,
-    {
-      connection,
-      create: `cat > /etc/sysctl.d/99-network-tuning.conf << 'EOF'
-net.core.default_qdisc = fq
-net.ipv4.tcp_congestion_control = bbr
-EOF
-sysctl --system`,
-      triggers: ["bbr-fq-v1"],
-    },
-    { dependsOn: [server] },
-  );
+  createNetworkTuning(name, connection, server);
 
   const hysteria = createHysteria(connection, server, edge.hysteria, name);
 

--- a/packages/infra/src/modules/exit.ts
+++ b/packages/infra/src/modules/exit.ts
@@ -1,7 +1,7 @@
-import * as crypto from "node:crypto";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
+import { sha256hex } from "../util.ts";
 
 /** An exit with its loopback port resolved (see deriveExitPort). */
 export type ResolvedExit = {
@@ -55,9 +55,7 @@ export function createExit(
       mode: "tcp_and_udp",
     }),
   );
-  const configHash = config.apply((c) =>
-    crypto.createHash("sha256").update(c).digest("hex"),
-  );
+  const configHash = sha256hex(config);
 
   // Secret, not ConfigMap: config.json embeds the ss password in cleartext.
   const secret = new k8s.core.v1.Secret(

--- a/packages/infra/src/modules/gateway.ts
+++ b/packages/infra/src/modules/gateway.ts
@@ -8,6 +8,7 @@ import type { GatewayConfSchema } from "../conf.schemas.ts";
 import { env } from "../env.ts";
 import { createHysteria } from "./hysteria.ts";
 import { createTailscale } from "./tailscale.ts";
+import { createNetworkTuning, inboundRule } from "./vps.ts";
 import { createXray } from "./xray.ts";
 
 /**
@@ -34,44 +35,12 @@ export function createGateway(
 
   const firewall = new hcloud.Firewall("gateway", {
     rules: [
-      {
-        description: "SSH",
-        direction: "in",
-        port: "22",
-        protocol: "tcp",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-      },
-      {
-        description: "HTTP",
-        direction: "in",
-        port: "80",
-        protocol: "tcp",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-      },
-      {
-        description: "HTTPS",
-        direction: "in",
-        port: "443",
-        protocol: "tcp",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-      },
-      {
-        description: "Rathole control channel",
-        direction: "in",
-        port: "2333",
-        protocol: "tcp",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-      },
+      inboundRule("SSH", 22),
+      inboundRule("HTTP", 80),
+      inboundRule("HTTPS", 443),
+      inboundRule("Rathole control channel", 2333),
       ...(gateway.hysteria
-        ? [
-            {
-              description: "Hysteria2 QUIC",
-              direction: "in",
-              port: String(gateway.hysteria.port),
-              protocol: "udp",
-              sourceIps: ["0.0.0.0/0", "::/0"],
-            },
-          ]
+        ? [inboundRule("Hysteria2 QUIC", gateway.hysteria.port, "udp")]
         : []),
     ],
   });
@@ -124,23 +93,7 @@ systemctl enable rathole
     user: "root",
   };
 
-  // Enable BBR congestion control + fq qdisc. Default (cubic) collapses
-  // throughput on packet loss; BBR holds the pipe open across lossy links,
-  // which is what the relayed traffic rides over. Applied over SSH so the
-  // server is never rebuilt.
-  new command.remote.Command(
-    "gateway-network-tuning",
-    {
-      connection,
-      create: `cat > /etc/sysctl.d/99-network-tuning.conf << 'EOF'
-net.core.default_qdisc = fq
-net.ipv4.tcp_congestion_control = bbr
-EOF
-sysctl --system`,
-      triggers: ["bbr-fq-v1"],
-    },
-    { dependsOn: [server] },
-  );
+  createNetworkTuning("gateway", connection, server);
 
   // Caching DNS forwarder on loopback. Clients dial 127.0.0.1:53 *at this box*
   // through the tunnel (a DNS server with detour=entry-select), so unbound has

--- a/packages/infra/src/modules/hysteria.ts
+++ b/packages/infra/src/modules/hysteria.ts
@@ -4,12 +4,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import type * as z from "zod";
 import type { HysteriaConfSchema } from "../conf.schemas.ts";
-
-type Connection = {
-  host: pulumi.Output<string>;
-  privateKey: pulumi.Output<string>;
-  user: string;
-};
+import { type Connection, resourcePrefix } from "./vps.ts";
 
 /**
  * Provisions Hysteria2 (QUIC/UDP) on the gateway VPS.
@@ -27,9 +22,7 @@ export function createHysteria(
   hysteria: z.infer<typeof HysteriaConfSchema>,
   name = "",
 ) {
-  // Empty name = the primary gateway, keeping its original resource names so
-  // Pulumi doesn't replace the live box. Edges pass a name → prefixed names.
-  const p = name ? `${name}-` : "";
+  const p = resourcePrefix(name);
   const authPassword = new random.RandomPassword(`${p}hysteria-auth`, {
     length: 32,
     special: false,

--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -1,8 +1,8 @@
-import * as crypto from "node:crypto";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import type * as z from "zod";
 import type { TraefikConfSchema } from "../conf.schemas.ts";
+import { sha256hex } from "../util.ts";
 
 /**
  * Deploys the ingress stack into the K8s cluster:
@@ -129,9 +129,7 @@ type = "tcp"
 local_addr = "${traefikSvc}:80"
 ${exitClientEntries}`;
 
-    const ratholeConfigHash = ratholeConfig.apply((c) =>
-      crypto.createHash("sha256").update(c).digest("hex"),
-    );
+    const ratholeConfigHash = sha256hex(ratholeConfig);
 
     const ratholeConfigMap = new k8s.core.v1.ConfigMap(
       "rathole-client-config",

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -1,6 +1,6 @@
-import * as crypto from "node:crypto";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
+import { sha256hex } from "../util.ts";
 
 /** One node in the client profile — the primary gateway or an edge. */
 export type SingboxNode = {
@@ -365,9 +365,7 @@ export function createSingboxDelivery(
         2,
       ),
     );
-  const profileHash = profileJson.apply((s) =>
-    crypto.createHash("sha256").update(s).digest("hex"),
-  );
+  const profileHash = sha256hex(profileJson);
 
   const destDir = "/srv/files/.sfm";
   const dest = `${destDir}/${opts.slug}.json`;

--- a/packages/infra/src/modules/tailscale.ts
+++ b/packages/infra/src/modules/tailscale.ts
@@ -3,12 +3,7 @@ import type * as hcloud from "@pulumi/hcloud";
 import * as pulumi from "@pulumi/pulumi";
 import type * as z from "zod";
 import type { TailnetConfSchema } from "../conf.schemas.ts";
-
-type Connection = {
-  host: pulumi.Output<string>;
-  privateKey: pulumi.Output<string>;
-  user: string;
-};
+import { type Connection, resourcePrefix } from "./vps.ts";
 
 /**
  * Joins the gateway VPS to the tailnet so it can relay client traffic into
@@ -38,9 +33,7 @@ export function createTailscale(
   authKey: pulumi.Output<string>,
   name = "",
 ) {
-  // Empty name = the primary gateway, keeping its original resource name so
-  // Pulumi doesn't replace the live box. Edges pass a name → prefixed name.
-  const p = name ? `${name}-` : "";
+  const p = resourcePrefix(name);
   return new command.remote.Command(
     `${p}tailscale-up`,
     {

--- a/packages/infra/src/modules/vps.ts
+++ b/packages/infra/src/modules/vps.ts
@@ -1,0 +1,55 @@
+import * as command from "@pulumi/command";
+import type * as hcloud from "@pulumi/hcloud";
+import type * as pulumi from "@pulumi/pulumi";
+
+/** SSH connection to a provisioned Hetzner VPS. */
+export type Connection = {
+  host: pulumi.Output<string>;
+  privateKey: pulumi.Output<string>;
+  user: string;
+};
+
+/**
+ * Resource-name prefix for a node. Empty name = the primary gateway, keeping
+ * its original resource names so Pulumi doesn't replace the live box; edges and
+ * their transports pass a name and get prefixed names.
+ */
+export const resourcePrefix = (name: string) => (name ? `${name}-` : "");
+
+/** An inbound hcloud firewall rule open to the whole internet (v4 + v6). */
+export const inboundRule = (
+  description: string,
+  port: number | string,
+  protocol: "tcp" | "udp" = "tcp",
+) => ({
+  description,
+  direction: "in",
+  port: String(port),
+  protocol,
+  sourceIps: ["0.0.0.0/0", "::/0"],
+});
+
+/**
+ * Enable BBR congestion control + fq qdisc over SSH. Default cubic collapses
+ * throughput on packet loss; BBR holds the pipe open across the lossy links the
+ * relayed/VPN traffic rides over. Applied over SSH so the box is never rebuilt.
+ */
+export function createNetworkTuning(
+  name: string,
+  connection: Connection,
+  server: hcloud.Server,
+) {
+  return new command.remote.Command(
+    `${name}-network-tuning`,
+    {
+      connection,
+      create: `cat > /etc/sysctl.d/99-network-tuning.conf << 'EOF'
+net.core.default_qdisc = fq
+net.ipv4.tcp_congestion_control = bbr
+EOF
+sysctl --system`,
+      triggers: ["bbr-fq-v1"],
+    },
+    { dependsOn: [server] },
+  );
+}

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -4,12 +4,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import type * as z from "zod";
 import type { XrayConfSchema } from "../conf.schemas.ts";
-
-type Connection = {
-  host: pulumi.Output<string>;
-  privateKey: pulumi.Output<string>;
-  user: string;
-};
+import { type Connection, resourcePrefix } from "./vps.ts";
 
 /**
  * Provisions Xray-core (VLESS-Vision-REALITY) on the gateway VPS.
@@ -26,9 +21,7 @@ export function createXray(
   xray: z.infer<typeof XrayConfSchema>,
   name = "",
 ) {
-  // Empty name = the primary gateway, keeping its original resource names so
-  // Pulumi doesn't replace the live box. Edges pass a name → prefixed names.
-  const p = name ? `${name}-` : "";
+  const p = resourcePrefix(name);
   const uuid = new random.RandomUuid(`${p}xray-uuid`);
   const shortId = new random.RandomId(`${p}xray-short-id`, { byteLength: 8 });
 

--- a/packages/infra/src/templates/healthcheck.schemas.ts
+++ b/packages/infra/src/templates/healthcheck.schemas.ts
@@ -1,19 +1,10 @@
 import * as z from "zod";
 
-export const HealthStatusSchema = z.enum([
-  "UP",
-  "DOWN",
-  "UNKNOWN",
-  "OUT_OF_SERVICE",
-]);
-
 export const HealthCheckConfigSchema = z.object({
   enableLiveness: z.boolean().default(true),
   enableReadiness: z.boolean().default(true),
   enableStartup: z.boolean().default(false),
-  expectedStatus: HealthStatusSchema.default("UP"),
   failureThreshold: z.uint32().default(3),
-  followRedirects: z.boolean().default(false),
   httpHeaders: z
     .array(
       z.object({

--- a/packages/infra/src/templates/service.test.ts
+++ b/packages/infra/src/templates/service.test.ts
@@ -112,8 +112,6 @@ describe("service template", () => {
         timeoutSeconds: 5,
         failureThreshold: 3,
         successThreshold: 1,
-        expectedStatus: "UP" as const,
-        followRedirects: false,
         httpHeaders: [],
       },
       hostVolumes: [],

--- a/packages/infra/src/templates/service.ts
+++ b/packages/infra/src/templates/service.ts
@@ -1,10 +1,31 @@
 import * as k8s from "@pulumi/kubernetes";
 import type * as z from "zod";
+import type { HealthCheckConfigSchema } from "./healthcheck.schemas.ts";
 import type { ServiceArgsSchema } from "./service.schemas.ts";
 
 const annotations = {
   "pulumi.com/skipAwait": "false",
 };
+
+// A k8s httpGet probe from the health-check config. Liveness/readiness/startup
+// share the same shape; startup passes a larger failureThreshold to tolerate a
+// slow first boot.
+const probe = (
+  hc: z.infer<typeof HealthCheckConfigSchema>,
+  httpPort: number,
+  failureThreshold = hc.failureThreshold,
+) => ({
+  httpGet: {
+    path: hc.path,
+    port: hc.port ?? httpPort,
+    ...(hc.httpHeaders.length > 0 && { httpHeaders: hc.httpHeaders }),
+  },
+  initialDelaySeconds: hc.initialDelaySeconds,
+  periodSeconds: hc.periodSeconds,
+  timeoutSeconds: hc.timeoutSeconds,
+  failureThreshold,
+  successThreshold: hc.successThreshold,
+});
 
 export function createService(
   provider: k8s.Provider,
@@ -118,6 +139,26 @@ export function createService(
     { provider },
   );
 
+  const probes = healthCheck
+    ? {
+        ...(healthCheck.enableLiveness && {
+          livenessProbe: probe(healthCheck, httpPort),
+        }),
+        ...(healthCheck.enableReadiness && {
+          readinessProbe: probe(healthCheck, httpPort),
+        }),
+        // Startup gets 3× the failure budget (min 30) so a cold boot isn't
+        // killed before it's ready.
+        ...(healthCheck.enableStartup && {
+          startupProbe: probe(
+            healthCheck,
+            httpPort,
+            Math.max(healthCheck.failureThreshold * 3, 30),
+          ),
+        }),
+      }
+    : {};
+
   new k8s.apps.v1.Deployment(
     `${serviceName}-deployment`,
     {
@@ -140,7 +181,7 @@ export function createService(
               {
                 name: serviceName,
                 image: `${image.repository}:${image.tag}`,
-                imagePullPolicy: "Always",
+                imagePullPolicy: image.pullPolicy ?? "Always",
                 ports: [
                   { name: "http", containerPort: httpPort },
                   ...ports.map(([hostPort, containerPort]) => ({
@@ -165,59 +206,7 @@ export function createService(
                     readOnly,
                   })),
                 ],
-                ...(healthCheck && {
-                  ...(healthCheck.enableLiveness && {
-                    livenessProbe: {
-                      httpGet: {
-                        path: healthCheck.path,
-                        port: healthCheck.port ?? httpPort,
-                        ...(healthCheck.httpHeaders.length > 0 && {
-                          httpHeaders: healthCheck.httpHeaders,
-                        }),
-                      },
-                      initialDelaySeconds: healthCheck.initialDelaySeconds,
-                      periodSeconds: healthCheck.periodSeconds,
-                      timeoutSeconds: healthCheck.timeoutSeconds,
-                      failureThreshold: healthCheck.failureThreshold,
-                      successThreshold: healthCheck.successThreshold,
-                    },
-                  }),
-                  ...(healthCheck.enableReadiness && {
-                    readinessProbe: {
-                      httpGet: {
-                        path: healthCheck.path,
-                        port: healthCheck.port ?? httpPort,
-                        ...(healthCheck.httpHeaders.length > 0 && {
-                          httpHeaders: healthCheck.httpHeaders,
-                        }),
-                      },
-                      initialDelaySeconds: healthCheck.initialDelaySeconds,
-                      periodSeconds: healthCheck.periodSeconds,
-                      timeoutSeconds: healthCheck.timeoutSeconds,
-                      failureThreshold: healthCheck.failureThreshold,
-                      successThreshold: healthCheck.successThreshold,
-                    },
-                  }),
-                  ...(healthCheck.enableStartup && {
-                    startupProbe: {
-                      httpGet: {
-                        path: healthCheck.path,
-                        port: healthCheck.port ?? httpPort,
-                        ...(healthCheck.httpHeaders.length > 0 && {
-                          httpHeaders: healthCheck.httpHeaders,
-                        }),
-                      },
-                      initialDelaySeconds: healthCheck.initialDelaySeconds,
-                      periodSeconds: healthCheck.periodSeconds,
-                      timeoutSeconds: healthCheck.timeoutSeconds,
-                      failureThreshold: Math.max(
-                        healthCheck.failureThreshold * 3,
-                        30,
-                      ),
-                      successThreshold: healthCheck.successThreshold,
-                    },
-                  }),
-                }),
+                ...probes,
                 securityContext: {
                   allowPrivilegeEscalation: false,
                 },

--- a/packages/infra/src/util.ts
+++ b/packages/infra/src/util.ts
@@ -1,0 +1,11 @@
+import * as crypto from "node:crypto";
+import type * as pulumi from "@pulumi/pulumi";
+
+/**
+ * sha256 hex digest of an Output string. Used as a `triggers` value so a
+ * command/pod only re-runs when the rendered content it depends on changes.
+ */
+export const sha256hex = (
+  input: pulumi.Output<string>,
+): pulumi.Output<string> =>
+  input.apply((s) => crypto.createHash("sha256").update(s).digest("hex"));

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -205,20 +205,11 @@
                         "default": false,
                         "type": "boolean"
                       },
-                      "expectedStatus": {
-                        "default": "UP",
-                        "type": "string",
-                        "enum": ["UP", "DOWN", "UNKNOWN", "OUT_OF_SERVICE"]
-                      },
                       "failureThreshold": {
                         "default": 3,
                         "type": "integer",
                         "minimum": 0,
                         "maximum": 4294967295
-                      },
-                      "followRedirects": {
-                        "default": false,
-                        "type": "boolean"
                       },
                       "httpHeaders": {
                         "default": [


### PR DESCRIPTION
General cleanup pass: rule-of-three dedup + dead-code removal. Everything is behaviour-preserving — the extracted helpers emit **identical** Pulumi resource inputs and resource names, so `pulumi preview` should show **no plan diff**. That's the whole point: tighter source, same infra.

## What changed
- **`util.ts` `sha256hex()`** — the `crypto.createHash("sha256")…` trigger idiom was inlined in `exit`, `ingress`, `singbox`. One helper now.
- **`modules/vps.ts`** — new home for shared VPS-provisioning bits:
  - `Connection` type (was defined verbatim 3× in hysteria/xray/tailscale)
  - `resourcePrefix()` — the `name ? "${name}-" : ""` helper + its explanatory comment (3×)
  - `inboundRule()` — collapses the `sourceIps: ["0.0.0.0/0","::/0"]` firewall boilerplate (~8×)
  - `createNetworkTuning()` — the BBR/fq sysctl block was a **byte-identical copy** in gateway + edge; deduping kills the drift risk
- **`service.ts`** — one `probe()` helper replaces 3 near-identical ~18-line liveness/readiness/startup blocks; **wire `image.pullPolicy`** (config set it, code hardcoded `"Always"` and ignored it — config already says `"Always"` everywhere so output is unchanged)
- **Dead fields dropped** — `kubeconfig.caCert`, and healthcheck `expectedStatus` / `followRedirects` / `HealthStatusSchema` (never read by the k8s httpGet probe; no config sets them). `schemas/infra.json` regenerated.
- **`main.ts`** — dropped the `dnsModules` map; the `if/else` already picked both the function and its arg by hand.

Net **−73 LOC** of source (after adding ~66 lines of new shared helpers — so ~140 lines of duplication removed).

## Verify
- `aube run typecheck:infra` ✅ / `aube run lint` ✅ 0/0 / `aube run test` ✅ 5/5
- Load-bearing check: **`pulumi preview` shows no replacements/updates.** Resource names preserved (`gateway-network-tuning`, edge `${name}-network-tuning`, all firewall rules), and every extracted value is identical to the inline original.
- No load-bearing comments touched (MTU/gvisor/198.18/accept-routes/unbound rationale all intact).