### PR TITLE
fix(mcp-gateway): order Postgres → migrate → Hydra/gateway

### DIFF
--- a/packages/infra/src/conf.ts
+++ b/packages/infra/src/conf.ts
@@ -12,6 +12,7 @@ const { data, error } = ConfSchema.safeParse({
   externalIp: config.get("externalIp"),
   fastmail: config.requireObject("fastmail"),
   gateway: config.getObject("gateway"),
+  mcpGateway: config.getObject("mcpGateway"),
   services: config.requireObject("services"),
   traefik: config.requireObject("traefik"),
   zones: config.requireObject("zones"),

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -138,7 +138,7 @@ export function createMcpGateway(
     opts,
   );
 
-  new k8s.apps.v1.Deployment(
+  const pgDeploy = new k8s.apps.v1.Deployment(
     "mcp-gateway-postgres",
     {
       metadata: { name: pgHost, namespace },
@@ -209,7 +209,7 @@ export function createMcpGateway(
     { name: "SECRETS_SYSTEM", ...secretRef("hydra-system-secret") },
   ];
 
-  new k8s.batch.v1.Job(
+  const migrateJob = new k8s.batch.v1.Job(
     "mcp-gateway-hydra-migrate",
     {
       metadata: {
@@ -233,7 +233,9 @@ export function createMcpGateway(
         },
       },
     },
-    { dependsOn: [secret], provider },
+    // Needs Postgres reachable (readinessProbe = pg_isready) before it can run
+    // the Hydra schema migration.
+    { dependsOn: [secret, pgDeploy], provider },
   );
 
   new k8s.apps.v1.Deployment(
@@ -293,7 +295,8 @@ export function createMcpGateway(
         },
       },
     },
-    { provider },
+    // Serve only after the schema migration has completed.
+    { dependsOn: [migrateJob], provider },
   );
 
   // Public API — named `<x>-service` so createIngressRoute can front it (port
@@ -460,7 +463,8 @@ export function createMcpGateway(
         },
       },
     },
-    { provider },
+    // The gateway's own tables live in the same Postgres; wait for it.
+    { dependsOn: [pgDeploy], provider },
   );
   new k8s.core.v1.Service(
     "mcp-gateway-service",

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -213,7 +213,9 @@ export function createMcpGateway(
     "mcp-gateway-hydra-migrate",
     {
       metadata: {
-        name: pulumi.interpolate`mcp-gateway-hydra-migrate-${hydraSystemSecret.result.apply((s) => s.slice(0, 6))}`,
+        // Suffix ties the Job name to the secret (Jobs are immutable, so a new
+        // secret forces a new Job). Lowercase it — k8s names are RFC 1123.
+        name: pulumi.interpolate`mcp-gateway-hydra-migrate-${hydraSystemSecret.result.apply((s) => s.slice(0, 6).toLowerCase())}`,
         namespace,
       },
       spec: {

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -47,22 +47,21 @@ export function createMcpGateway(
   const svcDns = (name: string) => `${name}.${namespace}.svc.cluster.local`;
 
   // --- Generated secrets ---
-  const pgPassword = new random.RandomPassword(
-    "mcp-gateway-pg",
-    { length: 32, special: false },
-    opts,
-  );
+  // NB: random.* resources use the default provider — passing the k8s provider
+  // here makes Pulumi look for `random:...` types on the k8s provider and fail
+  // with "unrecognized resource type".
+  const pgPassword = new random.RandomPassword("mcp-gateway-pg", {
+    length: 32,
+    special: false,
+  });
   const hydraSystemSecret = new random.RandomPassword(
     "mcp-gateway-hydra-system",
     { length: 48, special: false },
-    opts,
   );
   // 32 random bytes, base64 — the token-encryption master key.
-  const tokenEncKey = new random.RandomBytes(
-    "mcp-gateway-token-enc",
-    { length: 32 },
-    opts,
-  );
+  const tokenEncKey = new random.RandomBytes("mcp-gateway-token-enc", {
+    length: 32,
+  });
 
   const pgUser = "fastmail";
   const pgDb = "fastmail_mcp";


### PR DESCRIPTION
## What

Adds explicit `dependsOn` ordering to the mcp-gateway module so resources come up in the only order that can actually work:

**Postgres Deployment → Hydra migrate Job → Hydra serve; gateway waits on Postgres.**

## Why

The first real deploy (#104) wedged. With no `dependsOn`, Pulumi created all four Deployments + the migrate Job concurrently and awaited each Deployment's rollout. Hydra and the gateway can't become ready until Postgres exists — so their readiness awaits blocked, saturated Pulumi's workers, and it **never came back to create the Postgres Deployment or the migrate Job**. Observed live: Postgres/migrate absent after 8 min, Hydra logging `no route to host` / `connection timed out` to `mcp-gateway-postgres:5432`, deploy hung.

## Verify

Deploy is green and, in-cluster: Postgres ready first, migrate Job `Completed`, Hydra `/health/ready` passing, gateway `/healthz` passing, then `mcp.blit.cc` / `auth.blit.cc` resolve and serve.

## Note

Requires the `ghcr.io/radiosilence/jaritanet-mcp-gateway` package to be pullable by the cluster (public, or via imagePullSecret) — separate from this ordering fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)