### PR TITLE
fix(vpn): deleteBeforeReplace on per-user profile write (was self-deleting on content change)

### DIFF
--- a/packages/infra/src/modules/singbox.ts
+++ b/packages/infra/src/modules/singbox.ts
@@ -423,13 +423,23 @@ export function createSingboxDelivery(
     const slug = userSlug(opts.slug, user.name);
     const dest = `${destDir}/${slug}.json`;
 
-    const write = new command.remote.Command(`singbox-profile-${user.name}`, {
-      connection,
-      create: `mkdir -p ${destDir} && cat > ${dest} && chmod 644 ${dest}`,
-      delete: `rm -f ${dest}`,
-      stdin: profileJson,
-      triggers: [profileHash],
-    });
+    const write = new command.remote.Command(
+      `singbox-profile-${user.name}`,
+      {
+        connection,
+        create: `mkdir -p ${destDir} && cat > ${dest} && chmod 644 ${dest}`,
+        delete: `rm -f ${dest}`,
+        stdin: profileJson,
+        triggers: [profileHash],
+      },
+      // `dest` is a deterministic per-user path, so a content change *replaces*
+      // this resource. Delete-before-replace is mandatory: the default
+      // (create-then-delete) would write the new profile and then `rm` the same
+      // path when deleting the old resource — silently clobbering it. Deleting
+      // first keeps the file present after a content change, while user removal
+      // still revokes it.
+      { deleteBeforeReplace: true },
+    );
 
     return {
       user,


### PR DESCRIPTION
**Follow-up outage fix.** The per-user profile `command.remote.Command` writes a deterministic slug path and has `delete: rm -f ${dest}` for revocation. On a *content change* (like the hy2 auth fix), pulumi-command **replaces** the resource, and the default **create-before-delete** ordering does: create-replacement (writes the file) → delete-original (`rm -f` the same path) → **file gone**. Result: every profile 404'd after any content-changing deploy.

`deleteBeforeReplace: true` flips the order (delete-old-then-create-new), so the file survives a content change. User removal still runs `delete` and revokes.

Verified: typecheck, lint, tests, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)