### PR TITLE
fix(vpn): hy2 client auth must be name:password for userpass server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ mise.local.toml
 
 node_modules
 
+
+# harness-managed agent worktrees
+.claude/worktrees/

--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -182,7 +182,10 @@ export function buildProfile(
   for (const n of nodes) {
     outbounds.push(reality(n, n.reality.uuids[user.name]));
     if (isAdmin) {
-      const pw = n.hysteria.passwords[user.name];
+      // hy2's server auth is `userpass`, so the client's password must be
+      // `<name>:<password>` — the server splits on the first colon to look the
+      // user up. Sending the bare password fails auth for every admin.
+      const pw = `${user.name}:${n.hysteria.passwords[user.name]}`;
       outbounds.push(hy2(n, pw), hy2Brutal(n, pw));
     }
   }


### PR DESCRIPTION
**Live-outage hotfix.** RBAC (#95) switched the hy2 server to `auth.type: userpass`, which expects the client to authenticate as `<name>:<password>` (server splits on the first colon). The generated profile shipped the bare password → every admin's hy2 auth rejected → no hy2 connectivity.

Prefix the per-admin hy2 password with the user name in the profile. Reality was unaffected (verified: admin not blackholed, UUID matches, config valid).

Also gitignores `.claude/worktrees/` so agent worktrees can't get swept into commits.

Verified: typecheck, lint, 13 tests, fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)