### PR TITLE
99 fix(xray): rebuild VLESS-REALITY routing scaffolding

### DIFF
--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -256,6 +256,8 @@ export default async function () {
       xrayPublicKey: xray.publicKey,
       xrayServerName: conf.gateway?.xray?.serverName,
       xrayShortId: xray.shortId,
+      // TEMP diagnostic (issue #99) — remove with the xray-journal command.
+      xrayJournal: xray.journal,
     }),
   };
 }

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -22,6 +22,12 @@ const EXIT_PORT_RANGE = "20000-29999";
  * minted per user (`email: <name>`) so a user is revoked by dropping them from
  * the clients list. Guests (reality-only) are blackholed server-side to the
  * tailnet CIDR and the exit loopbacks — a hard block, not a profile omission.
+ *
+ * `user`-scoped routing only resolves once the inbound sniffs the flow, so the
+ * inbound enables sniffing with `routeOnly` (route on the sniffed destination
+ * without rewriting it). Outbounds are tagged (`direct` freedom, `block`
+ * blackhole) and routing ends in an explicit `direct` default, so a non-guest
+ * (matching no rule) proxies out cleanly instead of relying on ordering.
  * Returns the shared REALITY params plus each user's per-node UUID.
  */
 export function createXray(
@@ -56,22 +62,15 @@ export function createXray(
       ),
     );
 
-  // Guest hard-block: reality is their only entry, so a routing rule keyed on
-  // their client email is airtight. Two rules — the tailnet mesh and the exit
-  // loopbacks — both to a blackhole outbound. Admins are unrestricted.
+  // Guest hard-block: reality is their only entry, so routing keyed on their
+  // client email is airtight — the tailnet mesh and the exit loopbacks both go
+  // to the blackhole. Admins match no guest rule and fall through to `direct`.
   const guests = clients.filter((c) => c.role === "guest").map((c) => c.name);
   const guestsList = JSON.stringify(guests);
-  const routingBlock = guests.length
-    ? `,
-  "routing": {
-    "rules": [
+  const guestRules = guests.length
+    ? `
       { "user": ${guestsList}, "ip": ["100.64.0.0/10", "fd7a:115c:a1e0::/48"], "outboundTag": "block" },
-      { "user": ${guestsList}, "ip": ["127.0.0.0/8"], "port": "${EXIT_PORT_RANGE}", "outboundTag": "block" }
-    ]
-  }`
-    : "";
-  const blackhole = guests.length
-    ? `, { "protocol": "blackhole", "tag": "block" }`
+      { "user": ${guestsList}, "ip": ["127.0.0.0/8"], "port": "${EXIT_PORT_RANGE}", "outboundTag": "block" },`
     : "";
 
   const install = new command.remote.Command(
@@ -140,10 +139,24 @@ cat > /usr/local/etc/xray/config.json << XRAY_EOF
           "privateKey": "$PRIV",
           "shortIds": ["${shortId.hex}"]
         }
+      },
+      "sniffing": {
+        "enabled": true,
+        "destOverride": ["http", "tls", "quic"],
+        "routeOnly": true
       }
     }
   ],
-  "outbounds": [{ "protocol": "freedom" }${blackhole}]${routingBlock}
+  "outbounds": [
+    { "protocol": "freedom", "tag": "direct" },
+    { "protocol": "blackhole", "tag": "block" }
+  ],
+  "routing": {
+    "domainStrategy": "AsIs",
+    "rules": [${guestRules}
+      { "network": "tcp,udp", "outboundTag": "direct" }
+    ]
+  }
 }
 XRAY_EOF
 systemctl restart xray`,
@@ -159,8 +172,24 @@ systemctl restart xray`,
     { dependsOn: [publicKey] },
   );
 
+  // TEMP diagnostic (issue #99): surface the xray journal so the real REALITY
+  // rejection reason is visible in the deploy log / `pulumi stack output`.
+  // Non-secret (warning-level logs, no keys). Re-runs on every config change.
+  // REMOVE before final merge.
+  const journal = new command.remote.Command(
+    `${p}xray-journal`,
+    {
+      connection,
+      create:
+        "sleep 2; echo \"active=$(systemctl is-active xray)\"; echo '--- journal ---'; journalctl -u xray -n 150 --no-pager 2>&1 | tail -c 8000",
+      triggers: [config.id],
+    },
+    { dependsOn: [config] },
+  );
+
   return {
     config,
+    journal: journal.stdout,
     publicKey: publicKey.stdout,
     shortId: shortId.hex,
     uuids,


### PR DESCRIPTION
Fixes #99.

## What this does

Reality (VLESS-Vision-REALITY) has been dead for **every** user since the #95 RBAC rewrite — all VLESS connections open then EOF ~300ms later, admins included, while hy2 stayed up. #95 added `user`-scoped guest routing to the xray inbound but not the scaffolding that `user` routing depends on. This rebuilds the server config (`packages/infra/src/modules/xray.ts`) to the pre-#95 working shape plus correct multi-user routing:

- **inbound `sniffing`** (`enabled`, `destOverride: [http,tls,quic]`, `routeOnly: true`) — `user`/destination rules can't resolve without it; `routeOnly` means we route on the sniffed dest without rewriting what freedom dials.
- **tagged outbounds** — `freedom` → `direct`, `blackhole` → `block`, always present (pre-#95 freedom was untagged; #95's blackhole was conditional).
- **explicit `direct` routing default** — a non-guest matches no rule and falls through to `direct` deterministically, instead of relying on first-outbound ordering.
- **guest hard-block preserved**, scoped to guest emails only: tailnet `100.64.0.0/10` (+ v6 ULA) and exit loopbacks `127.0.0.0/8:20000-29999` → `block`. Admins match no guest rule → `direct`.

The client profile is **unchanged** — reality params are single-sourced from the server (verified jc's live profile: uuid/pubkey/shortId/sni/flow all internally consistent), so the failure was server-side runtime, not the profile.

## Load-bearing decisions

- `domainStrategy: "AsIs"` — the guest block matches on `ip` (tailnet/exit are IP-addressed by the client), so no forced DNS resolution is needed.
- hy2 is untouched — the working path admins rely on stays exactly as-is.

## Evidence-first: TEMP diagnostic (must be removed before merge)

Per #99, do **not** blind-ship. This PR includes a throwaway `xray-journal` remote command surfaced as the non-secret `xrayJournal` stack output (warning-level logs, no keys). After deploy, read the real rejection reason:

```
gh run view <deploy-run-id> --log | grep -A40 xrayJournal
# or, with stack access: pulumi stack output xrayJournal
```

Confirm the journal is clean (xray `active`, no config/outbound/routing errors) after this deploy. **Then strip the diagnostic before final merge:** the `xray-journal` `command.remote.Command` + `journal` return field in `xray.ts`, and the `xrayJournal` line in `main.ts`.

## How to confirm it works

1. Deploy to the live stack (this reaches the shared gateway — expected).
2. Read `xrayJournal` — verify no reality/routing errors on startup.
3. **Test reality end-to-end (human only):** in a client, force `reality-primary` (disable hy2 / select reality) and confirm fast, full connectivity for an admin; confirm a guest reaches the open internet but is blocked from tailnet + exits. This cannot be verified from CI — it needs a real client handshake.

Gates: `typecheck:infra`, `lint` (0/0), `fmt:check`, 13/13 tests all pass.