### PR TITLE
fix(mcp-gateway): give fastmail a GraphQL endpoint like every other MCP

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -36,9 +36,10 @@ config:
       - id: fastmail
         name: Fastmail
         image: "ghcr.io/radiosilence/fastmail-cli:v3.3.0"
-        args: ["mcp", "--http", "0.0.0.0:8080"]
+        args: ["mcp", "--http", "0.0.0.0:8080", "--graphql"]
         port: 8080
         path: "/mcp"
+        graphqlPath: "/graphql"
         credentialHeader: "X-Fastmail-Token"
         keyHelpUrl: "https://app.fastmail.com/settings/security/tokens"
         keyHint: "fmu1-…"


### PR DESCRIPTION
Fastmail was the **only** backend started without `--graphql`, and the only
registry entry without a `graphqlPath`:

| | args | graphqlPath |
|---|---|---|
| fastmail | `mcp --http 0.0.0.0:8080` | — |
| caldav | `mcp --http 0.0.0.0:8080 --graphql` | `/graphql` |
| folk | `--http 0.0.0.0:8080 --graphql` | `/graphql` |
| tfl | `--http 0.0.0.0:8080 --graphql` | `/graphql` |

So it was the only one the gateway couldn't reach over plain GraphQL. With no
endpoint configured, `backend::graphql` falls back to invoking the MCP `graphql`
*tool* — a different transport with a different response envelope.

That's why its credential check came back unknown and the dashboard showed
**Configured** rather than **Connected**, while caldav — which differs from it
in essentially nothing else — worked. The query itself was verified correct
against v3.3.0 by hand:

```json
{ "data": { "session": { "status": "CONNECTED" } } }
```

Nothing about Fastmail wanted the odd transport; it supports `--graphql` like
the rest. This also means its settings could use `optionsQuery` in future, which
the tool route made awkward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THmxM9BsQdHA9hexpQoGoN