### PR TITLE
ci: close the summary issue over REST

### DIFF
--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -183,7 +183,11 @@ jobs:
             fi
             url=$(gh issue create --title "$title" --body "$details
           [Run]($RUN_URL)")
-            gh issue close "$url" --reason completed >/dev/null
+            # REST, not `gh issue close`: that goes through the GraphQL
+            # closeIssue mutation, which the app token is refused for even
+            # though it may create the issue over REST perfectly well.
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/${url##*/}" \
+              -f state=closed -f state_reason=completed >/dev/null
             echo "recorded at $url"
           else
             echo "nothing to update"


### PR DESCRIPTION
Run 30195714243 did all its work correctly — pushed MCP Gateway v0.1.1, Folk MCP
v1.1.0 and TfL MCP v1.2.0 — then failed on the final line:

```
GraphQL: Resource not accessible by integration (closeIssue)
```

`gh issue close` uses the GraphQL `closeIssue` mutation, which the app token is
refused, even though it creates the issue over REST perfectly happily. So the
run went red and left the issue open — exactly the backlog noise that
consolidating to one closed issue per run was meant to stop.

Closing via the REST endpoint the token already demonstrably reaches. The issue
number comes off the URL `gh issue create` prints.

Checked with `bash -n` against the step as the workflow yields it.

Issues #132, #134 and #136 were left open by this bug and are closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN