### PR TITLE
chore(mcp-gateway): tfl-mcp v1.0.1

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -102,8 +102,8 @@ config:
       # this works the moment someone logs in.
       - id: tfl
         name: TfL (London transport)
-        image: "ghcr.io/radiosilence/tfl-cli:v0.5.1"
-        args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
+        image: "ghcr.io/radiosilence/tfl-mcp:v1.0.1"
+        args: ["--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"
         graphqlPath: "/graphql"


### PR DESCRIPTION
Two changes that must land together.

**The image moves path.** The project renamed `tfl-cli` → [`tfl-mcp`](https://github.com/radiosilence/tfl-mcp): it was never really a CLI. Its siblings earn the suffix — you do want to send mail from a terminal — but nobody checks the tube from a shell when they could ask an assistant.

**The `mcp` argument goes.** Serving is the default now, so it is `tfl --http …`, with deliberately no compatibility alias. Tag and args therefore can no longer move independently, hence one edit.

## Scoping

`fastmail`, `caldav` and `folk` carry the byte-identical args line and still take the `mcp` subcommand. A document-wide find-and-replace stops three unrelated pods from starting — the diff here is deliberately two lines, both inside the `tfl` entry.

## What v1.0.1 carries over v0.5.1

- **Every read takes the same path** — resolver, loader, request. The argument-less feeds went straight at the client, so two branches of one query each fetched them. They share a loader now: `{ a: modes { name } b: modes { name } }` costs one request rather than two.
- The `arrivals`/`status`/`search` subcommands are gone, along with the GraphQL string-escaping they needed so a station called `King's Cross` could not end a literal early.

## Verifying

`{ now { local } roads { displayName status } airQuality { current { band } } }` exercises three domains and needs no key. If the args were wrong the pod fails to start rather than misbehaving, so a clean rollout is the check.

## Note on the version

Pinned to **v1.0.1**, not v1.0.0. The 1.0.0 tag was cut from the last commit before the rename, so its image published to the old path. v1.0.1 is identical in behaviour and is the first release under `ghcr.io/radiosilence/tfl-mcp`.

**Do not merge until that tag exists** — it is building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXYBpEL46ZUMbfDUuEaqF6