### PR TITLE
fix(mcp-gateway): the Postgres role and database are not Fastmail's

### DIFF
--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -63,8 +63,11 @@ export function createMcpGateway(
     length: 32,
   });
 
-  const pgUser = "fastmail";
-  const pgDb = "fastmail_mcp";
+  // One instance, two databases: the gateway's vault and Hydra's. They share it
+  // deliberately — the two must agree on who a subject is, and a second
+  // datastore would be a second thing to back up for three tables.
+  const pgUser = "mcpgw";
+  const pgDb = "mcp_gateway";
   const pgHost = "mcp-gateway-postgres";
   const databaseUrl = pulumi.interpolate`postgres://${pgUser}:${pgPassword.result}@${svcDns(pgHost)}:5432/${pgDb}`;
   const hydraDsn = pulumi.interpolate`postgres://${pgUser}:${pgPassword.result}@${svcDns(pgHost)}:5432/hydra?sslmode=disable`;


### PR DESCRIPTION
The stack was named when the gateway only fronted Fastmail: role `fastmail`,
database `fastmail_mcp`. It fronts four MCPs now and is called mcp-gateway
everywhere else. `mcpgw` / `mcp_gateway`.

## Why Postgres stays

The gateway's three tables are pure key-value — `credentials` (sub+mcp_id →
ciphertext), `sessions`, `oauth_flows` — so it would fit Redis or SQLite. Hydra
is the constraint: it speaks postgres, mysql, cockroach or sqlite, and nothing
else. SQLite does work on the stock `oryd/hydra:v2.2.0` image (verified: migrate,
serve, and discovery all fine), but SQLite's idea of sharing is filesystem
locking, so one file means one node — Hydra and the gateway would have to share
a pod, dropping the gateway to a single replica and tying its lifecycle to
Hydra's. Two pods sharing a datastore is a database server. One instance, two
databases, as now.

## Before deploying

`POSTGRES_DB` and `POSTGRES_USER` only apply to an empty data directory, so the
existing volume keeps the old names until they are renamed. Nothing is lost by
doing it in place — stored credentials and Hydra's registered clients both
survive, so no connector needs re-adding in Claude.

```sh
# 1. the gateway must be off the database before it can be renamed
kubectl -n jaritanet scale deploy/mcp-gateway --replicas=0

# 2. rename, as the superuser, connected to a *different* database
kubectl -n jaritanet exec deploy/mcp-gateway-postgres -- \
  psql -U fastmail -d postgres \
    -c 'ALTER DATABASE fastmail_mcp RENAME TO mcp_gateway;' \
    -c 'ALTER ROLE fastmail RENAME TO mcpgw;'

# 3. deploy this PR, then bring it back (Pulumi restores replicas: 2 on refresh)
kubectl -n jaritanet scale deploy/mcp-gateway --replicas=2
kubectl -n jaritanet rollout restart deploy/mcp-gateway-hydra
```

The role rename is safe on PG16: the password-clearing hazard applies to md5
hashes, which are salted with the username, and 16 defaults to scram-sha-256,
which is not.

Hydra needs the explicit restart because its DSN arrives by `secretKeyRef`, and
a Secret changing under a pod does not roll it — the same class of thing as the
registry ConfigMap in #118. Its open connections keep working on the renamed
role in the meantime, so there is no window where it is broken.

## Ordering

Independent of #118 — different lines in the same file, no conflict. Land in
either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN