### PR TITLE
fix(mcp-gateway): pin folk to an image that exists

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -89,7 +89,7 @@ config:
       # licence to front an MCP unauthenticated.
       - id: folk
         name: Folk (Mainly Norfolk)
-        image: "ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0"
+        image: "ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.1"
         args: ["--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
The folk pod is in `ImagePullBackOff` and has been for a while — it is serving
from the previous ReplicaSet on `mainlynorfolk-cli:v0.1.1`, so folk works, but
nothing has rolled.

`ghcr.io/radiosilence/mainlynorfolk-mcp:v1.0.0` was never published. 1.0.0 was
released while that repo was still named `mainlynorfolk-cli`, so its images went
to the old package; the rename came afterwards and a GHCR package does not
follow its repository.

`v1.0.1` was cut under the correct name (radiosilence/mainlynorfolk-mcp#10) and
resolves — verified against the registry:

```
mainlynorfolk-mcp:v1.0.0  404
mainlynorfolk-mcp:v1.0.1  200
```

This is what the nightly poll would write anyway; it just stops waiting for it,
since folk is degraded now and the poll rewrite is still in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN