### PR TITLE
chore(mcp-gateway): caldav-cli v0.4.0

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -43,7 +43,7 @@ config:
       # in one request instead of an MCP session handshake.
       - id: caldav
         name: Calendar (CalDAV)
-        image: "ghcr.io/radiosilence/caldav-cli:v0.3.0"
+        image: "ghcr.io/radiosilence/caldav-cli:v0.4.0"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
The caldav backend is running v0.3.0, which has no `setDefaultCalendar` — the dashboard's calendar picker (jaritanet-mcp-gateway#8) can store a choice but can't point the account's own default at it.

v0.4.0 adds the write surface (radiosilence/caldav-cli#11) and keeps `--graphql` and the `X-CalDAV-Calendar` header the gateway already relies on, so nothing else moves.

Verified the tag carries both, and that the image is published and multi-arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN