### PR TITLE
chore(mcp-gateway): tfl-cli v0.2.1

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -98,7 +98,7 @@ config:
       # this works the moment someone logs in.
       - id: tfl
         name: TfL (London transport)
-        image: "ghcr.io/radiosilence/tfl-cli:v0.2.0"
+        image: "ghcr.io/radiosilence/tfl-cli:v0.2.1"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
Bumps the `tfl` backend to [v0.2.1](https://github.com/radiosilence/tfl-cli/releases/tag/v0.2.1).

Journey planning and Santander Cycles were added in v0.2.0 but never made it into the tool descriptions or server instructions, which were written before those features existed. A model connected to the gateway could therefore use arrivals and line status but had no way to learn it could plan a journey or find a bike.

The tool description is the load-bearing part — it is always loaded and decides whether the server is reached for at all, where the instructions only arrive per session once something has already prompted a connection.

No schema or behaviour change; the deployed v0.2.0 works, it just under-advertises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXYBpEL46ZUMbfDUuEaqF6