### PR TITLE
docs(architecture): clarify rathole binds are loopback, not internet-exposed

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,8 +30,8 @@ flowchart TD
   end
 
   subgraph rh["rathole tunnel — single connection, multiplexed services"]
-    HTTPS_P["https service<br/>VPS :8443"]
-    EXIT_P["exit-home service<br/>VPS :9000"]
+    HTTPS_P["https service<br/>127.0.0.1:8443 (loopback)"]
+    EXIT_P["exit-home service<br/>127.0.0.1:9000 (loopback)"]
     RC["rathole client<br/>(home k8s)"]
     HTTPS_P -.-> RC
     EXIT_P -.-> RC
@@ -79,7 +79,11 @@ exit has the VPS dial `127.0.0.1:<port>`. rathole performs no routing — it
 exposes a fixed set of named services (`https → Traefik`, `exit-home → ss-rust`),
 and the loopback port a connection arrives on selects the service. All services
 share a single rathole tunnel, one outbound connection from the home client to
-the VPS, rather than one tunnel per service.
+the VPS, rather than one tunnel per service. Both service binds (`:8443`,
+`:9000`) listen on loopback and are absent from the firewall's inbound allow-list
+(`22`, `80`, `443`, `2333`, Hysteria2 UDP), so neither is reachable from the
+internet: Xray reaches `:8443` locally, and an exit request reaches `:9000` only
+after arriving through the tunnel.
 
 Tailnet `100.x` isn't drawn here — it rides the same entry transports and the VPS
 dials it locally over `tailscale0`; see [Tailnet over the tunnel](#tailnet-over-the-tunnel-censorship-resistant-100x).


### PR DESCRIPTION
The `:8443`/`:9000` labels (shortened from `127.0.0.1:…` in an earlier de-slop) read as public ports. They're not: both bind loopback-only and are absent from the Hetzner firewall's inbound allow-list (`22`, `80`, `443`, `2333`, Hysteria2 UDP). Restores the loopback address on the labels and adds a caption line stating it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)