### PR TITLE
feat(mcp-gateway): tell the gateway how to check each credential

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -42,6 +42,14 @@ config:
         credentialHeader: "X-Fastmail-Token"
         keyHelpUrl: "https://app.fastmail.com/settings/security/tokens"
         keyHint: "fmu1-…"
+        # Re-runs the handshake rather than reading a cached client, so a
+        # revoked token is caught rather than reported as fine. Only a 401 is a
+        # verdict on the credential; rate limits and outages are UNREACHABLE.
+        verify:
+          query: "{ session { status } }"
+          path: session.status
+          ok: CONNECTED
+          rejected: INVALID_CREDENTIALS
       # CalDAV needs three values rather than one token, and serves plain
       # GraphQL beside /mcp so the dashboard can list an account's calendars
       # in one request instead of an MCP session handshake.
@@ -53,6 +61,12 @@ config:
         path: "/mcp"
         graphqlPath: "/graphql"
         keyHelpUrl: "https://appleid.apple.com"
+        # A cheap PROPFIND for the principal — never touches the calendar list.
+        verify:
+          query: "{ viewer { status } }"
+          path: viewer.status
+          ok: CONNECTED
+          rejected: INVALID_CREDENTIALS
         fields:
           - id: username
             label: "Apple ID / username"

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -53,6 +53,26 @@ export const McpSchema = z
     graphqlPath: z.string().optional(),
     keyHelpUrl: z.string().optional(),
     keyHint: z.string().optional(),
+    /**
+     * How to ask this backend whether the stored credentials still work, so the
+     * dashboard can distinguish one that is configured from one that is
+     * working. Omit it and the gateway claims nothing, which is the honest
+     * answer for a backend that authenticates nothing.
+     *
+     * `path`, `ok` and `rejected` are all optional because backends disagree
+     * about how to report bad auth: one that raises needs only a query, one
+     * that answers calmly with a status names the values. Nothing is ever
+     * reported as rejected unless `rejected` says which value means it — an
+     * unreachable server is not evidence about a password.
+     */
+    verify: z
+      .object({
+        query: z.string(),
+        path: z.string().optional(),
+        ok: z.string().optional(),
+        rejected: z.string().optional(),
+      })
+      .optional(),
   })
   .refine(
     (b) =>

--- a/packages/infra/src/modules/mcp-gateway.ts
+++ b/packages/infra/src/modules/mcp-gateway.ts
@@ -53,6 +53,7 @@ export function mcpRegistry(
         ...(m.graphqlPath && { graphql: url(m.graphqlPath) }),
         ...(m.keyHelpUrl && { key_help_url: m.keyHelpUrl }),
         ...(m.keyHint && { key_hint: m.keyHint }),
+        ...(m.verify && { verify: m.verify }),
       };
     }),
   );

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -6,7 +6,9 @@
       "$ref": "#/$defs/__schema0"
     }
   },
-  "required": ["config"],
+  "required": [
+    "config"
+  ],
   "description": "Schema for infrastructure configuration",
   "title": "Infrastructure Configuration Schema",
   "$defs": {
@@ -20,7 +22,9 @@
               "type": "string"
             }
           },
-          "required": ["accountId"]
+          "required": [
+            "accountId"
+          ]
         },
         "jaritanet:edges": {
           "type": "array",
@@ -71,7 +75,9 @@
                 "type": "string"
               }
             },
-            "required": ["name"]
+            "required": [
+              "name"
+            ]
           }
         },
         "jaritanet:exits": {
@@ -96,10 +102,14 @@
               "substrate": {
                 "default": "k8s",
                 "type": "string",
-                "enum": ["k8s"]
+                "enum": [
+                  "k8s"
+                ]
               }
             },
-            "required": ["name"]
+            "required": [
+              "name"
+            ]
           }
         },
         "jaritanet:gateway": {
@@ -152,7 +162,9 @@
                   "type": "string"
                 }
               },
-              "required": ["serverName"]
+              "required": [
+                "serverName"
+              ]
             }
           }
         },
@@ -229,13 +241,22 @@
                   },
                   "keyHint": {
                     "$ref": "#/$defs/__schema15"
+                  },
+                  "verify": {
+                    "$ref": "#/$defs/__schema16"
                   }
                 },
-                "required": ["id", "name", "image"]
+                "required": [
+                  "id",
+                  "name",
+                  "image"
+                ]
               }
             }
           },
