### PR TITLE
feat: mcp-gateway stack (OAuth-fronted MCP gateway)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,6 +49,16 @@ on:
         required: false
       VPN_USERS:
         required: false
+      MCP_HOSTNAME:
+        required: false
+      MCP_AUTH_HOSTNAME:
+        required: false
+      GH_CLIENT_ID:
+        required: false
+      GH_CLIENT_SECRET:
+        required: false
+      GH_ALLOWED:
+        required: false
 
 concurrency:
   group: ci-cd-${{ github.ref }}
@@ -195,6 +205,8 @@ jobs:
           pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
           pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
           pulumi config set --path jaritanet:gateway.xray.serverName "$BLIT_HOSTNAME"
+          pulumi config set --path jaritanet:mcpGateway.hostname "$MCP_HOSTNAME"
+          pulumi config set --path jaritanet:mcpGateway.authHostname "$MCP_AUTH_HOSTNAME"
           if [[ -n "$EXTERNAL_IP" ]]; then
             pulumi config set jaritanet:externalIp "$EXTERNAL_IP"
           fi
@@ -206,6 +218,8 @@ jobs:
           NAVIDROME_HOSTNAME: ${{ secrets.NAVIDROME_HOSTNAME }}
           FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           BLIT_HOSTNAME: ${{ secrets.BLIT_HOSTNAME }}
