### PR TITLE
chore(vpn): remove temporary xray-journal diagnostic (#99)

### DIFF
--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -256,8 +256,6 @@ export default async function () {
       xrayPublicKey: xray.publicKey,
       xrayServerName: conf.gateway?.xray?.serverName,
       xrayShortId: xray.shortId,
-      // TEMP diagnostic (issue #99) — remove with the xray-journal command.
-      xrayJournal: xray.journal,
     }),
   };
 }

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -172,24 +172,8 @@ systemctl restart xray`,
     { dependsOn: [publicKey] },
   );
 
-  // TEMP diagnostic (issue #99): surface the xray journal so the real REALITY
-  // rejection reason is visible in the deploy log / `pulumi stack output`.
-  // Non-secret (warning-level logs, no keys). Re-runs on every config change.
-  // REMOVE before final merge.
-  const journal = new command.remote.Command(
-    `${p}xray-journal`,
-    {
-      connection,
-      create:
-        "sleep 2; echo \"active=$(systemctl is-active xray)\"; echo '--- journal ---'; journalctl -u xray -n 150 --no-pager 2>&1 | tail -c 8000",
-      triggers: [config.id],
-    },
-    { dependsOn: [config] },
-  );
-
   return {
     config,
-    journal: journal.stdout,
     publicKey: publicKey.stdout,
     shortId: shortId.hex,
     uuids,


### PR DESCRIPTION
Reality is fixed and confirmed working (jc connects via reality-primary). Removes the temporary `xray-journal` remote command + the `xrayJournal` stack output that surfaced xray's startup journal for diagnosis.

Closes the #99 reality rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)