-          "required": ["image"]
+          "required": [
+            "image"
+          ]
         },
         "jaritanet:traefik": {
           "type": "object",
@@ -248,7 +269,9 @@
               "type": "string"
             }
           },
-          "required": ["acmeEmail"]
+          "required": [
+            "acmeEmail"
+          ]
         },
         "jaritanet:services": {
           "type": "object",
@@ -310,7 +333,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"]
+                          "required": [
+                            "name",
+                            "value"
+                          ]
                         }
                       },
                       "initialDelaySeconds": {
@@ -381,7 +407,11 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["hostPath", "mountPath", "name"]
+                      "required": [
+                        "hostPath",
+                        "mountPath",
+                        "name"
+                      ]
                     }
                   },
                   "httpPort": {
@@ -479,18 +509,25 @@
                       "type": {
                         "default": "RollingUpdate",
                         "type": "string",
-                        "enum": ["Recreate", "RollingUpdate"]
+                        "enum": [
+                          "Recreate",
+                          "RollingUpdate"
+                        ]
                       }
                     }
                   }
                 },
-                "required": ["image"]
+                "required": [
+                  "image"
+                ]
               },
               "hostname": {
                 "type": "string"
               }
             },
-            "required": ["args"]
+            "required": [
+              "args"
+            ]
           }
         },
         "jaritanet:zones": {
@@ -502,7 +539,10 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": ["bluesky", "fastmail"]
+                  "enum": [
+                    "bluesky",
+                    "fastmail"
+                  ]
                 }
               },
               "name": {
@@ -512,7 +552,11 @@
                 "type": "string"
               }
             },
-            "required": ["modules", "name", "zoneId"]
+            "required": [
+              "modules",
+              "name",
+              "zoneId"
+            ]
           }
         },
         "jaritanet:fastmail": {
@@ -557,7 +601,9 @@
               "type": "string"
             }
           },
-          "required": ["did"]
+          "required": [
+            "did"
+          ]
         },
         "cloudflare:apiToken": {
           "type": "object",
@@ -566,7 +612,9 @@
               "type": "string"
             }
           },
-          "required": ["secure"]
+          "required": [
+            "secure"
+          ]
         },
         "hcloud:token": {
           "type": "object",
@@ -575,7 +623,9 @@
               "type": "string"
             }
           },
-          "required": ["secure"]
+          "required": [
+            "secure"
+          ]
         }
       },
       "required": [
@@ -616,7 +666,10 @@
           "type": "string"
         }
       },
-      "required": ["repository", "tag"]
+      "required": [
+        "repository",
+        "tag"
+      ]
     },
     "__schema3": {
       "type": "object",
@@ -691,7 +744,11 @@
             "type": "string"
           }
         },
-        "required": ["id", "label", "header"]
+        "required": [
+          "id",
+          "label",
+          "header"
+        ]
       }
     },
     "__schema12": {
@@ -705,6 +762,26 @@
     },
     "__schema15": {
       "type": "string"
+    },
+    "__schema16": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "ok": {
+          "type": "string"
+        },
+        "rejected": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ]
     }
   }
 }


### PR DESCRIPTION
Draft: the gateway side is radiosilence/mcp-gateway#37, and both MCPs need a
release before this does anything.

fastmail-cli and caldav-cli now both expose a status field that *answers* rather
than raises — `CONNECTED | INVALID_CREDENTIALS | UNREACHABLE` — so the dashboard
can tell a stored credential from a working one, and both from a backend that is
simply unwell.

```yaml
verify:
  query: "{ session { status } }"   # caldav: { viewer { status } }
  path: session.status
  ok: CONNECTED
  rejected: INVALID_CREDENTIALS
```

## This is safe to merge before the releases

An image that doesn't know the query answers with an error; the gateway never
reads an error as a rejection; the badge shows "configured" and claims nothing.
It starts reporting for real the moment the pins move — no coordination needed,
no window where it lies.

## Waiting on

| | merged | released | pinned |
|---|---|---|---|
| fastmail-cli #49 + #50 | ✅ | ❌ v3.2.1 | v3.2.1 |
| caldav-cli #21 | ✅ | ❌ v0.5.3 | v0.5.3 |

Both need a version bump in their own repo. The nightly poll picks the pins up
on its own after that — nothing to do here.

## TfL declares nothing

Deliberate, not an omission. It authenticates nothing; a key only raises its rate
limit. Anything else would be inventing a verdict.

Separately, TfL currently reads "Not configured" while working perfectly, which
mcp-gateway#37 makes more visible. That needs deciding there, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN