### PR TITLE
feat(mcp-gateway): public backends, and the folk archive as the first

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -78,6 +78,19 @@ config:
             # supportsEvents marks the task-only collections nothing can land in.
             optionsQuery: "{ options: calendars(first: 100) { nodes { value: id label: name disabled: readOnly isDefault supportsEvents } } }"
             syncMutation: "mutation($value: String!) { setDefaultCalendar(id: $value) { success error } }"
+      # The English folk archive. The first backend needing no credentials at
+      # all: mainlynorfolk.info is a public website, so there is nothing to
+      # authenticate to and nothing to store. `public: true` says so
+      # explicitly — an omitted credential block is a schema error, not a
+      # licence to front an MCP unauthenticated.
+      - id: folk
+        name: Folk (Mainly Norfolk)
+        image: "ghcr.io/radiosilence/mainlynorfolk-cli:v0.1.0"
+        args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
+        port: 8080
+        path: "/mcp"
+        graphqlPath: "/graphql"
+        public: true
   jaritanet:gateway:
     # xray shares :443; traffic that doesn't match a client falls back to
     # dest (local rathole https). serverName is injected from BLIT_HOSTNAME

--- a/packages/infra/src/conf.schemas.test.ts
+++ b/packages/infra/src/conf.schemas.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { McpBackendSchema } from "./conf.schemas.ts";
+
+/**
+ * A backend declares how the gateway gets its credentials: one header, several
+ * fields, or nothing at all. Exactly one — the rule exists so a backend that
+ * declares none is a deploy-time error rather than an MCP quietly fronted
+ * without a key.
+ */
+describe("McpBackendSchema credentials", () => {
+  const base = {
+    id: "x",
+    name: "X",
+    image: "ghcr.io/example/x:v1",
+  };
+
+  it("accepts the single-header shorthand", () => {
+    const b = McpBackendSchema.parse({ ...base, credentialHeader: "X-Token" });
+    expect(b.public).toBeUndefined();
+  });
+
+  it("accepts a multi-field backend", () => {
+    const b = McpBackendSchema.parse({
+      ...base,
+      fields: [{ id: "user", label: "User", header: "X-User" }],
+    });
+    expect(b.fields).toHaveLength(1);
+  });
+
+  it("accepts a public backend with no credentials", () => {
+    const b = McpBackendSchema.parse({ ...base, public: true });
+    expect(b.public).toBe(true);
+    expect(b.credentialHeader).toBeUndefined();
+    expect(b.fields).toBeUndefined();
+  });
+
+  it("rejects a backend declaring nothing", () => {
+    // The typo case: silence must not be read as "needs no credentials".
+    expect(() => McpBackendSchema.parse(base)).toThrow();
+  });
+
+  it("rejects public alongside a credential", () => {
+    // One of the two is a mistake, and guessing which would either drop a
+    // credential or put a connect form on a backend that has nothing to store.
+    expect(() =>
+      McpBackendSchema.parse({
+        ...base,
+        public: true,
+        credentialHeader: "X-Token",
+      }),
+    ).toThrow();
+    expect(() =>
+      McpBackendSchema.parse({
+        ...base,
+        public: true,
+        fields: [{ id: "user", label: "User", header: "X-User" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects both credential forms together", () => {
+    expect(() =>
+      McpBackendSchema.parse({
+        ...base,
+        credentialHeader: "X-Token",
+        fields: [{ id: "user", label: "User", header: "X-User" }],
+      }),
+    ).toThrow();
+  });
+
+  it("treats public: false as no declaration at all", () => {
+    // Otherwise `public: false` would satisfy the rule while declaring nothing.
+    expect(() => McpBackendSchema.parse({ ...base, public: false })).toThrow();
+  });
+});

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -22,8 +22,13 @@ export const McpCredentialFieldSchema = z.object({
  *
  * `credentialHeader` is the shorthand for the common one-token case;
  * `fields` covers backends wanting several values (CalDAV needs a username, an
- * app password, and a server URL). Exactly one of the two, matching what the
+ * app password, and a server URL); `public` covers a backend fronting something
+ * public, which needs neither. Exactly one of the three, matching what the
  * gateway's registry accepts.
+ *
+ * `public` is opt-in rather than inferred from an absent credential block: a
+ * backend declaring no credentials is far more often a typo than a decision,
+ * and the deploy should fail rather than quietly front an unauthenticated MCP.
  */
 export const McpBackendSchema = z
   .object({
@@ -35,6 +40,8 @@ export const McpBackendSchema = z
     path: z.string().default("/mcp"),
     credentialHeader: z.string().optional(),
     fields: z.array(McpCredentialFieldSchema).optional(),
+    /** Takes no credentials at all — see the note above. */
+    public: z.boolean().optional(),
     /**
      * Path to a plain GraphQL endpoint the backend serves beside its MCP one,
      * for the dashboard's own lookups. In-cluster only — never proxied.
@@ -43,9 +50,12 @@ export const McpBackendSchema = z
     keyHelpUrl: z.string().optional(),
     keyHint: z.string().optional(),
   })
-  .refine((b) => !!b.credentialHeader !== !!b.fields?.length, {
-    message: "set credentialHeader or fields, never both",
-  });
+  .refine(
+    (b) =>
+      [!!b.credentialHeader, !!b.fields?.length, !!b.public].filter(Boolean)
+        .length === 1,
+    { message: "set exactly one of credentialHeader, fields, or public" },
+  );
 
 /** The MCP Gateway stack (gateway + Hydra + Postgres + backends). */
 export const McpGatewayConfSchema = z.object({

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -353,6 +353,7 @@ export function createMcpGateway(
     name: b.name,
     backend: `http://${svcDns(`mcp-gateway-mcp-${b.id}`)}:${b.port}${b.path}`,
     // snake_case: this is the gateway's on-disk registry format, not ours.
+    ...(b.public && { public: true }),
     ...(b.credentialHeader && { credential_header: b.credentialHeader }),
     ...(b.fields?.length && {
       fields: b.fields.map((f) => ({


### PR DESCRIPTION
Adds a third credential form for backend MCPs — `public: true`, for one fronting something public — and registers [mainlynorfolk-cli](https://github.com/radiosilence/mainlynorfolk-cli) as `folk` using it.

## What it does

`McpBackendSchema` required exactly one of `credentialHeader` or `fields`. A backend that needs neither had no way to be expressed, so a credential-less MCP could not be deployed at all.

`public: true` is now a third mutually-exclusive form. The rule is still "exactly one of the three", so:

- declaring nothing is **still an error** — silence is far more often a typo than a decision, and it should fail the deploy rather than quietly front an MCP with no key
- `public` alongside a credential is an error — one of them is a mistake, and guessing which would either drop a credential or put a connect form on a backend with nothing to store
- `public: false` is treated as no declaration at all, so it can't satisfy the rule by accident

The module emits `public: true` into the registry ConfigMap; the gateway reads it from there ([jaritanet-mcp-gateway#12](https://github.com/radiosilence/jaritanet-mcp-gateway/pull/12)) and renders the MCP already connected — connector URL, no form, no Disconnect.

The OAuth login is unchanged and still gates the route. Public means *this backend needs no key of its own*, not that the route is open.

## Load-bearing decisions

- **`folk` serves `--graphql` beside `/mcp`**, like `caldav`, so the dashboard reaches the same schema a model sees rather than paying for an MCP session handshake.
- **Pinned to `v0.1.0`, not `:main`**, matching the convention the other two backends already follow — a floating tag with the default pull policy leaves a running pod on whatever it first pulled.

## How to verify

`bunx vitest run` — 20 pass, 7 of them new in `conf.schemas.test.ts` covering every branch of the rule above. Type check and lint clean via the pre-commit hooks.

`packages/infra/Pulumi.main.yaml` parses with three backends: `fastmail`, `caldav`, `folk`.

## Dependency

**Blocked on `ghcr.io/radiosilence/mainlynorfolk-cli:v0.1.0` existing.** That repo's CI builds multi-arch images and cuts the release tag on push to main; the `check` job has passed and the image/release jobs are still running as of opening this. Don't deploy until the tag resolves — Pulumi will happily create a Deployment that then sits in `ImagePullBackOff`.

Pairs with [jaritanet-mcp-gateway#12](https://github.com/radiosilence/jaritanet-mcp-gateway/pull/12), which teaches the gateway itself the same flag. That one should land first — this config is inert without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5whuNANbZ3Ve35rNwUxPN