### PR TITLE
ci: close the summary issue with the workflow token, and never fail over it

### DIFF
--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Update tracked versions
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The app installation can open an issue but is refused when amending
+          # one, so closing uses the workflow's own token — this job already
+          # grants that issues:write.
+          ISSUE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -183,11 +187,12 @@ jobs:
             fi
             url=$(gh issue create --title "$title" --body "$details
           [Run]($RUN_URL)")
-            # REST, not `gh issue close`: that goes through the GraphQL
-            # closeIssue mutation, which the app token is refused for even
-            # though it may create the issue over REST perfectly well.
-            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/${url##*/}" \
-              -f state=closed -f state_reason=completed >/dev/null
+            # Best-effort. The updates are already pushed by this point, and a
+            # note left open is not worth reporting the run as failed over.
+            GH_TOKEN="$ISSUE_TOKEN" gh api -X PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/${url##*/}" \
+              -f state=closed -f state_reason=completed >/dev/null \
+              || echo "::warning::opened $url but could not close it"
             echo "recorded at $url"
           else
             echo "nothing to update"


### PR DESCRIPTION
Run 30204669071 pushed `MCP Gateway v0.1.1 -> v0.1.2` correctly and then went
red on `gh: Resource not accessible by integration (HTTP 403)`.

The app installation can *open* an issue but is refused when amending one —
over REST too, so #137 moved the failure rather than removing it. Issue #138 was
created and left open, exactly as before.

Two changes:

- **Close with `secrets.GITHUB_TOKEN`.** This job already declares
  `permissions: issues: write`, which elevates the workflow token regardless of
  the repository's read-only default. The app token stays for the git push,
  which is the thing it is actually needed for.
- **Never fail the run over it.** By the time the issue is written the updates
  are pushed and the cluster is rolling. A note left open is cosmetic; reporting
  the run as failed is not, and it has now twice made a successful update look
  like a broken one.

If the token still can't close it, you get a warning naming the issue instead of
a red run.

#138 closed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN