### PR TITLE
chore(mcp-gateway): tfl-cli v0.5.1

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -98,7 +98,7 @@ config:
       # this works the moment someone logs in.
       - id: tfl
         name: TfL (London transport)
-        image: "ghcr.io/radiosilence/tfl-cli:v0.5.0"
+        image: "ghcr.io/radiosilence/tfl-cli:v0.5.1"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
Bumps `tfl` from v0.5.0 to [v0.5.1](https://github.com/radiosilence/tfl-cli/releases/tag/v0.5.1) — ten fixes from two audit passes (correctness/concurrency and LLM-ergonomics, run as separate lenses).

## Worth deploying for

**A failed fetch no longer reads as a confident empty answer.** Two mechanisms, same shape: `load_batch`'s retry path discarded every error and returned `Ok` regardless, so a revoked key produced nulls rather than a failure; and a per-key failure was dropped from the loader's map, which every resolver turned into an empty list. That second one is the ordinary shape of a multi-stop query — one stop's arrivals timing out beside working siblings reported "no trains due", and a failed disruption fetch reported **good service**, with the successful siblings lending the response an air of authority.

**`StopDisruption.isBlocked` could only ever return `false`** — both branches of its expression produced the same value, so "is this station closed" answered confidently wrong behind a trustworthy-looking name. Replaced with `isClosed`/`closureText` off the fields that actually carry closure state.

**The MCP instructions had gone stale.** They still listed only the domains that existed two releases ago, so nothing signalled that roads, air quality, taxis, charge points, car parks or collision history were reachable at all.

Plus: `vehicleArrivals` now chunks at TfL's documented 25 rather than claiming a batching it never did; `accidents` orders by date when given no coordinate rather than claiming "nearest first" over an arbitrary slice; `journey`'s `accessibility` lists all six of TfL's accepted values; `roadSeverities` added since roads grade in words where lines use numbers.

## Verifying

No deployment shape change — same image repo, args and optional-credential field; only the tag moves.

`{ now { local } roads { displayName status } airQuality { current { band } } }` exercises three domains and needs no key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXYBpEL46ZUMbfDUuEaqF6