+          MCP_HOSTNAME: ${{ secrets.MCP_HOSTNAME }}
+          MCP_AUTH_HOSTNAME: ${{ secrets.MCP_AUTH_HOSTNAME }}
 
       - name: Deploy
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
@@ -237,3 +251,8 @@ jobs:
           TAILNET_MAGICDNS_SUFFIX: ${{ secrets.TAILNET_MAGICDNS_SUFFIX }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          # MCP gateway: GitHub OAuth app creds + login allowlist (read by
+          # env.ts). Hostnames go via `pulumi config set` above, not env.
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_ALLOWED: ${{ secrets.GH_ALLOWED }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -76,6 +76,8 @@ jobs:
           pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
           pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
           pulumi config set --path jaritanet:gateway.xray.serverName "$BLIT_HOSTNAME"
+          pulumi config set --path jaritanet:mcpGateway.hostname "$MCP_HOSTNAME"
+          pulumi config set --path jaritanet:mcpGateway.authHostname "$MCP_AUTH_HOSTNAME"
           if [[ -n "$EXTERNAL_IP" ]]; then
             pulumi config set jaritanet:externalIp "$EXTERNAL_IP"
           fi
@@ -87,6 +89,8 @@ jobs:
           NAVIDROME_HOSTNAME: ${{ secrets.NAVIDROME_HOSTNAME }}
           FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           BLIT_HOSTNAME: ${{ secrets.BLIT_HOSTNAME }}
+          MCP_HOSTNAME: ${{ secrets.MCP_HOSTNAME }}
+          MCP_AUTH_HOSTNAME: ${{ secrets.MCP_AUTH_HOSTNAME }}
 
       - name: Preview
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
@@ -106,6 +110,9 @@ jobs:
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_ALLOWED: ${{ secrets.GH_ALLOWED }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           OLDBOY_HOST: ${{ secrets.OLDBOY_HOST }}
           OLDBOY_USER: ${{ secrets.OLDBOY_USER }}

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -20,8 +20,10 @@ config:
       cpu: "500m"
       memory: "256Mi"
     image:
-      repository: "ghcr.io/radiosilence/mcp-gateway"
-      tag: latest
+      # tag is auto-bumped to sha-<short> by jaritanet-mcp-gateway's ci-cd
+      # (update-deployment job); `main` is the initial pointer.
+      repository: "ghcr.io/radiosilence/jaritanet-mcp-gateway"
+      tag: main
       pullPolicy: "Always"
     backends:
       - id: fastmail

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -8,6 +8,31 @@ config:
     # acmeEmail injected from the ACME_EMAIL secret in CI (see ci-cd.yml)
     acmeEmail: ''
     chartVersion: "41.0.2"
+  jaritanet:mcpGateway:
+    # hostname/authHostname injected in CI from MCP_HOSTNAME / MCP_AUTH_HOSTNAME
+    # (kept out of this public repo). GitHub OAuth creds + allowlist come via
+    # GH_CLIENT_ID / GH_CLIENT_SECRET / GH_ALLOWED env in CI.
+    hostname: ''
+    authHostname: ''
+    hydraTag: "v2.2.0"
+    replicas: 2
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
+    image:
+      repository: "ghcr.io/radiosilence/mcp-gateway"
+      tag: latest
+      pullPolicy: "Always"
+    backends:
+      - id: fastmail
+        name: Fastmail
+        image: "ghcr.io/radiosilence/fastmail-cli:mcp"
+        args: ["mcp", "--http", "0.0.0.0:8080"]
+        port: 8080
+        path: "/mcp"
+        credentialHeader: "X-Fastmail-Token"
+        keyHelpUrl: "https://app.fastmail.com/settings/security/tokens"
+        keyHint: "fmu1-…"
   jaritanet:gateway:
     # xray shares :443; traffic that doesn't match a client falls back to
     # dest (local rathole https). serverName is injected from BLIT_HOSTNAME

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -28,7 +28,7 @@ config:
     backends:
       - id: fastmail
         name: Fastmail
-        image: "ghcr.io/radiosilence/fastmail-cli:mcp"
+        image: "ghcr.io/radiosilence/fastmail-cli:main"
         args: ["mcp", "--http", "0.0.0.0:8080"]
         port: 8080
         path: "/mcp"

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -1,5 +1,36 @@
 import * as z from "zod";
+import { ImageSchema, LimitsSchema } from "./templates/schemas.ts";
 import { ServiceArgsSchema } from "./templates/service.schemas.ts";
+
+/** A backend MCP the gateway fronts (one Deployment + Service each). */
+export const McpBackendSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  image: z.string(),
+  args: z.array(z.string()).default([]),
+  port: z.number().default(8080),
+  path: z.string().default("/mcp"),
+  credentialHeader: z.string(),
+  keyHelpUrl: z.string().optional(),
+  keyHint: z.string().optional(),
+});
+
+/** The MCP Gateway stack (gateway + Hydra + Postgres + backends). */
+export const McpGatewayConfSchema = z.object({
+  // Blank in the (public) repo; injected at CI time from secrets, so the source
+  // reveals no hostnames. An empty hostname skips the stack (see main.ts).
+  hostname: z.string().default(""),
+  authHostname: z.string().default(""),
+  image: ImageSchema,
+  hydraTag: z.string().default("v2.2.0"),
+  replicas: z.number().default(2),
+  limits: LimitsSchema.default({ cpu: "500m", memory: "256Mi" }),
+  nodeAffinityHostname: z.string().default("oldboy"),
+  postgresHostPath: z
+    .string()
+    .default("/var/lib/jaritanet/mcp-gateway-postgres"),
+  backends: z.array(McpBackendSchema).default([]),
+});
 
 export const CloudflareConfSchema = z.object({
   accountId: z.string(),
@@ -158,6 +189,7 @@ export const ConfSchema = z.object({
   fastmail: FastmailConfSchema,
   gateway: GatewayConfSchema.optional(),
   managedBy: z.string().default("jaritanet"),
+  mcpGateway: McpGatewayConfSchema.optional(),
   namespace: z.string().default("jaritanet"),
   services: ServicesMapSchema,
   traefik: TraefikConfSchema,

--- a/packages/infra/src/env.schema.ts
+++ b/packages/infra/src/env.schema.ts
@@ -10,6 +10,12 @@ export const EnvSchema = z.object({
   KUBE_TOKEN: z.string().min(1, "KUBE_TOKEN is required"),
   TS_AUTHKEY: z.string().optional(),
 
+  // MCP gateway: GitHub OAuth app creds + login allowlist. GH_ prefix because
+  // GitHub Actions reserves GITHUB_. Absent → the gateway stack is skipped.
+  GH_CLIENT_ID: z.string().optional(),
+  GH_CLIENT_SECRET: z.string().optional(),
+  GH_ALLOWED: z.string().optional(),
+
   // Per-user VPN access (RBAC). One comma-separated list; a trailing `+` marks
   // an admin. Absent → single implicit owner-admin (see main.ts). Parsed by
   // parseVpnUsers below into a typed {name, role}[]; delivery is per-user.

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -19,6 +19,7 @@ import {
   createIpWatcher,
   createRedirectMiddleware,
 } from "./modules/ingress.ts";
+import { createMcpGateway } from "./modules/mcp-gateway.ts";
 import { createSingboxDelivery, type SingboxNode } from "./modules/singbox.ts";
 import { createService } from "./templates/service.ts";
 
@@ -212,6 +213,36 @@ export default async function () {
 
       return [name, { hostname, service: service.metadata.name }] as const;
     });
+
+  // --- MCP Gateway: OAuth-fronted gateway for self-hosted MCP servers ---
+  // Skipped unless configured and the GitHub OAuth app creds are present.
+  if (
+    conf.mcpGateway?.hostname &&
+    conf.mcpGateway.authHostname &&
+    env.GH_CLIENT_ID &&
+    env.GH_CLIENT_SECRET
+  ) {
+    const mg = conf.mcpGateway;
+    createMcpGateway(provider, namespace, mg, {
+      githubClientId: env.GH_CLIENT_ID,
+      githubClientSecret: pulumi.secret(env.GH_CLIENT_SECRET),
+      githubAllowed: env.GH_ALLOWED ?? "",
+    });
+    // Two public hostnames: the gateway and Hydra's public API. Admin stays
+    // in-cluster (no ingress route).
+    for (const [svcName, host] of [
+      ["mcp-gateway", mg.hostname],
+      ["mcp-gateway-hydra", mg.authHostname],
+    ] as const) {
+      if (dnsTarget) {
+        const zone = conf.zones.find(
+          (z) => z.name === host.split(".").slice(-2).join("."),
+        );
+        if (zone) createServiceRecord(dnsTarget, zone, host);
+      }
+      createIngressRoute(provider, svcName, host, namespace);
+    }
+  }
 
   // --- sing-box client profile: generate + deliver + notify, all in Pulumi ---
   // Builds the profile from the nodes, writes it to the file server over SSH

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -1,0 +1,472 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import type * as z from "zod";
+import type { McpGatewayConfSchema } from "../conf.schemas.ts";
+
+const SECRETS_NAME = "mcp-gateway-secrets";
+/** An env `valueFrom` pointing at a key in the stack's Secret. */
+const secretRef = (key: string) => ({
+  valueFrom: { secretKeyRef: { name: SECRETS_NAME, key } },
+});
+
+/**
+ * The MCP Gateway stack: an OAuth-fronted gateway for self-hosted MCP servers.
+ *
+ * Three deployments in one namespace, wired together:
+ *  - postgres      — one instance, two DBs (gateway + hydra), hostPath PV.
+ *  - hydra         — Ory Hydra (the OAuth AS). A migrate Job runs first. Its
+ *                    public API is exposed at the auth hostname; admin is
+ *                    in-cluster only.
+ *  - gateway       — the Rust axum app: OAuth resource server + credential vault
+ *                    + dashboard, routing /<id> to each backend MCP.
+ *  - backends      — one Deployment per registered MCP (e.g. fastmail-cli
+ *                    mcp --http), reached in-cluster; the gateway injects the
+ *                    per-user credential.
+ *
+ * Generated secrets (Postgres password, Hydra SECRETS_SYSTEM, TOKEN_ENC_KEY)
+ * never leave the cluster — created here via @pulumi/random and wired with
+ * secretKeyRef. The only externally-provided secrets are the GitHub OAuth app
+ * credentials (env → this module).
+ *
+ * This is a bespoke module (not the generic `createService` template) because it
+ * needs secretKeyRef env, a migrate Job, and a ConfigMap — none of which the
+ * template supports.
+ */
+export function createMcpGateway(
+  provider: k8s.Provider,
+  namespace: string,
+  conf: z.infer<typeof McpGatewayConfSchema>,
+  secrets: {
+    githubClientId: pulumi.Input<string>;
+    githubClientSecret: pulumi.Input<string>;
+    githubAllowed: pulumi.Input<string>;
+  },
+) {
+  const opts = { provider };
+  const svcDns = (name: string) => `${name}.${namespace}.svc.cluster.local`;
+
+  // --- Generated secrets ---
+  const pgPassword = new random.RandomPassword(
+    "mcp-gateway-pg",
+    { length: 32, special: false },
+    opts,
+  );
+  const hydraSystemSecret = new random.RandomPassword(
+    "mcp-gateway-hydra-system",
+    { length: 48, special: false },
+    opts,
+  );
+  // 32 random bytes, base64 — the token-encryption master key.
+  const tokenEncKey = new random.RandomBytes(
+    "mcp-gateway-token-enc",
+    { length: 32 },
+    opts,
+  );
+
+  const pgUser = "fastmail";
+  const pgDb = "fastmail_mcp";
+  const pgHost = "mcp-gateway-postgres";
+  const databaseUrl = pulumi.interpolate`postgres://${pgUser}:${pgPassword.result}@${svcDns(pgHost)}:5432/${pgDb}`;
+  const hydraDsn = pulumi.interpolate`postgres://${pgUser}:${pgPassword.result}@${svcDns(pgHost)}:5432/hydra?sslmode=disable`;
+
+  const secret = new k8s.core.v1.Secret(
+    "mcp-gateway-secrets",
+    {
+      metadata: { name: "mcp-gateway-secrets", namespace },
+      stringData: {
+        "postgres-password": pgPassword.result,
+        "database-url": databaseUrl,
+        "hydra-dsn": hydraDsn,
+        "hydra-system-secret": hydraSystemSecret.result,
+        "token-enc-key": tokenEncKey.base64,
+        "gh-client-secret": pulumi.output(secrets.githubClientSecret),
+      },
+    },
+    opts,
+  );
+
+  // --- Postgres (one instance, hydra DB created by an initdb ConfigMap) ---
+  const pgInit = new k8s.core.v1.ConfigMap(
+    "mcp-gateway-postgres-initdb",
+    {
+      metadata: { name: "mcp-gateway-postgres-initdb", namespace },
+      data: { "initdb.sql": "CREATE DATABASE hydra;\n" },
+    },
+    opts,
+  );
+
+  const pgPv = new k8s.core.v1.PersistentVolume(
+    "mcp-gateway-postgres-pv",
+    {
+      spec: {
+        accessModes: ["ReadWriteOnce"],
+        capacity: { storage: "2Gi" },
+        local: { path: conf.postgresHostPath },
+        nodeAffinity: {
+          required: {
+            nodeSelectorTerms: [
+              {
+                matchExpressions: [
+                  {
+                    key: "kubernetes.io/hostname",
+                    operator: "In",
+                    values: [conf.nodeAffinityHostname],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        persistentVolumeReclaimPolicy: "Retain",
+        storageClassName: "manual",
+        volumeMode: "Filesystem",
+      },
+    },
+    opts,
+  );
+  const pgPvc = new k8s.core.v1.PersistentVolumeClaim(
+    "mcp-gateway-postgres-pvc",
+    {
+      metadata: { name: "mcp-gateway-postgres-pvc", namespace },
+      spec: {
+        accessModes: ["ReadWriteOnce"],
+        resources: { requests: { storage: "2Gi" } },
+        storageClassName: "manual",
+        volumeName: pgPv.metadata.name,
+      },
+    },
+    opts,
+  );
+
+  new k8s.apps.v1.Deployment(
+    "mcp-gateway-postgres",
+    {
+      metadata: { name: pgHost, namespace },
+      spec: {
+        replicas: 1,
+        strategy: { type: "Recreate" },
+        selector: { matchLabels: { app: pgHost } },
+        template: {
+          metadata: { labels: { app: pgHost } },
+          spec: {
+            containers: [
+              {
+                name: "postgres",
+                image: "postgres:16",
+                env: [
+                  { name: "POSTGRES_USER", value: pgUser },
+                  { name: "POSTGRES_DB", value: pgDb },
+                  {
+                    name: "POSTGRES_PASSWORD",
+                    ...secretRef("postgres-password"),
+                  },
+                  { name: "PGDATA", value: "/var/lib/postgresql/data/pgdata" },
+                ],
+                ports: [{ containerPort: 5432 }],
+                volumeMounts: [
+                  { name: "data", mountPath: "/var/lib/postgresql/data" },
+                  { name: "initdb", mountPath: "/docker-entrypoint-initdb.d" },
+                ],
+                readinessProbe: {
+                  exec: {
+                    command: ["pg_isready", "-U", pgUser, "-d", pgDb],
+                  },
+                  initialDelaySeconds: 5,
+                  periodSeconds: 5,
+                },
+              },
+            ],
+            volumes: [
+              {
+                name: "data",
+                persistentVolumeClaim: { claimName: pgPvc.metadata.name },
+              },
+              { name: "initdb", configMap: { name: pgInit.metadata.name } },
+            ],
+          },
+        },
+      },
+    },
+    { deleteBeforeReplace: true, provider },
+  );
+
+  new k8s.core.v1.Service(
+    "mcp-gateway-postgres-service",
+    {
+      metadata: { name: pgHost, namespace },
+      spec: {
+        selector: { app: pgHost },
+        ports: [{ port: 5432, targetPort: 5432 }],
+      },
+    },
+    opts,
+  );
+
+  // --- Hydra: migrate Job, then Deployment + public/admin Services ---
+  const hydraImage = `oryd/hydra:${conf.hydraTag}`;
+  const hydraEnvCommon = [
+    { name: "DSN", ...secretRef("hydra-dsn") },
+    { name: "SECRETS_SYSTEM", ...secretRef("hydra-system-secret") },
+  ];
+
+  new k8s.batch.v1.Job(
+    "mcp-gateway-hydra-migrate",
+    {
+      metadata: {
+        name: pulumi.interpolate`mcp-gateway-hydra-migrate-${hydraSystemSecret.result.apply((s) => s.slice(0, 6))}`,
+        namespace,
+      },
+      spec: {
+        backoffLimit: 5,
+        template: {
+          spec: {
+            restartPolicy: "OnFailure",
+            containers: [
+              {
+                name: "migrate",
+                image: hydraImage,
+                args: ["migrate", "sql", "-e", "--yes"],
+                env: [{ name: "DSN", ...secretRef("hydra-dsn") }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    { dependsOn: [secret], provider },
+  );
+
+  new k8s.apps.v1.Deployment(
+    "mcp-gateway-hydra",
+    {
+      metadata: { name: "mcp-gateway-hydra", namespace },
+      spec: {
+        replicas: 1,
+        selector: { matchLabels: { app: "mcp-gateway-hydra" } },
+        template: {
+          metadata: { labels: { app: "mcp-gateway-hydra" } },
+          spec: {
+            containers: [
+              {
+                name: "hydra",
+                image: hydraImage,
+                args: ["serve", "all"],
+                env: [
+                  ...hydraEnvCommon,
+                  {
+                    name: "URLS_SELF_ISSUER",
+                    value: `https://${conf.authHostname}`,
+                  },
+                  {
+                    name: "URLS_LOGIN",
+                    value: `https://${conf.hostname}/auth/login`,
+                  },
+                  {
+                    name: "URLS_CONSENT",
+                    value: `https://${conf.hostname}/auth/consent`,
+                  },
+                  {
+                    name: "WEBFINGER_OIDC_DISCOVERY_CLIENT_REGISTRATION_URL",
+                    value: `https://${conf.hostname}/register`,
+                  },
+                  { name: "SERVE_COOKIES_SAME_SITE_MODE", value: "Lax" },
+                  // Traefik terminates TLS and forwards http in-cluster; trust
+                  // it so Hydra treats the connection as secure (no --dev).
+                  {
+                    name: "SERVE_TLS_ALLOW_TERMINATION_FROM",
+                    value: "0.0.0.0/0",
+                  },
+                  { name: "OAUTH2_EXPOSE_INTERNAL_ERRORS", value: "false" },
+                ],
+                ports: [
+                  { name: "public", containerPort: 4444 },
+                  { name: "admin", containerPort: 4445 },
+                ],
+                readinessProbe: {
+                  httpGet: { path: "/health/ready", port: 4445 },
+                  initialDelaySeconds: 5,
+                  periodSeconds: 10,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    { provider },
+  );
+
+  // Public API — named `<x>-service` so createIngressRoute can front it (port
+  // 80 → 4444). Reached by Claude at auth.<domain>.
+  new k8s.core.v1.Service(
+    "mcp-gateway-hydra-public-service",
+    {
+      metadata: { name: "mcp-gateway-hydra-service", namespace },
+      spec: {
+        selector: { app: "mcp-gateway-hydra" },
+        ports: [{ port: 80, targetPort: 4444 }],
+      },
+    },
+    opts,
+  );
+  // Admin API — ClusterIP, internal only. NEVER fronted by an IngressRoute.
+  new k8s.core.v1.Service(
+    "mcp-gateway-hydra-admin-service",
+    {
+      metadata: { name: "mcp-gateway-hydra-admin", namespace },
+      spec: {
+        selector: { app: "mcp-gateway-hydra" },
+        ports: [{ port: 4445, targetPort: 4445 }],
+      },
+    },
+    opts,
+  );
+
+  // --- Backend MCPs (one Deployment + Service each) ---
+  for (const b of conf.backends) {
+    new k8s.apps.v1.Deployment(
+      `mcp-gateway-backend-${b.id}`,
+      {
+        metadata: { name: `mcp-gateway-mcp-${b.id}`, namespace },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: `mcp-gateway-mcp-${b.id}` } },
+          template: {
+            metadata: { labels: { app: `mcp-gateway-mcp-${b.id}` } },
+            spec: {
+              containers: [
+                {
+                  name: "mcp",
+                  image: b.image,
+                  args: b.args,
+                  ports: [{ containerPort: b.port }],
+                },
+              ],
+            },
+          },
+        },
+      },
+      opts,
+    );
+    new k8s.core.v1.Service(
+      `mcp-gateway-backend-${b.id}-service`,
+      {
+        metadata: { name: `mcp-gateway-mcp-${b.id}`, namespace },
+        spec: {
+          selector: { app: `mcp-gateway-mcp-${b.id}` },
+          ports: [{ port: b.port, targetPort: b.port }],
+        },
+      },
+      opts,
+    );
+  }
+
+  // --- MCP registry ConfigMap ---
+  const registry = conf.backends.map((b) => ({
+    id: b.id,
+    name: b.name,
+    backend: `http://${svcDns(`mcp-gateway-mcp-${b.id}`)}:${b.port}${b.path}`,
+    credential_header: b.credentialHeader,
+    ...(b.keyHelpUrl && { key_help_url: b.keyHelpUrl }),
+    ...(b.keyHint && { key_hint: b.keyHint }),
+  }));
+  const registryCm = new k8s.core.v1.ConfigMap(
+    "mcp-gateway-registry",
+    {
+      metadata: { name: "mcp-gateway-registry", namespace },
+      data: { "mcps.json": JSON.stringify(registry, null, 2) },
+    },
+    opts,
+  );
+
+  // --- Gateway (the Rust app) ---
+  new k8s.apps.v1.Deployment(
+    "mcp-gateway",
+    {
+      metadata: { name: "mcp-gateway", namespace },
+      spec: {
+        replicas: conf.replicas,
+        selector: { matchLabels: { app: "mcp-gateway" } },
+        template: {
+          metadata: {
+            labels: { app: "mcp-gateway" },
+            annotations: {
+              // Roll when the registry changes.
+              "jaritanet/registry-hash": registryCm.metadata.name,
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: "mcp-gateway",
+                image: `${conf.image.repository}:${conf.image.tag}`,
+                imagePullPolicy: conf.image.pullPolicy ?? "Always",
+                ports: [{ name: "http", containerPort: 8080 }],
+                env: [
+                  { name: "BIND_ADDR", value: "0.0.0.0:8080" },
+                  { name: "PUBLIC_URL", value: `https://${conf.hostname}` },
+                  {
+                    name: "HYDRA_ISSUER",
+                    value: `https://${conf.authHostname}`,
+                  },
+                  {
+                    name: "HYDRA_ADMIN_URL",
+                    value: `http://${svcDns("mcp-gateway-hydra-admin")}:4445`,
+                  },
+                  { name: "MCP_REGISTRY", value: "/etc/mcp-gateway/mcps.json" },
+                  { name: "DATABASE_URL", ...secretRef("database-url") },
+                  { name: "TOKEN_ENC_KEY", ...secretRef("token-enc-key") },
+                  {
+                    name: "GH_CLIENT_ID",
+                    value: pulumi.output(secrets.githubClientId),
+                  },
+                  {
+                    name: "GH_CLIENT_SECRET",
+                    ...secretRef("gh-client-secret"),
+                  },
+                  {
+                    name: "GH_ALLOWED",
+                    value: pulumi.output(secrets.githubAllowed),
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "registry",
+                    mountPath: "/etc/mcp-gateway",
+                    readOnly: true,
+                  },
+                ],
+                readinessProbe: {
+                  httpGet: { path: "/healthz", port: 8080 },
+                  initialDelaySeconds: 5,
+                  periodSeconds: 10,
+                },
+                resources: { limits: conf.limits },
+                securityContext: { allowPrivilegeEscalation: false },
+              },
+            ],
+            volumes: [
+              {
+                name: "registry",
+                configMap: { name: registryCm.metadata.name },
+              },
+            ],
+          },
+        },
+      },
+    },
+    { provider },
+  );
+  new k8s.core.v1.Service(
+    "mcp-gateway-service",
+    {
+      metadata: { name: "mcp-gateway-service", namespace },
+      spec: {
+        selector: { app: "mcp-gateway" },
+        ports: [{ port: 80, targetPort: 8080 }],
+      },
+    },
+    opts,
+  );
+}

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -333,7 +333,12 @@ export function createMcpGateway(
           replicas: 1,
           selector: { matchLabels: { app: `mcp-gateway-mcp-${b.id}` } },
           template: {
-            metadata: { labels: { app: `mcp-gateway-mcp-${b.id}` } },
+            metadata: {
+              labels: {
+                app: `mcp-gateway-mcp-${b.id}`,
+                "mcp-gateway/role": "backend",
+              },
+            },
             spec: {
               containers: [
                 {
@@ -465,6 +470,46 @@ export function createMcpGateway(
       spec: {
         selector: { app: "mcp-gateway" },
         ports: [{ port: 80, targetPort: 8080 }],
+      },
+    },
+    opts,
+  );
+
+  // --- NetworkPolicies: lock sensitive internal pods to their callers ---
+  // Backends trust the gateway-injected credential header and have no auth of
+  // their own, so only the gateway may reach them.
+  new k8s.networking.v1.NetworkPolicy(
+    "mcp-gateway-backends-netpol",
+    {
+      metadata: { name: "mcp-gateway-backends", namespace },
+      spec: {
+        podSelector: { matchLabels: { "mcp-gateway/role": "backend" } },
+        policyTypes: ["Ingress"],
+        ingress: [
+          { from: [{ podSelector: { matchLabels: { app: "mcp-gateway" } } }] },
+        ],
+      },
+    },
+    opts,
+  );
+  // Postgres holds the encrypted credential vault + Hydra's DB — only the
+  // gateway and Hydra connect to it.
+  new k8s.networking.v1.NetworkPolicy(
+    "mcp-gateway-postgres-netpol",
+    {
+      metadata: { name: "mcp-gateway-postgres", namespace },
+      spec: {
+        podSelector: { matchLabels: { app: pgHost } },
+        policyTypes: ["Ingress"],
+        ingress: [
+          {
+            from: [
+              { podSelector: { matchLabels: { app: "mcp-gateway" } } },
+              { podSelector: { matchLabels: { app: "mcp-gateway-hydra" } } },
+            ],
+            ports: [{ protocol: "TCP", port: 5432 }],
+          },
+        ],
       },
     },
     opts,


### PR DESCRIPTION
Deploys the MCP gateway (code in `radiosilence/fastmail-mcp-service`) to the cluster: an OAuth-fronted gateway that lets Fastmail (and future MCPs) be added to Claude as custom connectors. Verified working end-to-end on a dev tunnel already.

## Shape
Bespoke Pulumi module (`modules/mcp-gateway.ts`) — the generic `createService` template can't express `secretKeyRef` env, a migrate Job, or a ConfigMap, all of which this needs. It stands up, in the `jaritanet` namespace:

- **postgres** — one instance, hostPath PV on `oldboy`, `initdb` ConfigMap creates the `hydra` DB alongside the app DB.
- **hydra** (Ory) — a `migrate sql` Job runs first; `serve all` (no `--dev`); public API on `auth.<domain>`, **admin API in-cluster only** (never routed).
- **backends** — one Deployment+Service per registered MCP (fastmail → `fastmail-cli mcp --http`).
- **gateway** — the axum app on `mcp.<domain>`, with an `mcps.json` ConfigMap.

Postgres password, Hydra `SECRETS_SYSTEM`, and `TOKEN_ENC_KEY` are generated via `@pulumi/random` and wired with `secretKeyRef` — they never leave the cluster.

## Config & secrets
- Hostnames are **blank in this public repo**, injected in CI from `MCP_HOSTNAME` / `MCP_AUTH_HOSTNAME` (same pattern as `BLIT_HOSTNAME`) — source reveals no URL.
- GitHub OAuth creds + login allowlist via `GH_CLIENT_ID` / `GH_CLIENT_SECRET` / `GH_ALLOWED` env (`GH_` because GitHub Actions reserves `GITHUB_`).
- ci-cd.yml + preview.yml updated to set/pass both.

## ⚠️ Do not merge until
1. **Images exist in GHCR**: `ghcr.io/radiosilence/mcp-gateway` (build workflow in fastmail-mcp-service) and `ghcr.io/radiosilence/fastmail-cli:mcp`. `pulumi up` will fail to pull otherwise (preview is fine).
2. **Secrets set** on this repo: `MCP_HOSTNAME`, `MCP_AUTH_HOSTNAME`, `GH_CLIENT_ID`, `GH_CLIENT_SECRET`, `GH_ALLOWED`.
3. Ideally **fastmail-cli #35 merged + released** so the sidecar pins a tag, not a branch.

Review the `pulumi preview` diff below before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)