### PR TITLE
feat(mcp-gateway): front tfl-cli as a backend

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -91,6 +91,26 @@ config:
         path: "/mcp"
         graphqlPath: "/graphql"
         public: true
+      # TfL needs no key at all — anonymous callers get 50 requests/minute,
+      # which is the same data, not a degraded tier. A key raises that to 500,
+      # so the field is offered and optional: the proxy treats a missing
+      # credential as fine and the backend simply runs anonymously, which means
+      # this works the moment someone logs in.
+      - id: tfl
+        name: TfL (London transport)
+        image: "ghcr.io/radiosilence/tfl-cli:v0.2.0"
+        args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
+        port: 8080
+        path: "/mcp"
+        graphqlPath: "/graphql"
+        keyHelpUrl: "https://api-portal.tfl.gov.uk/profile"
+        fields:
+          - id: app_key
+            label: "TfL app key (optional — raises the rate limit)"
+            header: "X-Tfl-App-Key"
+            secret: true
+            required: false
+            hint: "32 hex characters"
   jaritanet:gateway:
     # xray shares :443; traffic that doesn't match a client falls back to
     # dest (local rathole https). serverName is injected from BLIT_HOSTNAME


### PR DESCRIPTION
Adds [tfl-cli](https://github.com/radiosilence/tfl-cli) as a gateway backend: London transport as a GraphQL API — live arrivals, line status, disruptions, journey planning and Santander Cycles.

## The one decision worth reviewing

The app key is an **optional** field, rather than `credentialHeader` (required) or `public: true`.

TfL's model fits neither. Anonymous callers get 50 requests/minute of exactly the same data — not a degraded tier — and a key raises it to 500. The proxy already treats an absent credential as non-fatal, so an optional field means the backend works the moment someone OAuth-logs-in, and rewards anyone who pastes a key without demanding one first.

`public: true` looks closest but is wrong: it forbids declaring credentials at all, so nobody could ever raise their own limit.

## Verifying

- The entry parses against `McpGatewayConfSchema` (checked by feeding `Pulumi.main.yaml` through the real zod schema, not just by eye — `required: false` on a field and an all-optional `fields` array are both accepted).
- `bun run typecheck:infra` and `bun run test` pass.
- The image runs `mcp --http 0.0.0.0:8080 --graphql`, matching the caldav/folk pattern, and serves `/mcp` plus `/graphql` for dashboard lookups.

Once deployed, `{ disruptedLines { name statuses { description } } }` against `/tfl` is the quickest smoke test — it needs no arguments and no key.

## Dependency

Pinned to `ghcr.io/radiosilence/tfl-cli:v0.2.0`. **Do not merge until that tag exists** — the release is building now; I'll confirm on this PR when it's published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXYBpEL46ZUMbfDUuEaqF6