### PR TITLE
ci: drive pulumi through the automation API

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -156,8 +156,6 @@ jobs:
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || github.event_name == 'schedule')
     runs-on: ubuntu-24.04
-    env:
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -179,62 +177,24 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
 
-      - name: Detect Server External IP
-        if: env.HCLOUD_TOKEN == ''
+      # Stack configuration, external-IP detection and the update itself all
+      # happen inside deploy.ts, so preview.yml runs the identical code path.
+      - name: Deploy
+        run: aube run deploy
         env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           KUBE_HOST: ${{ secrets.KUBE_HOST }}
           KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-        run: |
-          DECODED_TOKEN=$(printf '%s' "$KUBE_TOKEN" | base64 -d)
-          EXTERNAL_IP=$(kubectl \
-            --server="https://$KUBE_HOST:$KUBE_API_PORT" \
-            --token="$DECODED_TOKEN" \
-            --insecure-skip-tls-verify \
-            run detect-ip --rm -i --restart=Never --quiet \
-            --image=curlimages/curl -- -4 -s https://1.1.1.1/cdn-cgi/trace 2>/dev/null | grep '^ip=' | cut -d= -f2 | tr -d '[:space:]')
-          echo "EXTERNAL_IP=$EXTERNAL_IP" >> "$GITHUB_ENV"
-          echo "Detected server external IP: $EXTERNAL_IP"
-
-      - name: Configure Stack
-        run: |
-          pulumi stack select radiosilence/jaritanet/main
-          pulumi config set --path jaritanet:cloudflare.accountId "$CLOUDFLARE_ACCOUNT_ID"
-          pulumi config set --path jaritanet:traefik.acmeEmail "$ACME_EMAIL"
-          pulumi config set --path jaritanet:services.navidrome.hostname "$NAVIDROME_HOSTNAME"
-          pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
-          pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
-          pulumi config set --path jaritanet:gateway.xray.serverName "$BLIT_HOSTNAME"
-          pulumi config set --path jaritanet:mcpGateway.hostname "$MCP_HOSTNAME"
-          pulumi config set --path jaritanet:mcpGateway.authHostname "$MCP_AUTH_HOSTNAME"
-          if [[ -n "$EXTERNAL_IP" ]]; then
-            pulumi config set jaritanet:externalIp "$EXTERNAL_IP"
-          fi
-        working-directory: packages/infra
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
           NAVIDROME_HOSTNAME: ${{ secrets.NAVIDROME_HOSTNAME }}
           FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           BLIT_HOSTNAME: ${{ secrets.BLIT_HOSTNAME }}
           MCP_HOSTNAME: ${{ secrets.MCP_HOSTNAME }}
           MCP_AUTH_HOSTNAME: ${{ secrets.MCP_AUTH_HOSTNAME }}
-
-      - name: Deploy
-        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
-        with:
-          command: up
-          stack-name: radiosilence/jaritanet/main
-          work-dir: packages/infra
-          refresh: true
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-          KUBE_HOST: ${{ secrets.KUBE_HOST }}
-          KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
           # Per-user VPN roster (RBAC). "jc+,guest1" → jc admin, guest1 guest.
@@ -247,12 +207,11 @@ jobs:
           OLDBOY_HOST: ${{ secrets.OLDBOY_HOST }}
           OLDBOY_USER: ${{ secrets.OLDBOY_USER }}
           SINGBOX_SLUG: ${{ secrets.SINGBOX_SLUG }}
-          FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           TAILNET_MAGICDNS_SUFFIX: ${{ secrets.TAILNET_MAGICDNS_SUFFIX }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           # MCP gateway: GitHub OAuth app creds + login allowlist (read by
-          # env.ts). Hostnames go via `pulumi config set` above, not env.
+          # env.ts). Hostnames reach the program as stack config instead.
           GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
           GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
           GH_ALLOWED: ${{ secrets.GH_ALLOWED }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,8 +25,6 @@ jobs:
   preview:
     name: Pulumi Preview
     runs-on: ubuntu-24.04
-    env:
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -48,76 +46,46 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
 
-      - name: Detect Server External IP
-        if: env.HCLOUD_TOKEN == ''
+      # Identical entrypoint to the deploy in ci-cd.yml, differing only in the
+      # verb — which is the point. Config is written to the checked-out
+      # Pulumi.main.yaml, not the shared stack, so PRs can't leak into each
+      # other's previews.
+      - name: Preview
+        run: aube run preview
         env:
+          PREVIEW_COMMENT_PATH: ${{ runner.temp }}/preview.md
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           KUBE_HOST: ${{ secrets.KUBE_HOST }}
           KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-        run: |
-          DECODED_TOKEN=$(printf '%s' "$KUBE_TOKEN" | base64 -d)
-          EXTERNAL_IP=$(kubectl \
-            --server="https://$KUBE_HOST:$KUBE_API_PORT" \
-            --token="$DECODED_TOKEN" \
-            --insecure-skip-tls-verify \
-            run detect-ip --rm -i --restart=Never --quiet \
-            --image=curlimages/curl -- -4 -s https://1.1.1.1/cdn-cgi/trace 2>/dev/null | grep '^ip=' | cut -d= -f2 | tr -d '[:space:]')
-          echo "EXTERNAL_IP=$EXTERNAL_IP" >> "$GITHUB_ENV"
-          echo "Detected server external IP: $EXTERNAL_IP"
-
-      # pulumi config lives in the (ephemeral) checked-out Pulumi.main.yaml, not
-      # the shared stack, so these injections don't leak between PRs.
-      - name: Configure Stack
-        run: |
-          pulumi stack select radiosilence/jaritanet/main
-          pulumi config set --path jaritanet:cloudflare.accountId "$CLOUDFLARE_ACCOUNT_ID"
-          pulumi config set --path jaritanet:traefik.acmeEmail "$ACME_EMAIL"
-          pulumi config set --path jaritanet:services.navidrome.hostname "$NAVIDROME_HOSTNAME"
-          pulumi config set --path jaritanet:services.files.hostname "$FILES_HOSTNAME"
-          pulumi config set --path jaritanet:services.blit.hostname "$BLIT_HOSTNAME"
-          pulumi config set --path jaritanet:gateway.xray.serverName "$BLIT_HOSTNAME"
-          pulumi config set --path jaritanet:mcpGateway.hostname "$MCP_HOSTNAME"
-          pulumi config set --path jaritanet:mcpGateway.authHostname "$MCP_AUTH_HOSTNAME"
-          if [[ -n "$EXTERNAL_IP" ]]; then
-            pulumi config set jaritanet:externalIp "$EXTERNAL_IP"
-          fi
-        working-directory: packages/infra
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
           NAVIDROME_HOSTNAME: ${{ secrets.NAVIDROME_HOSTNAME }}
           FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           BLIT_HOSTNAME: ${{ secrets.BLIT_HOSTNAME }}
           MCP_HOSTNAME: ${{ secrets.MCP_HOSTNAME }}
           MCP_AUTH_HOSTNAME: ${{ secrets.MCP_AUTH_HOSTNAME }}
-
-      - name: Preview
-        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
-        with:
-          command: preview
-          stack-name: radiosilence/jaritanet/main
-          work-dir: packages/infra
-          comment-on-pr: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          refresh: true
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-          KUBE_HOST: ${{ secrets.KUBE_HOST }}
-          KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
-          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
-          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
-          GH_ALLOWED: ${{ secrets.GH_ALLOWED }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           OLDBOY_HOST: ${{ secrets.OLDBOY_HOST }}
           OLDBOY_USER: ${{ secrets.OLDBOY_USER }}
           SINGBOX_SLUG: ${{ secrets.SINGBOX_SLUG }}
-          FILES_HOSTNAME: ${{ secrets.FILES_HOSTNAME }}
           TAILNET_MAGICDNS_SUFFIX: ${{ secrets.TAILNET_MAGICDNS_SUFFIX }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_ALLOWED: ${{ secrets.GH_ALLOWED }}
+
+      # Edited in place rather than appended, so a PR pushed to repeatedly
+      # carries one comment showing the current preview instead of a pile of
+      # superseded ones.
+      - name: Comment preview on PR
+        run: gh pr comment "$PR" --body-file "$BODY" --edit-last --create-if-none
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.number }}
+          BODY: ${{ runner.temp }}/preview.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ The same gateway also fronts a censorship-resistant VPN/proxy layer: Xray VLESS-
 - `aube run lint:fix` - Lint and auto-fix with oxlint
 - `aube run fmt` - Format code with oxfmt
 - `aube run fmt:check` - Check formatting with oxfmt
+- `aube run preview` / `aube run deploy` - Drive the stack through `src/deploy.ts`, the same entrypoint CI uses. Both rewrite the local `Pulumi.main.yaml` from the environment first, so run them with CI's secrets or not at all.
 
 ### Git Hooks
 
@@ -95,11 +96,13 @@ Without a gateway, Traefik serves directly via hostPort 443 and DNS points at th
 Triggered on pushes and pull requests affecting package files, manually via `workflow_dispatch`, or as a reusable workflow (`workflow_call`, with the Pulumi/Cloudflare/Hetzner secrets):
 
 1. **Test** - Type checks, lints, runs vitest suite
-2. **Deploy** (main branch only) - Single `pulumi up` deploying everything
+2. **Deploy** (main branch only) - `aube run deploy`, a single `pulumi up` deploying everything
 
 ### Preview (`preview.yml`)
 
-Runs `pulumi preview` on infra PRs and posts the diff as a PR comment — read-only, surfaces resource **replacements** (e.g. the gateway VPS) before merge.
+Runs `aube run preview` on infra PRs and posts the diff as a PR comment — read-only, surfaces resource **replacements** (e.g. the gateway VPS) before merge.
+
+Both verbs enter `packages/infra/src/deploy.ts` (Pulumi Automation API), which applies stack config from the environment and then previews or updates. Sharing an entrypoint is the point: a preview produced by different machinery than the deploy predicts nothing. Config is written to the checked-out `Pulumi.main.yaml` rather than the shared stack, so one PR's injected hostnames never reach another's preview.
 
 ### Schema Generation (`generate-schemas.yml`)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "fmt:check": "oxfmt --check",
     "typecheck:infra": "tsc -p ./packages/infra/tsconfig.json",
     "gen:schemas": "./scripts/gen-schemas.ts",
+    "deploy": "./packages/infra/src/deploy.ts up",
+    "preview": "./packages/infra/src/deploy.ts preview",
     "prepare": "lefthook install"
   },
   "dependencies": {

--- a/packages/infra/src/deploy.ts
+++ b/packages/infra/src/deploy.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env -S node --experimental-strip-types --no-warnings
+/**
+ * Drives the stack from CI, for both `preview` and `up`.
+ *
+ * A preview is only worth reading if it was produced the same way as the deploy
+ * it predicts. Assembling the configuration separately in each workflow meant
+ * nothing enforced that, and the two had already drifted apart.
+ *
+ * Configuration is written to the checked-out Pulumi.main.yaml rather than to
+ * the shared stack, so hostnames injected for one PR's preview never reach
+ * another's.
+ */
+import { execFile } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+// Explicit file, and a namespace import: the automation API is CommonJS with
+// no exports map, so neither a bare subpath nor a named import resolves.
+import * as automation from "@pulumi/pulumi/automation/index.js";
+
+const STACK = "radiosilence/jaritanet/main";
+const WORK_DIR = join(import.meta.dirname, "..");
+
+/** GitHub refuses a comment body beyond 65536 characters. */
+const COMMENT_LIMIT = 60_000;
+
+/**
+ * Injected from CI secrets, so this public repo carries no hostnames. Set
+ * unconditionally: the checked-in values are empty strings, and writing one
+ * back is what an absent secret should mean.
+ */
+const CONFIG_FROM_ENV = {
+  "jaritanet:cloudflare.accountId": "CLOUDFLARE_ACCOUNT_ID",
+  "jaritanet:traefik.acmeEmail": "ACME_EMAIL",
+  "jaritanet:services.navidrome.hostname": "NAVIDROME_HOSTNAME",
+  "jaritanet:services.files.hostname": "FILES_HOSTNAME",
+  "jaritanet:services.blit.hostname": "BLIT_HOSTNAME",
+  "jaritanet:gateway.xray.serverName": "BLIT_HOSTNAME",
+  "jaritanet:mcpGateway.hostname": "MCP_HOSTNAME",
+  "jaritanet:mcpGateway.authHostname": "MCP_AUTH_HOSTNAME",
+} as const;
+
+const env = (name: string) => process.env[name] ?? "";
+
+/**
+ * Where the home server currently answers from. Only meaningful in direct mode:
+ * the cluster sits behind a residential connection whose address moves, and
+ * only something running inside the cluster can see what it has become.
+ */
+async function detectExternalIp() {
+  const token = Buffer.from(env("KUBE_TOKEN"), "base64").toString("utf8");
+  const { stdout } = await promisify(execFile)("kubectl", [
+    `--server=https://${env("KUBE_HOST")}:${env("KUBE_API_PORT")}`,
+    `--token=${token}`,
+    "--insecure-skip-tls-verify",
+    "run",
+    "detect-ip",
+    "--rm",
+    "-i",
+    "--restart=Never",
+    "--quiet",
+    "--image=curlimages/curl",
+    "--",
+    "-4",
+    "-s",
+    "https://1.1.1.1/cdn-cgi/trace",
+  ]);
+  return stdout
+    .split("\n")
+    .find((line) => line.startsWith("ip="))
+    ?.slice(3)
+    .trim();
+}
+
+/**
+ * Truncated from the top, because the resource summary a preview is read for
+ * sits at the end of the output.
+ */
+function previewComment(output: string) {
+  const overflowed = output.length > COMMENT_LIMIT;
+  const body = overflowed ? output.slice(-COMMENT_LIMIT) : output;
+  const note = overflowed
+    ? `\n> Truncated to the last ${COMMENT_LIMIT} characters — see the run for the whole preview.\n`
+    : "";
+  return `#### Pulumi preview — \`${STACK}\`\n${note}\n\`\`\`\n${body}\n\`\`\`\n`;
+}
+
+const mode = process.argv[2];
+if (mode !== "preview" && mode !== "up") {
+  throw new Error(`expected "preview" or "up", got "${mode ?? ""}"`);
+}
+
+const stack = await automation.LocalWorkspace.createOrSelectStack({
+  stackName: STACK,
+  workDir: WORK_DIR,
+});
+
+await stack.setAllConfig(
+  Object.fromEntries(
+    Object.entries(CONFIG_FROM_ENV).map(([key, source]) => [
+      key,
+      { value: env(source) },
+    ]),
+  ),
+  true,
+);
+
+if (!env("HCLOUD_TOKEN")) {
+  const externalIp = await detectExternalIp();
+  process.stdout.write(
+    `detected server external IP: ${externalIp ?? "none"}\n`,
+  );
+  if (externalIp) {
+    await stack.setConfig("jaritanet:externalIp", { value: externalIp });
+  }
+}
+
+const onOutput = (out: string) => process.stdout.write(out);
+
+if (mode === "up") {
+  await stack.up({ refresh: true, onOutput });
+} else {
+  const { stdout } = await stack.preview({
+    refresh: true,
+    color: "never",
+    onOutput,
+  });
+  const commentPath = process.env.PREVIEW_COMMENT_PATH;
+  if (commentPath) {
+    await writeFile(commentPath, previewComment(stdout));
+  }
+}

--- a/packages/infra/src/deploy.ts
+++ b/packages/infra/src/deploy.ts
@@ -73,12 +73,23 @@ async function detectExternalIp() {
 }
 
 /**
+ * Plugin download progress is most of a cold run's output and none of its
+ * meaning. Dropping it keeps the comment about the resources that change, and
+ * leaves far more room before the truncation limit.
+ */
+const NOISE = /^(Downloading|Installing) plugin /;
+
+/**
  * Truncated from the top, because the resource summary a preview is read for
  * sits at the end of the output.
  */
 function previewComment(output: string) {
-  const overflowed = output.length > COMMENT_LIMIT;
-  const body = overflowed ? output.slice(-COMMENT_LIMIT) : output;
+  const cleaned = output
+    .split("\n")
+    .filter((line) => !NOISE.test(line))
+    .join("\n");
+  const overflowed = cleaned.length > COMMENT_LIMIT;
+  const body = overflowed ? cleaned.slice(-COMMENT_LIMIT) : cleaned;
   const note = overflowed
     ? `\n> Truncated to the last ${COMMENT_LIMIT} characters — see the run for the whole preview.\n`
     : "";


### PR DESCRIPTION
Closes #148.

Stack configuration was copy-pasted between `ci-cd.yml` and `preview.yml` — the same eight `pulumi config set --path` calls and the same `kubectl run detect-ip` block in each, with nothing keeping them in step. They had already drifted onto different majors of `pulumi/actions`, so a preview could be produced by different machinery than the deploy it was meant to predict.

Both verbs now enter `packages/infra/src/deploy.ts`, which applies config from the environment and then previews or updates. Net −68 lines of workflow YAML.

## Load-bearing decisions

- **Config still writes to the checked-out `Pulumi.main.yaml`, not the shared stack.** `setAllConfig(..., path: true)` runs `pulumi config set-all --path`, which writes the local stack file — same isolation property the old bash relied on, so one PR's injected hostnames can't reach another's preview.
- **`gh pr comment --edit-last --create-if-none`** replaces `pulumi/actions`' `comment-on-pr`. A PR pushed to repeatedly keeps one comment showing the current preview rather than a pile of superseded ones.
- **Preview output is truncated from the *top*** when it would exceed GitHub's 65536-character comment limit. The resource summary sits at the end of Pulumi's output, and that is what the diff is read for.
- **The import is `@pulumi/pulumi/automation/index.js`, namespace-style.** The automation API is CommonJS with no `exports` map, so under `nodenext` neither a bare subpath nor a named import resolves. Verified both under `tsc` and at runtime.
- `pulumi/actions` is gone from both workflows, which is what stops this drifting again. Supersedes #150 — that one is the stopgap pin; merge whichever lands first and the other rebases out.

## Verifying

The preview job **on this PR exercises the new code path end to end** — if a preview comment appears below with the usual resource diff, config injection, IP detection, `refresh`, preview and comment posting all worked. That is the check that matters; read it before merging.

Locally verified: `lint` (0 warnings), `fmt:check`, `typecheck:infra`, `test` (23 passing). Ran `./packages/infra/src/deploy.ts` with no argument and with `preview` — the argument guard rejects the former, and the latter reaches `createOrSelectStack` → `setAllConfig` → IP detection, confirming the entrypoint, shebang and module resolution all work. That local `setAllConfig` produced **no diff** to `Pulumi.main.yaml`, confirming the eight injected keys are all `''` on disk and that writing an absent secret back is a no-op — identical to the old bash.

Not covered by tests: `deploy.ts` is a script with side effects at import, so there is nothing to import into vitest without executing it. The only pure logic is the comment truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Unusj2hWcc6HarqBGVZade