### PR TITLE
chore(mcp-gateway): folk is mainlynorfolk-mcp v1.0.0, with no `mcp` argument

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -89,8 +89,8 @@ config:
       # licence to front an MCP unauthenticated.
       - id: folk
         name: Folk (Mainly Norfolk)
-        image: "ghcr.io/radiosilence/mainlynorfolk-cli:v0.1.1"
-        args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
+        image: "ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0"
+        args: ["--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"
         graphqlPath: "/graphql"


### PR DESCRIPTION
[mainlynorfolk-mcp#9](https://github.com/radiosilence/mainlynorfolk-mcp/pull/9) dropped the CLI and renamed the project. The binary *is* the MCP server now rather than having an `mcp` subcommand, so two things move together for the `folk` entry:

- image `ghcr.io/radiosilence/mainlynorfolk-cli:v0.1.1` → `ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0`
- args `["mcp", "--http", "0.0.0.0:8080", "--graphql"]` → `["--http", "0.0.0.0:8080", "--graphql"]`

They can't be split: the old args against the new image fail to parse, and the old image name no longer resolves after the repo rename.

`fastmail`, `caldav` and `tfl` still have a CLI and keep their `mcp` argument — untouched.

## Why 1.0.0 rather than a patch

The upstream change removes the entire CLI surface (~1,000 lines) and reshapes the crate to one path: GraphQL resolver → DataLoader → API call. Nothing about the *MCP* behaviour changes — same two tools, same schema, same `public: true` registry entry — so this is a rename plus an argument change from the gateway's point of view.

## Verify

Pulumi preview should show only the `folk` backend Deployment changing: image and args. No schema or module changes.

## Dependency

Needs `ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0`. That repo's CI publishes it on the merge that renamed it — merged, with the release and image jobs still running when this was opened. **Confirm the tag resolves before deploying**, or the Deployment will sit in `ImagePullBackOff`.

Pairs with [mcp-gateway#16](https://github.com/radiosilence/mcp-gateway/pull/16), which makes the same change to the compose topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5whuNANbZ3Ve35rNwUxPN