### PR TITLE
chore(mcp-gateway): caldav-cli v0.5.0, fastmail-cli v3.2.0

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -31,7 +31,7 @@ config:
       # backends would silently drift from the gateway they serve.
       - id: fastmail
         name: Fastmail
-        image: "ghcr.io/radiosilence/fastmail-cli:v3.1.2"
+        image: "ghcr.io/radiosilence/fastmail-cli:v3.2.0"
         args: ["mcp", "--http", "0.0.0.0:8080"]
         port: 8080
         path: "/mcp"
@@ -43,7 +43,7 @@ config:
       # in one request instead of an MCP session handshake.
       - id: caldav
         name: Calendar (CalDAV)
-        image: "ghcr.io/radiosilence/caldav-cli:v0.4.0"
+        image: "ghcr.io/radiosilence/caldav-cli:v0.5.0"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
**Draft: both tags are unreleased.** Latest are caldav-cli v0.4.0 and fastmail-cli v3.1.3. Un-draft when they publish; until then the pods would `ImagePullBackOff`.

## What's in them

**caldav-cli v0.5.0** carries radiosilence/caldav-cli#14: `calendar` with no id ignored the calendar the gateway sends per user, so it reported the account's own default while `createEvent` wrote to the user's chosen one. Wrong for every hosted caller — a model that checks before writing got a wrong answer.

**fastmail-cli v3.2.0** is the binary rename plus what landed since v3.1.2 (currently pinned here; v3.1.3 shipped in between).

## The rename doesn't affect this repo

Both CLIs renamed their binary (`caldav-cli` → `caldav`, `fastmail-cli` → `fastmail`). Nothing here changes: image names are repo names, and `args: ["mcp", "--http", …]` are passed to each image's own entrypoint, which those repos updated. The gateway's compose Dockerfiles *did* hardcode the old names — handled separately in radiosilence/jaritanet-mcp-gateway#11, which drops them in favour of these same published images.

## Verifying

`tsc -p packages/infra`, `vitest run` (13 pass).

Worth a look after rollout: pick a calendar in the dashboard and confirm the pod serves `/graphql` and honours `X-CalDAV-Calendar` — both already verified against v0.4.0 in production, so this is a regression check rather than a first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN