### PR TITLE
chore(mcp-gateway): tfl-mcp v1.1.0

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -102,7 +102,7 @@ config:
       # this works the moment someone logs in.
       - id: tfl
         name: TfL (London transport)
-        image: "ghcr.io/radiosilence/tfl-mcp:v1.0.1"
+        image: "ghcr.io/radiosilence/tfl-mcp:v1.1.0"
         args: ["--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
Bumps `tfl` to [v1.1.0](https://github.com/radiosilence/tfl-mcp/releases/tag/v1.1.0).

**Station crowding** — `StopPoint.crowding` for right now, `crowdingOn(day:)` for a typical day in quarter-hours. Answers "is Oxford Circus hell at the moment" and "when is the quietest time to travel".

None of it appears in TfL's Swagger document; the endpoint the spec *does* describe returns a stop point with no crowding in it, which is why it first looked withdrawn rather than undocumented.

Also fixes the serve flags, which needed spelling out in full — `--graphiql` alone used to start the stdio server and look like a hang. No change to what `--http 0.0.0.0:8080 --graphql` means, so the args here are untouched.

## Verifying

```graphql
{ stopPoint(id: "940GZZLUKSX") { crowding { relativeToNormal description } } }
```

Note the figure is relative to that station's own normal, not a headcount, and `dataAvailable` is separate — many stops have no sensors, and a missing figure is not a quiet station.

Diff is one line, scoped to the `tfl` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXYBpEL46ZUMbfDUuEaqF6