### PR TITLE
chore(mcp-gateway): caldav-cli v0.5.1

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -43,7 +43,7 @@ config:
       # in one request instead of an MCP session handshake.
       - id: caldav
         name: Calendar (CalDAV)
-        image: "ghcr.io/radiosilence/caldav-cli:v0.5.0"
+        image: "ghcr.io/radiosilence/caldav-cli:v0.5.1"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
Picks up [caldav-cli v0.5.1](https://github.com/radiosilence/caldav-cli/releases/tag/v0.5.1),
which fixes every write to an *existing* event failing on iCloud.

Mutations resolve their target by UID, and iCloud answers a `calendar-query`
`prop-filter` on `UID` with `412`. Reads filter on a time range instead, so a
hosted caller could list an event and then get `Event not found` trying to
change it — `updateEvent`, `deleteEvent`, `moveEvent`, `deleteOccurrence` and
`respondToInvite` were all affected. Lookups now address the UID-named resource
directly, and fall back to matching client-side when a server refuses the
filter.

Image-tag bump only; nothing about the deployment shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8SyrLxXBVrDppq335eNeM