### PR TITLE
chore(mcp-gateway): folk pins v1.0.2

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -89,7 +89,7 @@ config:
       # licence to front an MCP unauthenticated.
       - id: folk
         name: Folk (Mainly Norfolk)
-        image: "ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0"
+        image: "ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.2"
         args: ["--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
**The currently-pinned `folk` image cannot be pulled.**

`v1.0.0` was released while the repository was still named `mainlynorfolk-cli`, so CI — which takes `IMAGE_NAME` from `github.repository` — pushed its images to the `mainlynorfolk-cli` package. The repository was renamed afterwards, and **a GHCR package does not follow its repository**, so `ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0` refers to nothing:

```
$ docker pull ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0
Error response from daemon: ... not found
$ docker pull ghcr.io/radiosilence/mainlynorfolk-cli:v1.0.0
ghcr.io/radiosilence/mainlynorfolk-cli:v1.0.0          # the images went here
```

`main` pins the name that doesn't resolve, so a deploy today would leave the folk Deployment in `ImagePullBackOff`. Nothing has broken yet because nothing has redeployed.

## What this pins

**v1.0.2**, which is the first tag published under the correct package name:

- `v1.0.1` — no code change, exists purely to republish under `mainlynorfolk-mcp`
- `v1.0.2` — `--browser` now implies `--graphiql` implies `--graphql`, matching `caldav-cli` and `fastmail-cli`

The args are unchanged and already correct: `["--http", "0.0.0.0:8080", "--graphql"]`. `--http` mounts MCP and `--graphql` serves the endpoint the dashboard queries; neither is affected by the implication change, which only adds inference where flags were previously rejected.

## Verify

Pulumi preview should show only the folk Deployment's image changing. Confirm the tag resolves first:

```
docker pull ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.2
```

## Cleanup, not in this PR

The old `mainlynorfolk-cli` GHCR package still holds every image up to `v1.0.0` and is now orphaned. Worth deleting once this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5whuNANbZ3Ve35rNwUxPN