### PR TITLE
ci: poll every MCP's releases, not just Navidrome and Traefik

### DIFF
--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -38,6 +38,10 @@ jobs:
             repo: "traefik/traefik-helm-chart"
             path: '.config["jaritanet:traefik"].chartVersion'
             value: "{version}"
+          - app: "MCP Gateway"
+            repo: "radiosilence/mcp-gateway"
+            path: '.config["jaritanet:mcpGateway"].image.tag'
+            value: "v{version}"
           - app: "Fastmail MCP"
             repo: "radiosilence/fastmail-cli"
             path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "fastmail") | .image)'

--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -16,18 +16,44 @@ jobs:
       contents: write
       issues: write
     strategy:
+      # Each entry commits and pushes to main, so they run one at a time — in
+      # parallel all but the first push is a non-fast-forward, and the update is
+      # silently lost until tomorrow's run.
+      max-parallel: 1
+      fail-fast: false
+      # `path` is the yq expression naming what to rewrite, and `value` what to
+      # write, with {version} substituted from the upstream release. Carrying
+      # both here rather than deriving them means a new entry is a row, and the
+      # step below never grows another special case — the MCPs in particular are
+      # image references inside a list, not a bare tag field, which the old
+      # "everything lives under jaritanet:services" assumption could not express.
       matrix:
         include:
           - app: "Navidrome"
-            type: "docker"
             repo: "deluan/navidrome"
-            config_key: "navidrome"
-            config_field: "args.image.tag"
+            path: '.config["jaritanet:services"].navidrome.args.image.tag'
+            value: "{version}"
+          # Chart tags look like "traefik-34.5.0"; the prefix strip below handles it.
           - app: "Traefik"
-            type: "helm"
             repo: "traefik/traefik-helm-chart"
-            config_key: "traefik"
-            config_field: "chartVersion"
+            path: '.config["jaritanet:traefik"].chartVersion'
+            value: "{version}"
+          - app: "Fastmail MCP"
+            repo: "radiosilence/fastmail-cli"
+            path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "fastmail") | .image)'
+            value: "ghcr.io/radiosilence/fastmail-cli:v{version}"
+          - app: "CalDAV MCP"
+            repo: "radiosilence/caldav-cli"
+            path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "caldav") | .image)'
+            value: "ghcr.io/radiosilence/caldav-cli:v{version}"
+          - app: "Folk MCP"
+            repo: "radiosilence/mainlynorfolk-mcp"
+            path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "folk") | .image)'
+            value: "ghcr.io/radiosilence/mainlynorfolk-mcp:v{version}"
+          - app: "TfL MCP"
+            repo: "radiosilence/tfl-mcp"
+            path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "tfl") | .image)'
+            value: "ghcr.io/radiosilence/tfl-mcp:v{version}"
 
     steps:
       - name: Generate App Token
@@ -48,72 +74,56 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
 
       - name: Check for Updates
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          YQ_PATH: ${{ matrix.path }}
+          VALUE_TEMPLATE: ${{ matrix.value }}
         run: |
-          set -e
+          set -euo pipefail
 
           CONFIG_PATH="packages/infra/Pulumi.main.yaml"
           REPO="${{ matrix.repo }}"
-          TYPE="${{ matrix.type }}"
-          CONFIG_KEY="${{ matrix.config_key }}"
-          CONFIG_FIELD="${{ matrix.config_field }}"
 
-          echo "Checking for updates to $REPO ($TYPE)"
+          echo "Checking $REPO"
 
