### PR TITLE
fix(mcp-gateway): key the calendar picker by id, and carry the sync mutation

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -72,7 +72,12 @@ config:
             secret: false
             required: false
             hint: "Blank = whichever calendar your calendar app uses"
-            optionsQuery: "{ options: calendars(first: 100) { nodes { value: name label: name disabled: readOnly isDefault } } }"
+            # Keyed by id, not display name: two calendars can share a name
+            # (this account has two "Family"), so a name is ambiguous — and the
+            # value is what rides X-CalDAV-Calendar into every write.
+            # supportsEvents marks the task-only collections nothing can land in.
+            optionsQuery: "{ options: calendars(first: 100) { nodes { value: id label: name disabled: readOnly isDefault supportsEvents } } }"
+            syncMutation: "mutation($value: String!) { setDefaultCalendar(id: $value) { success error } }"
   jaritanet:gateway:
     # xray shares :443; traffic that doesn't match a client falls back to
     # dest (local rathole https). serverName is injected from BLIT_HOSTNAME

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -13,6 +13,8 @@ export const McpCredentialFieldSchema = z.object({
   required: z.boolean().optional(),
   /** Query whose results become this field's suggestions in the dashboard. */
   optionsQuery: z.string().optional(),
+  /** Mutation run after a save, telling the backend what was picked. */
+  syncMutation: z.string().optional(),
 });
 
 /**

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -364,6 +364,7 @@ export function createMcpGateway(
         ...(f.hint && { hint: f.hint }),
         ...(f.required !== undefined && { required: f.required }),
         ...(f.optionsQuery && { options_query: f.optionsQuery }),
+        ...(f.syncMutation && { sync_mutation: f.syncMutation }),
       })),
     }),
     ...(b.graphqlPath && {


### PR DESCRIPTION
Prod's MCP registry is generated from this config, not from the gateway repo's `mcps.json` — so two fixes made there never reached the cluster. The deployed dashboard is still offering calendars by name:

```
$ curl https://mcp.blit.cc/dashboard/caldav/options/calendar
[{"label":"Bootbag","value":"Bootbag"}, …]
```

## Why id, not name

The chosen value is what rides `X-CalDAV-Calendar` into every write. Names aren't unique — this account has two calendars called **Family** — so by name, picking between them is a coin flip over where events land. Ids are unique; the label stays the display name, so the dropdown reads the same.

Verified against a live account that the two "Family" entries have distinct ids, and that one of them reports `supportsEvents: false` — a task-only collection nothing can land in. That now comes back so the dashboard can show it without offering it; caldav-cli refuses those outright (*"holds no events, so nothing would ever land in it"*).

## Why syncMutation

`McpCredentialFieldSchema` had no way to express it, so prod could store a pick but never tell the account about it. The gateway already reads `sync_mutation`; this is the config half.

## What this does not depend on

The header path works regardless. Confirmed against a live backend that `createEvent` resolves the header ahead of the account's own default — a header naming a calendar that doesn't exist fails looking for it rather than quietly falling back:

```
X-CalDAV-Calendar: __probe_does_not_exist__
→ { success: false, error: "Calendar not found: __probe_does_not_exist__" }
```

So precedence is: explicit argument → our stored id → the server's `isDefault` → first writable. The sync is a courtesy to other CalDAV clients, not what makes the gateway work.

## Verifying

`tsc -p packages/infra`, `vitest run` (13 pass), `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN