### PR TITLE
ci: run preview on the same pulumi/actions as deploy

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -93,7 +93,7 @@ jobs:
           MCP_AUTH_HOSTNAME: ${{ secrets.MCP_AUTH_HOSTNAME }}
 
       - name: Preview
-        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
+        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
         with:
           command: preview
           stack-name: radiosilence/jaritanet/main


### PR DESCRIPTION
`preview.yml` pinned `pulumi/actions@8582a9e8` (v6) while `ci-cd.yml` pinned `@8e5e406f` (v7). A preview is only useful if it is produced by the same machinery as the deploy it predicts; two majors apart, it is a guess.

Pins preview to the v7 SHA already in use by `ci-cd.yml`.

## Verifying

The two `uses:` SHAs now match — `grep pulumi/actions .github/workflows/*.yml`. The preview job on this PR exercises the changed line directly: if v7 works here, it works.

This is a stopgap. #148 removes `pulumi/actions` from both workflows in favour of the Automation API, which is what stops them drifting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Unusj2hWcc6HarqBGVZade