-          if [[ "$TYPE" == "docker" ]]; then
-            # GitHub releases -> Docker image tag
-            LATEST_RELEASE=$(curl -s -L \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/$REPO/releases/latest")
-            LATEST_VERSION=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
-            LATEST_VERSION="${LATEST_VERSION#v}"
-          elif [[ "$TYPE" == "helm" ]]; then
-            # Helm chart repo -> chart version
-            LATEST_RELEASE=$(curl -s -L \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/$REPO/releases/latest")
-            LATEST_VERSION=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
-            # Traefik chart tags are like "traefik-34.5.0"
-            LATEST_VERSION="${LATEST_VERSION#traefik-}"
-            LATEST_VERSION="${LATEST_VERSION#v}"
-          fi
+          TAG=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
+          # Upstreams disagree on how a release is spelled: chart repos prefix
+          # the chart name, most prefix a v, some neither. Normalise to the bare
+          # version and let each entry's template put back what it needs.
+          VERSION="${TAG#traefik-}"
+          VERSION="${VERSION#v}"
 
-          if [[ -z "$LATEST_VERSION" || "$LATEST_VERSION" == "null" ]]; then
-            echo "Error: Could not fetch latest version"
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "Could not read a release tag for $REPO"
             exit 1
           fi
 
-          echo "Latest version: $LATEST_VERSION"
+          NEW_VALUE="${VALUE_TEMPLATE//\{version\}/$VERSION}"
+          CURRENT_VALUE=$(yq eval "$YQ_PATH" "$CONFIG_PATH")
 
-          # Determine yq path based on config key type
-          if [[ "$CONFIG_KEY" == "traefik" ]]; then
-            YQ_PATH='.config["jaritanet:'$CONFIG_KEY'"]["'$CONFIG_FIELD'"]'
-          else
-            YQ_PATH='.config["jaritanet:services"]["'$CONFIG_KEY'"].'$CONFIG_FIELD
-          fi
-
-          CURRENT_VERSION=$(yq eval "$YQ_PATH" "$CONFIG_PATH")
-
-          if [[ -z "$CURRENT_VERSION" ]]; then
-            echo "Error: Could not find current version at $YQ_PATH"
+          # An empty read means the path no longer matches anything — a renamed
+          # id or a restructured config. Fail rather than write a second copy
+          # somewhere, or silently stop tracking this one.
+          if [[ -z "$CURRENT_VALUE" || "$CURRENT_VALUE" == "null" ]]; then
+            echo "Nothing at $YQ_PATH — the config moved and this entry needs updating"
             exit 1
           fi
 
-          echo "Current version: $CURRENT_VERSION"
+          echo "current: $CURRENT_VALUE"
+          echo "latest:  $NEW_VALUE"
 
-          if [[ "$CURRENT_VERSION" == "$LATEST_VERSION" ]]; then
+          if [[ "$CURRENT_VALUE" == "$NEW_VALUE" ]]; then
             echo "Already up to date."
             exit 0
           fi
 
-          echo "Update available: $CURRENT_VERSION -> $LATEST_VERSION"
+          yq eval "($YQ_PATH) = \"$NEW_VALUE\"" -i "$CONFIG_PATH"
 
-          yq eval "$YQ_PATH = \"$LATEST_VERSION\"" -i "$CONFIG_PATH"
-
-          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
-          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
-          echo "VERSION_UPDATED=true" >> $GITHUB_ENV
+          {
+            echo "CURRENT_VALUE=$CURRENT_VALUE"
+            echo "NEW_VALUE=$NEW_VALUE"
+            echo "VERSION_UPDATED=true"
+          } >> "$GITHUB_ENV"
 
       - name: Commit Changes
         if: env.VERSION_UPDATED == 'true'
@@ -122,7 +132,7 @@ jobs:
           git config --local user.name "GitHub Action"
 
           git add packages/infra/Pulumi.main.yaml
-          git commit -m "chore: update ${{ matrix.app }} from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}"
+          git commit -m "chore: update ${{ matrix.app }} to ${{ env.NEW_VALUE }}"
 
           git push
 
@@ -130,12 +140,12 @@ jobs:
         if: env.VERSION_UPDATED == 'true'
         run: |
           gh issue create \
-            --title "${{ matrix.app }} Updated: ${{ env.CURRENT_VERSION }} -> ${{ env.LATEST_VERSION }}" \
+            --title "${{ matrix.app }} updated" \
             --body "${{ matrix.app }} has been automatically updated.
 
           **Details:**
-          - Previous: \`${{ env.CURRENT_VERSION }}\`
-          - New: \`${{ env.LATEST_VERSION }}\`
+          - Previous: \`${{ env.CURRENT_VALUE }}\`
+          - New: \`${{ env.NEW_VALUE }}\`
           - Repository: ${{ matrix.repo }}
           - Updated at: $(date -u)
 

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -20,10 +20,10 @@ config:
       cpu: "500m"
       memory: "256Mi"
     image:
-      # tag is auto-bumped to sha-<short> by mcp-gateway's ci-cd
-      # (update-deployment job); `main` is the initial pointer.
+      # Bumped by update-apps.yml, which watches mcp-gateway's releases. It used
+      # to be a sha pushed here by that repo's CI on every build.
       repository: "ghcr.io/radiosilence/mcp-gateway"
-      tag: sha-9dd0e1f
+      tag: v0.1.0
       pullPolicy: "Always"
     # Each entry is both a backend pod and its entry in the registry the gateway
     # boots from (MCP_REGISTRY) — declared once, since a registry naming a pod

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -47,7 +47,7 @@ config:
       # in one request instead of an MCP session handshake.
       - id: caldav
         name: Calendar (CalDAV)
-        image: "ghcr.io/radiosilence/caldav-cli:v0.5.1"
+        image: "ghcr.io/radiosilence/caldav-cli:v0.5.2"
         args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
The four MCP backends were pinned by hand, and it showed — caldav sits on
`v0.5.1` against a released `v0.5.2`. They are the components that move fastest
and the only ones nothing was watching.

## Why the workflow needed changing first

The step derived its yq path from the config key: `traefik` was special-cased
and everything else assumed to live under `jaritanet:services`. An MCP is
neither — it's an `image:` string inside a list keyed by `id`, so the old shape
could not name it at all.

`path` (a yq expression) and `value` (a template with `{version}`) now come from
the matrix. Adding a component is a row; the step never grows another branch.
Both existing entries keep their exact behaviour, including the `traefik-`
prefix strip.

## Verified against the real config

Every path read correctly with yq v4.53.3:

| entry | reads |
|---|---|
| Navidrome | `0.63.2` |
| Traefik | `41.0.2` |
| Fastmail | `ghcr.io/radiosilence/fastmail-cli:v3.2.0` |
| CalDAV | `ghcr.io/radiosilence/caldav-cli:v0.5.1` |
| Folk | `ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0` |
| TfL | `ghcr.io/radiosilence/tfl-mcp:v1.0.1` |

And a write through `select()` — the part most worth doubting — is surgical:
bumping caldav to v0.5.2 changed exactly one line and left every comment intact.

## Two fixes that came with it

- **`max-parallel: 1`.** Every entry commits and pushes to main. Run in
  parallel, all but the first push is a non-fast-forward and the update is
  silently lost until tomorrow. Latent with two entries; near-certain with six.
- **An unmatched path is now an error.** Previously a path matching nothing
  gave an empty read; with `select(.id == ...)` a renamed id would just stop
  tracking that component, quietly and forever.

## Dependency

The Folk row depends on radiosilence/mainlynorfolk-mcp#10.
`ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0` has never been published — 1.0.0
was released before the repo was renamed, so the images went to the
`mainlynorfolk-cli` package. The folk pod is in ImagePullBackOff on that pin
right now, serving from the previous ReplicaSet. That PR cuts v1.0.1 under the
correct name; this row will then bump the pin to it.

## mcp-gateway joins too

It is in the matrix, and its pin moves from `sha-9dd0e1f` to `v0.1.0`.

**Merge radiosilence/mcp-gateway#20 first.** That removes the job which pushes a
sha into this repo. Until it lands, both it and this poll write
`mcpGateway.image.tag` and would take turns overwriting each other.

The pin change is not the rollback it resembles: the two commits between
`sha-9dd0e1f` and `v0.1.0` touch `docker-compose.yml` and the README only.
Nothing under `src/`, `Cargo.toml`, `Cargo.lock`, `templates/`, `migrations/` or
`Dockerfile` differs, so it is the same image under a name that says what it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN
