### PR TITLE
chore(mcp-gateway): tfl-mcp v1.2.0

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -102,7 +102,7 @@ config:
       # this works the moment someone logs in.
       - id: tfl
         name: TfL (London transport)
-        image: "ghcr.io/radiosilence/tfl-mcp:v1.1.0"
+        image: "ghcr.io/radiosilence/tfl-mcp:v1.2.0"
         args: ["--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"


### PR DESCRIPTION
Bumps `tfl` to [v1.2.0](https://github.com/radiosilence/tfl-mcp/releases/tag/v1.2.0).

**Scheduled departures** — `Line.timetable(from:, direction:)`, so *when is the last train* has an answer. Closes the last real capability gap.

The blocker was documentation rather than a missing endpoint: `direction` is a query parameter absent from TfL's Swagger document, and the docs imply a path segment that 404s. Without it TfL replies asking which way you meant — at HTTP 200, so it cannot be told from success by status code.

TfL's hour runs past 23 after midnight, so the last Friday train from Vauxhall arrives as hour 27. Reported as `03:13` with `isNextDay: true` rather than a train at twenty-seven o'clock.

One line, scoped to the `tfl` entry — the other backends share an identical args line and a document-wide replace would stop them starting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXYBpEL46ZUMbfDUuEaqF6