### PR TITLE
chore(mcp-gateway): mainlynorfolk-cli v0.1.1

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -85,7 +85,7 @@ config:
       # licence to front an MCP unauthenticated.
       - id: folk
         name: Folk (Mainly Norfolk)
-        image: "ghcr.io/radiosilence/mainlynorfolk-cli:v0.1.0"
+        image: "ghcr.io/radiosilence/mainlynorfolk-cli:v0.1.1"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
One-line pin bump for the `folk` backend.

[mainlynorfolk-cli#8](https://github.com/radiosilence/mainlynorfolk-cli/pull/8) fixes three data-quality bugs, all found by running the published `v0.1.0` image against the live archive rather than by any test:

- **All-caps labels lost their catalogue number** — `HMV DLP 1143` came back as a label with `catalogueNumber: null`. Four of Shirley Collins' first twelve releases were affected; zero after the fix.
- **`Roud -` was stored as the reference number `-`** — junk that looks like data, and which `Song.sameRoud` fed straight back into the archive's own search, where it matched nothing.
- **Artist life dates were part of the name** — `"Ewan MacColl(25 January 1915 - 22 October 1989)"`, which then followed him into every attribution naming him.

## Verify

Pulumi preview should show only the `folk` backend Deployment's image changing. No schema or module changes — `public: true` and the rest of the entry are untouched.

## Dependency

Needs `ghcr.io/radiosilence/mainlynorfolk-cli:v0.1.1`, which that repo's CI publishes on merge to main (merged; the release and image jobs were still running when this was opened). Confirm the tag resolves before deploying, or the Deployment will sit in `ImagePullBackOff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5whuNANbZ3Ve35rNwUxPN