### PR TITLE
chore(mcp-gateway): tfl-cli v0.5.0

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -98,7 +98,7 @@ config:
       # this works the moment someone logs in.
       - id: tfl
         name: TfL (London transport)
-        image: "ghcr.io/radiosilence/tfl-cli:v0.2.1"
+        image: "ghcr.io/radiosilence/tfl-cli:v0.5.0"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
Bumps the `tfl` backend from `v0.2.1` to [v0.5.0](https://github.com/radiosilence/tfl-cli/releases/tag/v0.5.0), which is three releases of work the deployment has been missing.

**v0.3.0** — the remaining six domains: roads and road disruptions, air quality, licensed taxi operators, EV charge connectors, car parks, and 2019 casualty records.

**v0.3.1** — an audit found the schema capped query *depth* but not *width*. `linesByMode(modes: ["bus"]) { stopPoints }` is two levels deep and 676 lines wide, so one tool call would have fired 676 concurrent requests at TfL — enough to exhaust the rate limit instantly and plausibly earn a block. Now refused before a single request. **This is the main reason to deploy.**

**v0.4.0** — stops in travel order (`Line.route`), stop-level disruptions, and reference data cached process-wide so the vocabulary a model reads before every query stops costing requests.

**v0.5.0** — `directionTo` and `canReachOnLine`, plus `now` (London local time with offset, since every TfL timestamp omits the zone).

## Verifying

Nothing about the deployment shape changes — same image repo, same args, same optional-credential field. The only edit is the tag.

Once deployed, `{ now { local tubeLikelyRunning } roads { displayName status } }` exercises both a no-request field and a new domain, and needs no key.

## Note on the preview diff

The VPN churn (`singbox-profile-guest1 delete` and friends) is baseline noise on every PR in this repo — #112, #113, #114 and #115 all showed it and all deployed to `115 unchanged`. Tracked and closed as not-worth-chasing in radiosilence/tfl-cli#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXYBpEL46ZUMbfDUuEaqF6