### PR TITLE
fix(mcp-gateway): dynamic PVC for Postgres (drop hand-rolled local PV)

### DIFF
--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -25,10 +25,9 @@ export const McpGatewayConfSchema = z.object({
   hydraTag: z.string().default("v2.2.0"),
   replicas: z.number().default(2),
   limits: LimitsSchema.default({ cpu: "500m", memory: "256Mi" }),
-  nodeAffinityHostname: z.string().default("oldboy"),
-  postgresHostPath: z
-    .string()
-    .default("/var/lib/jaritanet/mcp-gateway-postgres"),
+  // Postgres uses the cluster's default StorageClass unless set — a few tiny
+  // tables, so (unlike the media services) we don't pin them to a disk path.
+  postgresStorageClass: z.string().optional(),
   backends: z.array(McpBackendSchema).default([]),
 });
 

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -109,7 +109,9 @@ export function createMcpGateway(
         storageClassName: conf.postgresStorageClass,
       },
     },
-    opts,
+    // An immutable spec change (e.g. storageClassName) forces a replace; delete
+    // the old claim first, else the fixed name collides with the replacement.
+    { deleteBeforeReplace: true, provider },
   );
 
   const pgDeploy = new k8s.apps.v1.Deployment(

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -95,35 +95,10 @@ export function createMcpGateway(
     opts,
   );
 
-  const pgPv = new k8s.core.v1.PersistentVolume(
-    "mcp-gateway-postgres-pv",
-    {
-      spec: {
-        accessModes: ["ReadWriteOnce"],
-        capacity: { storage: "2Gi" },
-        local: { path: conf.postgresHostPath },
-        nodeAffinity: {
-          required: {
-            nodeSelectorTerms: [
-              {
-                matchExpressions: [
-                  {
-                    key: "kubernetes.io/hostname",
-                    operator: "In",
-                    values: [conf.nodeAffinityHostname],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        persistentVolumeReclaimPolicy: "Retain",
-        storageClassName: "manual",
-        volumeMode: "Filesystem",
-      },
-    },
-    opts,
-  );
+  // Dynamically provisioned by the cluster's default StorageClass (on jaritanet
+  // that's microk8s-hostpath, which creates the volume wherever it likes). No
+  // hand-rolled PV / node pinning — these are tiny tables, we just want them to
+  // persist. `undefined` storageClassName means "use the default SC".
   const pgPvc = new k8s.core.v1.PersistentVolumeClaim(
     "mcp-gateway-postgres-pvc",
     {
@@ -131,8 +106,7 @@ export function createMcpGateway(
       spec: {
         accessModes: ["ReadWriteOnce"],
         resources: { requests: { storage: "2Gi" } },
-        storageClassName: "manual",
-        volumeName: pgPv.metadata.name,
+        storageClassName: conf.postgresStorageClass,
       },
     },
     opts,


### PR DESCRIPTION
## What

Postgres storage was a hand-rolled `local` PersistentVolume pinned via nodeAffinity to a made-up host path (`/var/lib/jaritanet/mcp-gateway-postgres`). `local` volumes never auto-create their path, so the pod hung in `ContainerCreating` / `FailedMount` on first deploy — the path only exists because it was `mkdir`'d on the node by hand.

This switches Postgres to a **dynamically-provisioned PVC** on the cluster's default StorageClass (`microk8s-hostpath`), which creates the volume wherever it likes. No PV, no node pinning, no manual dir.

## Why

The `local` PVs elsewhere (`files`→`/srv/files`, `navidrome`→`/mnt/kontent/music`) are deliberate — large data on specific disks. Postgres here is a few tiny tables (Hydra + gateway sessions/credentials) that just need to persist; where they live is irrelevant. Reproducible for self-hosters (any default SC), no hand-made directory to depend on.

Replaces the `postgresHostPath` / `nodeAffinityHostname` config with an optional `postgresStorageClass` override (unset → cluster default SC).

## Verify

Deploy green; Postgres pod binds a fresh dynamic PVC and reaches Ready, migrate Job `Complete`, Hydra + gateway reconnect (both auto-migrate their schema idempotently on boot, so the empty new volume re-populates). `mcp.blit.cc` discovery chain still serves.

## Note

The current prod volume has no real data yet (fresh Hydra schema + empty gateway tables), so replacing the PVC now is a no-op data-wise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)