### PR TITLE
ci: move version bumping out of workflow bash

### DIFF
--- a/.github/tracked-versions.yml
+++ b/.github/tracked-versions.yml
@@ -1,54 +1,56 @@
-# What update-apps.yml watches. Adding a component is an entry here; the
-# workflow itself never needs touching.
+# What the version updater watches. Adding a component is an entry here; the
+# updater itself never needs touching.
 #
 #   repo   where the releases are read from
-#   path   a yq expression naming what to rewrite in Pulumi.main.yaml
+#   path   what to rewrite in Pulumi.main.yaml, as a list of keys. A mapping
+#          segment like `{ id: tfl }` picks a list entry out by field rather
+#          than by position, so reordering that list is harmless.
 #   value  what to write, with {version} substituted
 #   image  an image reference to confirm exists before committing the bump.
 #          Defaults to `value` when that is already a full reference, so only
 #          entries writing a bare tag need to spell it out. Omit entirely when
 #          there is no image to check, as for a Helm chart.
 #
-# {version} is the release tag with any chart-name prefix and leading `v`
-# stripped, so an entry puts back whatever form it actually needs — a bare
-# version for a tag field, a full reference for an image.
+# {version} is the release tag with everything before its first digit stripped,
+# which covers both a leading `v` and a chart-name prefix. An entry puts back
+# whatever form it actually needs — a bare version for a tag field, a full
+# reference for an image.
 
 - app: Navidrome
   repo: deluan/navidrome
-  path: '.config["jaritanet:services"].navidrome.args.image.tag'
+  path: [config, "jaritanet:services", navidrome, args, image, tag]
   value: "{version}"
   image: "deluan/navidrome:{version}"
 
 # Chart releases are tagged "traefik-34.5.0".
 - app: Traefik
   repo: traefik/traefik-helm-chart
-  path: '.config["jaritanet:traefik"].chartVersion'
+  path: [config, "jaritanet:traefik", chartVersion]
   value: "{version}"
 
 - app: MCP Gateway
   repo: radiosilence/mcp-gateway
-  path: '.config["jaritanet:mcpGateway"].image.tag'
+  path: [config, "jaritanet:mcpGateway", image, tag]
   value: "v{version}"
   image: "ghcr.io/radiosilence/mcp-gateway:v{version}"
 
-# The MCPs the gateway fronts. Each is an image reference inside a list, picked
-# out by its id rather than its position, so reordering the list is harmless.
+# The MCPs the gateway fronts, each an image reference inside a list.
 - app: Fastmail MCP
   repo: radiosilence/fastmail-cli
-  path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "fastmail") | .image)'
+  path: [config, "jaritanet:mcpGateway", mcps, { id: fastmail }, image]
   value: "ghcr.io/radiosilence/fastmail-cli:v{version}"
 
 - app: CalDAV MCP
   repo: radiosilence/caldav-cli
-  path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "caldav") | .image)'
+  path: [config, "jaritanet:mcpGateway", mcps, { id: caldav }, image]
   value: "ghcr.io/radiosilence/caldav-cli:v{version}"
 
 - app: Folk MCP
   repo: radiosilence/mainlynorfolk-mcp
-  path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "folk") | .image)'
+  path: [config, "jaritanet:mcpGateway", mcps, { id: folk }, image]
   value: "ghcr.io/radiosilence/mainlynorfolk-mcp:v{version}"
 
 - app: TfL MCP
   repo: radiosilence/tfl-mcp
-  path: '(.config["jaritanet:mcpGateway"].mcps[] | select(.id == "tfl") | .image)'
+  path: [config, "jaritanet:mcpGateway", mcps, { id: tfl }, image]
   value: "ghcr.io/radiosilence/tfl-mcp:v{version}"

--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -1,7 +1,12 @@
 name: Update App Versions
 
 on:
+  # main only. This job commits and pushes to whatever branch it runs on, so a
+  # feature branch touching these paths got the day's version bumps written into
+  # its own PR. Verify a change with `--dry-run` or workflow_dispatch instead.
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/update-apps.yml"
       - ".github/tracked-versions.yml"

--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -5,23 +5,21 @@ on:
     paths:
       - ".github/workflows/update-apps.yml"
       - ".github/tracked-versions.yml"
+      - "packages/infra/src/update-apps.ts"
+      - "packages/infra/src/versions.ts"
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
-# One run at a time. Editing either file triggers a run, and reaching for
-# workflow_dispatch straight after starts a second; both would push to main.
-# Queue rather than cancel — a cancelled run drops that day's updates instead of
-# retrying them.
+# One run at a time. Editing any of the tracked files triggers a run, and
+# reaching for workflow_dispatch straight after starts a second; both would push
+# to main. Queue rather than cancel — a cancelled run drops that day's updates
+# instead of retrying them.
 concurrency:
   group: update-apps
   cancel-in-progress: false
 
 jobs:
-  # One job walking the list, rather than a job per component. The work is a few
-  # seconds of API calls; a matrix spent minutes booting runners, checking out
-  # and re-downloading yq to do it, and had to be serialised anyway because each
-  # entry pushes to the same branch.
   update-apps:
     name: Update tracked versions
     runs-on: ubuntu-latest
@@ -42,12 +40,18 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+      - name: Setup Environment
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+
+      - name: Install Dependencies
+        uses: endevco/aube-action@f82ca2f6c943dbde1904945d9f0ee1a0faf8e945 # v1.0.0
+        with:
+          node-version: auto
+          run-install: true
+          install-args: --frozen-lockfile
 
       - name: Update tracked versions
+        run: aube run update:apps
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # The app installation can open an issue but is refused when amending
@@ -55,150 +59,3 @@ jobs:
           # grants that issues:write.
           ISSUE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          CONFIG="packages/infra/Pulumi.main.yaml"
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-          git pull --rebase --autostash
-
-          # A GitHub release does not prove an image was published. A release job
-          # that runs alongside the image build rather than after it will happily
-          # tag a release whose build then fails, and pinning to that is an
-          # ImagePullBackOff we inflicted on ourselves. So ask the registry.
-          image_exists() {
-            local ref="$1" tag repo registry token url code
-            tag="${ref##*:}"; ref="${ref%:*}"
-            case "$ref" in
-              */*/*) registry="${ref%%/*}"; repo="${ref#*/}" ;;
-              *)     registry="docker.io"; repo="$ref" ;;
-            esac
-            case "$registry" in
-              ghcr.io)
-                token=$(curl -sf "https://ghcr.io/token?scope=repository:$repo:pull&service=ghcr.io" | jq -r '.token // empty')
-                url="https://ghcr.io/v2/$repo/manifests/$tag" ;;
-              docker.io)
-                token=$(curl -sf "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$repo:pull" | jq -r '.token // empty')
-                url="https://registry-1.docker.io/v2/$repo/manifests/$tag" ;;
-              *)
-                echo "::warning::no registry client for $registry, skipping the existence check"
-                return 0 ;;
-            esac
-            [ -n "$token" ] || return 1
-            code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" \
-              -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json' \
-              "$url")
-            [ "$code" = "200" ]
-          }
-
-          updated=0
-          failed=""
-          titles=""
-          details=""
-
-          while IFS= read -r entry; do
-            app=$(jq -r '.app'   <<<"$entry")
-            repo=$(jq -r '.repo' <<<"$entry")
-            yqpath=$(jq -r '.path'  <<<"$entry")
-            template=$(jq -r '.value' <<<"$entry")
-
-            if ! tag=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null); then
-              echo "::warning::$app — no readable release on $repo"
-              failed="$failed $app"
-              continue
-            fi
-
-            # Upstreams disagree on how a release is spelled; normalise to the
-            # bare version and let the entry's template put back what it needs.
-            version="${tag#traefik-}"
-            version="${version#v}"
-            new="${template//\{version\}/$version}"
-
-            current=$(yq eval "$yqpath" "$CONFIG")
-            # An empty read means the path matches nothing — a renamed id, or a
-            # restructured config. Say so, rather than silently stop tracking it.
-            if [[ -z "$current" || "$current" == "null" ]]; then
-              echo "::warning::$app — nothing at $yqpath, the config moved"
-              failed="$failed $app"
-              continue
-            fi
-
-            # Checked even when already up to date, so a pin that stopped
-            # resolving — a release deleted, or one whose image never published
-            # in the first place — is reported rather than sitting quietly until
-            # the next pod restart finds it.
-            # Defaults to the new value when that is already a full reference,
-            # which covers every entry that pins an image by name.
-            verify=$(jq -r '.image // ""' <<<"$entry")
-            verify="${verify//\{version\}/$version}"
-            if [[ -z "$verify" && "$new" == */*:* ]]; then
-              verify="$new"
-            fi
-            if [[ -n "$verify" ]] && ! image_exists "$verify"; then
-              if [[ "$current" == "$new" ]]; then
-                echo "::warning::$app — pinned to $verify, which is not in the registry"
-              else
-                echo "::warning::$app — $repo released $tag but $verify is not in the registry; staying on $current"
-              fi
-              failed="$failed $app"
-              continue
-            fi
-
-            if [[ "$current" == "$new" ]]; then
-              echo "$app — up to date ($current)"
-              continue
-            fi
-
-            echo "$app — $current -> $new"
-            yq eval "($yqpath) = \"$new\"" -i "$CONFIG"
-            git add "$CONFIG"
-            git commit -q -m "chore: update $app to $new"
-            updated=$((updated + 1))
-
-            titles="${titles:+$titles, }$app $version"
-            details="$details- **$app** \`$current\` → \`$new\` (from $repo)"$'\n'
-          done < <(yq -o=json '.' .github/tracked-versions.yml | jq -c '.[]')
-
-          if (( updated > 0 )); then
-            # main can move while this runs — a merged PR, or a long list of
-            # releases to fetch. Rebase these commits on top and retry, since it
-            # can move again between the rebase and the push.
-            for attempt in 1 2 3; do
-              if git pull --rebase --autostash && git push; then
-                break
-              fi
-              echo "push attempt $attempt lost a race, retrying"
-              sleep $((attempt * 5))
-              if (( attempt == 3 )); then
-                echo "::error::could not push after 3 attempts"
-                exit 1
-              fi
-            done
-            echo "pushed $updated update(s)"
-
-            # One issue per run, and only when something moved — a job per
-            # component meant a separate issue each, which buried the backlog in
-            # notifications nobody was meant to action. Closed on creation for
-            # the same reason: it is a record that something changed, not work.
-            title="Updated $titles"
-            if (( ${#title} > 200 )); then
-              title="Updated $updated versions"
-            fi
-            url=$(gh issue create --title "$title" --body "$details
-          [Run]($RUN_URL)")
-            # Best-effort. The updates are already pushed by this point, and a
-            # note left open is not worth reporting the run as failed over.
-            GH_TOKEN="$ISSUE_TOKEN" gh api -X PATCH \
-              "repos/$GITHUB_REPOSITORY/issues/${url##*/}" \
-              -f state=closed -f state_reason=completed >/dev/null \
-              || echo "::warning::opened $url but could not close it"
-            echo "recorded at $url"
-          else
-            echo "nothing to update"
-          fi
-
-          if [[ -n "$failed" ]]; then
-            echo "::error::could not check:$failed"
-            exit 1
-          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ The same gateway also fronts a censorship-resistant VPN/proxy layer: Xray VLESS-
 - `aube run lint:fix` - Lint and auto-fix with oxlint
 - `aube run fmt` - Format code with oxfmt
 - `aube run fmt:check` - Check formatting with oxfmt
+- `./packages/infra/src/update-apps.ts --dry-run` - Report which tracked components have moved, without writing or committing anything
 
 ### Git Hooks
 
@@ -107,7 +108,11 @@ Generates JSON schemas from Zod definitions on changes or daily schedule. Commit
 
 ### App Version Updates (`update-apps.yml`)
 
-Daily check for new releases of deployed services (Navidrome Docker image + Traefik Helm chart). Uses a GitHub App token so version bump commits trigger the CI/CD pipeline.
+Daily check for new releases of the components listed in `.github/tracked-versions.yml`. Uses a GitHub App token so version bump commits trigger the CI/CD pipeline.
+
+The workflow only supplies tokens; the work is `packages/infra/src/update-apps.ts`, with the decisions it makes — tag normalisation, image reference parsing, and whether an entry moved — isolated in `versions.ts` where they are unit tested. A release tag is never trusted on its own: the registry is asked whether the image actually published, including for entries already up to date, so a pin that stopped resolving is reported rather than waiting for the next pod restart to find it.
+
+Rewrites go through the YAML document API and mutate the existing scalar, so a bump changes exactly one line and leaves comments and quoting alone.
 
 ### Ansible Deployment (`run-playbook.yml`)
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,3 @@
 aube = "1"
 node = "24"
 pulumi = "latest"
-yq = "latest"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "fmt:check": "oxfmt --check",
     "typecheck:infra": "tsc -p ./packages/infra/tsconfig.json",
     "gen:schemas": "./scripts/gen-schemas.ts",
+    "update:apps": "./packages/infra/src/update-apps.ts",
     "prepare": "lefthook install"
   },
   "dependencies": {

--- a/packages/infra/src/update-apps.ts
+++ b/packages/infra/src/update-apps.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env -S node --experimental-strip-types --no-warnings
+/**
+ * Walks the tracked components, bumps whichever moved, and pushes a commit per
+ * component.
+ *
+ * One pass rather than a job per component: the work is a few seconds of API
+ * calls, and a matrix spent minutes booting runners to do it — then had to be
+ * serialised anyway, because every entry writes the same file on the same
+ * branch.
+ *
+ * The decisions live in versions.ts, which is where the tests are; this file is
+ * the IO around them.
+ */
+// Every loop below is sequential on purpose. Entries commit to the same branch
+// in turn, and the push retry has to see whether the previous attempt worked,
+// so the usual "collect into Promise.all" advice would break both.
+/* oxlint-disable no-await-in-loop */
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { promisify } from "node:util";
+import { parse, parseDocument } from "yaml";
+import {
+  applyTemplate,
+  decide,
+  normaliseVersion,
+  parseImageRef,
+  readAt,
+  STRINGIFY_OPTIONS,
+  TrackedListSchema,
+  verifyRef,
+  writeAt,
+} from "./versions.ts";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const TRACKED = join(ROOT, ".github", "tracked-versions.yml");
+const CONFIG = join(ROOT, "packages", "infra", "Pulumi.main.yaml");
+
+const MANIFEST_ACCEPT = [
+  "application/vnd.oci.image.index.v1+json",
+  "application/vnd.docker.distribution.manifest.list.v2+json",
+  "application/vnd.oci.image.manifest.v1+json",
+  "application/vnd.docker.distribution.manifest.v2+json",
+].join(",");
+
+const REGISTRIES: Record<
+  string,
+  {
+    token: (repo: string) => string;
+    manifest: (repo: string, tag: string) => string;
+  }
+> = {
+  "ghcr.io": {
+    token: (repo) =>
+      `https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io`,
+    manifest: (repo, tag) => `https://ghcr.io/v2/${repo}/manifests/${tag}`,
+  },
+  "docker.io": {
+    token: (repo) =>
+      `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull`,
+    manifest: (repo, tag) =>
+      `https://registry-1.docker.io/v2/${repo}/manifests/${tag}`,
+  },
+};
+
+const run = promisify(execFile);
+const git = (...args: string[]) => run("git", args, { cwd: ROOT });
+const log = (message: string) => process.stdout.write(`${message}\n`);
+const warn = (message: string) =>
+  process.stdout.write(`::warning::${message}\n`);
+const env = (name: string) => process.env[name] ?? "";
+
+/**
+ * A GitHub release does not prove an image was published. A release job that
+ * runs alongside the image build rather than after it will happily tag a
+ * release whose build then fails, and pinning to that is an ImagePullBackOff we
+ * inflicted on ourselves. So ask the registry.
+ */
+async function imageExists(ref: string) {
+  const { registry, repository, tag } = parseImageRef(ref);
+  const endpoints = REGISTRIES[registry];
+  if (!endpoints) {
+    warn(`no registry client for ${registry}, skipping the existence check`);
+    return true;
+  }
+  const auth = await fetch(endpoints.token(repository));
+  if (!auth.ok) return false;
+  const { token } = (await auth.json()) as { token?: string };
+  if (!token) return false;
+  const manifest = await fetch(endpoints.manifest(repository, tag), {
+    headers: { authorization: `Bearer ${token}`, accept: MANIFEST_ACCEPT },
+  });
+  return manifest.status === 200;
+}
+
+async function latestTag(repo: string) {
+  try {
+    const { stdout } = await run("gh", [
+      "api",
+      `repos/${repo}/releases/latest`,
+      "--jq",
+      ".tag_name",
+    ]);
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * main can move while this runs — a merged PR, or a long list of releases to
+ * fetch. Rebase these commits on top and retry, since it can move again between
+ * the rebase and the push.
+ */
+async function pushWithRebase() {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      await git("pull", "--rebase", "--autostash");
+      await git("push");
+      return;
+    } catch {
+      if (attempt === 3) throw new Error("could not push after 3 attempts");
+      log(`push attempt ${attempt} lost a race, retrying`);
+      await sleep(attempt * 5000);
+    }
+  }
+}
+
+/**
+ * One issue per run, and only when something moved — a job per component meant
+ * a separate issue each, which buried the backlog in notifications nobody was
+ * meant to action. Closed on creation for the same reason: it is a record that
+ * something changed, not work.
+ */
+async function record(titles: string[], details: string[]) {
+  const listed = `Updated ${titles.join(", ")}`;
+  const title =
+    listed.length > 200 ? `Updated ${titles.length} versions` : listed;
+  const { stdout } = await run("gh", [
+    "issue",
+    "create",
+    "--title",
+    title,
+    "--body",
+    `${details.join("\n")}\n[Run](${env("RUN_URL")})`,
+  ]);
+  const url = stdout.trim();
+  try {
+    // The app installation can open an issue but is refused when amending one,
+    // so closing uses the workflow's own token.
+    await run(
+      "gh",
+      [
+        "api",
+        "-X",
+        "PATCH",
+        `repos/${env("GITHUB_REPOSITORY")}/issues/${url.slice(url.lastIndexOf("/") + 1)}`,
+        "-f",
+        "state=closed",
+        "-f",
+        "state_reason=completed",
+      ],
+      { env: { ...process.env, GH_TOKEN: env("ISSUE_TOKEN") } },
+    );
+  } catch {
+    // Best-effort. The updates are already pushed by this point, and a note
+    // left open is not worth reporting the run as failed over.
+    warn(`opened ${url} but could not close it`);
+  }
+  log(`recorded at ${url}`);
+}
+
+/** Reports what would move without touching the working tree, so the release
+ *  and registry checks can be exercised from a laptop. */
+const dryRun = process.argv.includes("--dry-run");
+
+const entries = TrackedListSchema.parse(parse(await readFile(TRACKED, "utf8")));
+const doc = parseDocument(await readFile(CONFIG, "utf8"));
+
+if (!dryRun) {
+  await git("config", "user.email", "action@github.com");
+  await git("config", "user.name", "GitHub Action");
+  await git("pull", "--rebase", "--autostash");
+}
+
+const failed: string[] = [];
+const titles: string[] = [];
+const details: string[] = [];
+
+for (const entry of entries) {
+  const tag = await latestTag(entry.repo);
+  if (!tag) {
+    warn(`${entry.app} — no readable release on ${entry.repo}`);
+    failed.push(entry.app);
+    continue;
+  }
+
+  const version = normaliseVersion(tag);
+  const next = applyTemplate(entry.value, version);
+  const ref = verifyRef(entry, version);
+  const decision = decide({
+    tag,
+    current: readAt(doc, entry.path),
+    next,
+    ref,
+    exists: ref ? await imageExists(ref) : true,
+  });
+
+  if (decision.kind === "problem") {
+    warn(`${entry.app} — ${decision.reason}`);
+    failed.push(entry.app);
+    continue;
+  }
+  if (decision.kind === "up-to-date") {
+    log(`${entry.app} — up to date (${decision.current})`);
+    continue;
+  }
+
+  log(`${entry.app} — ${decision.from} -> ${decision.to}`);
+  if (!dryRun) {
+    writeAt(doc, entry.path, decision.to);
+    await writeFile(CONFIG, doc.toString(STRINGIFY_OPTIONS));
+    await git("add", CONFIG);
+    await git(
+      "commit",
+      "-q",
+      "-m",
+      `chore: update ${entry.app} to ${decision.to}`,
+    );
+  }
+  titles.push(`${entry.app} ${version}`);
+  details.push(
+    `- **${entry.app}** \`${decision.from}\` → \`${decision.to}\` (from ${entry.repo})`,
+  );
+}
+
+if (titles.length === 0) {
+  log("nothing to update");
+} else if (dryRun) {
+  log(`dry run — ${titles.length} update(s) not written`);
+} else {
+  await pushWithRebase();
+  log(`pushed ${titles.length} update(s)`);
+  await record(titles, details);
+}
+
+if (failed.length > 0) {
+  process.stdout.write(`::error::could not check: ${failed.join(" ")}\n`);
+  process.exitCode = 1;
+}

--- a/packages/infra/src/versions.test.ts
+++ b/packages/infra/src/versions.test.ts
@@ -1,0 +1,234 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse, parseDocument } from "yaml";
+import {
+  applyTemplate,
+  decide,
+  normaliseVersion,
+  parseImageRef,
+  readAt,
+  STRINGIFY_OPTIONS,
+  TrackedListSchema,
+  verifyRef,
+  writeAt,
+} from "./versions.ts";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const config = () =>
+  readFile(join(ROOT, "packages", "infra", "Pulumi.main.yaml"), "utf8");
+const tracked = async () =>
+  TrackedListSchema.parse(
+    parse(
+      await readFile(join(ROOT, ".github", "tracked-versions.yml"), "utf8"),
+    ),
+  );
+
+describe("normaliseVersion", () => {
+  it.each([
+    ["v3.2.1", "3.2.1"],
+    ["traefik-34.5.0", "34.5.0"],
+    ["v0.63.2", "0.63.2"],
+    ["2024.1.0", "2024.1.0"],
+    ["v10.0.0-rc1", "10.0.0-rc1"],
+  ])("%s -> %s", (tag, expected) => {
+    expect(normaliseVersion(tag)).toBe(expected);
+  });
+});
+
+describe("parseImageRef", () => {
+  it("treats a two-part name as Docker Hub", () => {
+    expect(parseImageRef("deluan/navidrome:0.63.2")).toEqual({
+      registry: "docker.io",
+      repository: "deluan/navidrome",
+      tag: "0.63.2",
+    });
+  });
+
+  it("treats a three-part name as a host plus repository", () => {
+    expect(parseImageRef("ghcr.io/radiosilence/tfl-mcp:v1.2.0")).toEqual({
+      registry: "ghcr.io",
+      repository: "radiosilence/tfl-mcp",
+      tag: "v1.2.0",
+    });
+  });
+
+  it("files a bare official image under library/", () => {
+    expect(parseImageRef("nginx:1.27")).toEqual({
+      registry: "docker.io",
+      repository: "library/nginx",
+      tag: "1.27",
+    });
+  });
+});
+
+describe("verifyRef", () => {
+  const entry = { app: "a", repo: "o/r", path: ["x"], value: "" };
+
+  it("prefers an explicit image, templated", () => {
+    expect(
+      verifyRef(
+        { ...entry, value: "{version}", image: "deluan/navidrome:{version}" },
+        "1.2.3",
+      ),
+    ).toBe("deluan/navidrome:1.2.3");
+  });
+
+  it("falls back to the value when it is already a full reference", () => {
+    expect(
+      verifyRef(
+        { ...entry, value: "ghcr.io/radiosilence/tfl-mcp:v{version}" },
+        "1.2.0",
+      ),
+    ).toBe("ghcr.io/radiosilence/tfl-mcp:v1.2.0");
+  });
+
+  it("has nothing to check for a bare version, as for a Helm chart", () => {
+    expect(
+      verifyRef({ ...entry, value: "{version}" }, "34.5.0"),
+    ).toBeUndefined();
+  });
+});
+
+describe("decide", () => {
+  const base = { tag: "v1.2.3", next: "1.2.3", ref: undefined, exists: true };
+
+  it("reports a config path that matches nothing rather than dropping the entry", () => {
+    expect(decide({ ...base, current: undefined })).toEqual({
+      kind: "problem",
+      reason: "nothing at the configured path, the config moved",
+    });
+  });
+
+  it("stays put when the release exists but its image does not", () => {
+    const decision = decide({
+      ...base,
+      current: "1.2.2",
+      ref: "o/r:1.2.3",
+      exists: false,
+    });
+    expect(decision).toEqual({
+      kind: "problem",
+      reason:
+        "released v1.2.3 but o/r:1.2.3 is not in the registry; staying on 1.2.2",
+    });
+  });
+
+  it("reports a current pin that stopped resolving, even when up to date", () => {
+    expect(
+      decide({ ...base, current: "1.2.3", ref: "o/r:1.2.3", exists: false }),
+    ).toEqual({
+      kind: "problem",
+      reason: "pinned to o/r:1.2.3, which is not in the registry",
+    });
+  });
+
+  it("is up to date when the value already matches", () => {
+    expect(decide({ ...base, current: "1.2.3" })).toEqual({
+      kind: "up-to-date",
+      current: "1.2.3",
+    });
+  });
+
+  it("updates when the value moved", () => {
+    expect(decide({ ...base, current: "1.2.2" })).toEqual({
+      kind: "update",
+      from: "1.2.2",
+      to: "1.2.3",
+    });
+  });
+});
+
+describe("paths against the real config", () => {
+  it("resolves every tracked entry to a string", async () => {
+    const doc = parseDocument(await config());
+    for (const entry of await tracked()) {
+      expect(readAt(doc, entry.path), `${entry.app} resolves`).toEqual(
+        expect.any(String),
+      );
+    }
+  });
+
+  it("picks a list entry by id rather than position", async () => {
+    const doc = parseDocument(await config());
+    const path = [
+      "config",
+      "jaritanet:mcpGateway",
+      "mcps",
+      { id: "tfl" },
+      "image",
+    ];
+    expect(readAt(doc, path)).toContain("tfl-mcp");
+  });
+
+  it("reports a selector matching nothing", async () => {
+    const doc = parseDocument(await config());
+    expect(
+      readAt(doc, [
+        "config",
+        "jaritanet:mcpGateway",
+        "mcps",
+        { id: "nope" },
+        "image",
+      ]),
+    ).toBeUndefined();
+    expect(
+      writeAt(
+        doc,
+        ["config", "jaritanet:mcpGateway", "mcps", { id: "nope" }, "image"],
+        "x",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("rewriting the config", () => {
+  it("round-trips an untouched document byte for byte", async () => {
+    const raw = await config();
+    expect(parseDocument(raw).toString(STRINGIFY_OPTIONS)).toBe(raw);
+  });
+
+  it("changes only the line it was asked to change", async () => {
+    const raw = await config();
+    const doc = parseDocument(raw);
+    const path = [
+      "config",
+      "jaritanet:mcpGateway",
+      "mcps",
+      { id: "tfl" },
+      "image",
+    ];
+
+    expect(writeAt(doc, path, "ghcr.io/radiosilence/tfl-mcp:v9.9.9")).toBe(
+      true,
+    );
+
+    const after = doc.toString(STRINGIFY_OPTIONS).split("\n");
+    const changed = raw
+      .split("\n")
+      .flatMap((line, i) => (line === after[i] ? [] : [i]));
+    expect(changed).toHaveLength(1);
+    expect(after[changed[0]!]).toContain("v9.9.9");
+  });
+
+  it("keeps a quoted scalar quoted, so a version cannot come back as a float", async () => {
+    const doc = parseDocument(await config());
+    const path = ["config", "jaritanet:traefik", "chartVersion"];
+
+    expect(writeAt(doc, path, "41.0")).toBe(true);
+
+    expect(doc.toString(STRINGIFY_OPTIONS)).toContain('chartVersion: "41.0"');
+    expect(readAt(parseDocument(doc.toString(STRINGIFY_OPTIONS)), path)).toBe(
+      "41.0",
+    );
+  });
+});
+
+describe("applyTemplate", () => {
+  it("substitutes every occurrence", () => {
+    expect(applyTemplate("ghcr.io/o/r:v{version}", "1.2.3")).toBe(
+      "ghcr.io/o/r:v1.2.3",
+    );
+    expect(applyTemplate("{version}-{version}", "1")).toBe("1-1");
+  });
+});

--- a/packages/infra/src/versions.ts
+++ b/packages/infra/src/versions.ts
@@ -1,0 +1,170 @@
+/**
+ * The decisions behind bumping a tracked component, separated from the IO that
+ * feeds them. Everything here is pure, because this is the part that breaks:
+ * upstreams spell releases differently, registries lag behind release tags, and
+ * the config underneath moves.
+ */
+import { type Document, isMap, isScalar, isSeq } from "yaml";
+import * as z from "zod";
+
+/**
+ * A key, or a selector picking a list entry by one of its fields. `{ id: tfl }`
+ * finds that MCP wherever it sits in the list, so reordering the list is
+ * harmless.
+ */
+const PathSegmentSchema = z.union([
+  z.string(),
+  z.record(z.string(), z.string()),
+]);
+
+export const TrackedSchema = z.object({
+  app: z.string(),
+  repo: z.string(),
+  path: z.array(PathSegmentSchema).min(1),
+  value: z.string(),
+  image: z.string().optional(),
+});
+
+export const TrackedListSchema = z.array(TrackedSchema);
+
+export type Tracked = z.infer<typeof TrackedSchema>;
+
+/**
+ * Chosen so an untouched document round-trips byte-for-byte. Left to its
+ * defaults the serialiser re-wraps long strings and pads flow collections,
+ * which would bury a one-line version bump in an unrelated reformat of the
+ * whole file.
+ */
+export const STRINGIFY_OPTIONS = {
+  lineWidth: 0,
+  flowCollectionPadding: false,
+} as const;
+
+export type Decision =
+  | { kind: "up-to-date"; current: string }
+  | { kind: "update"; from: string; to: string }
+  | { kind: "problem"; reason: string };
+
+/**
+ * Upstreams disagree on how a release is spelled — `v3.2.1`, `traefik-34.5.0`.
+ * Everything before the first digit goes, and each entry's template puts back
+ * whatever form it actually needs.
+ */
+export const normaliseVersion = (tag: string) => tag.replace(/^\D*/, "");
+
+export const applyTemplate = (template: string, version: string) =>
+  template.replaceAll("{version}", version);
+
+/**
+ * Splits a reference the way the registry APIs want it. Two or more slashes
+ * means the first part is a host; otherwise it is Docker Hub, which files
+ * official images under `library/` that a bare name omits.
+ */
+export function parseImageRef(ref: string) {
+  const colon = ref.lastIndexOf(":");
+  const tag = ref.slice(colon + 1);
+  const name = ref.slice(0, colon);
+  const parts = name.split("/");
+  if (parts.length > 2) {
+    const [registry, ...repository] = parts;
+    return { registry, repository: repository.join("/"), tag };
+  }
+  return {
+    registry: "docker.io",
+    repository: parts.length === 2 ? name : `library/${name}`,
+    tag,
+  };
+}
+
+/**
+ * The reference to confirm in a registry before committing a bump. Defaults to
+ * the new value when that is already a full reference, so only entries writing
+ * a bare tag need to spell `image` out; a Helm chart has none, and is skipped.
+ */
+export function verifyRef(entry: Tracked, version: string) {
+  if (entry.image) return applyTemplate(entry.image, version);
+  const next = applyTemplate(entry.value, version);
+  return /\/.*:/.test(next) ? next : undefined;
+}
+
+/**
+ * The registry is checked even when the entry is already up to date, so a pin
+ * that stopped resolving — a release deleted, or one whose image never
+ * published in the first place — is reported rather than sitting quietly until
+ * the next pod restart finds it.
+ */
+export function decide({
+  tag,
+  current,
+  next,
+  ref,
+  exists,
+}: {
+  tag: string;
+  current: string | undefined;
+  next: string;
+  ref: string | undefined;
+  exists: boolean;
+}): Decision {
+  // An empty read means the path matches nothing — a renamed id, or a
+  // restructured config. Say so, rather than silently stop tracking it.
+  if (!current) {
+    return {
+      kind: "problem",
+      reason: "nothing at the configured path, the config moved",
+    };
+  }
+  if (ref && !exists) {
+    return {
+      kind: "problem",
+      reason:
+        current === next
+          ? `pinned to ${ref}, which is not in the registry`
+          : `released ${tag} but ${ref} is not in the registry; staying on ${current}`,
+    };
+  }
+  if (current === next) return { kind: "up-to-date", current };
+  return { kind: "update", from: current, to: next };
+}
+
+/**
+ * Turns each selector segment into the list index it currently matches, giving
+ * a path the document can address directly.
+ */
+export function resolvePath(doc: Document, path: Tracked["path"]) {
+  const resolved: (string | number)[] = [];
+  for (const segment of path) {
+    if (typeof segment === "string") {
+      resolved.push(segment);
+      continue;
+    }
+    const [field, wanted] = Object.entries(segment)[0] ?? [];
+    const list = doc.getIn(resolved);
+    if (field === undefined || !isSeq(list)) return undefined;
+    const index = list.items.findIndex(
+      (item) => isMap(item) && item.get(field) === wanted,
+    );
+    if (index < 0) return undefined;
+    resolved.push(index);
+  }
+  return resolved;
+}
+
+export function readAt(doc: Document, path: Tracked["path"]) {
+  const resolved = resolvePath(doc, path);
+  const value = resolved && doc.getIn(resolved);
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Mutates the existing scalar rather than replacing it, so the value keeps
+ * whatever quoting it was written with. Without that an unquoted `41.0` would
+ * come back as a float on the next read.
+ */
+export function writeAt(doc: Document, path: Tracked["path"], value: string) {
+  const resolved = resolvePath(doc, path);
+  const node = resolved && doc.getIn(resolved, true);
+  if (!isScalar(node)) return false;
+  node.value = value;
+  return true;
+}


### PR DESCRIPTION
Closes #149.

The tracked-version updater was ~150 lines of bash embedded in `update-apps.yml` — registry token exchanges, manifest fetches, `yq` surgery, tag normalisation, and the decision of what to commit. None of it could be exercised without pushing to main, and none of it was covered by the vitest suite the repo already has.

Net −136 lines. The workflow now only supplies tokens.

## Layout

- **`versions.ts`** — the decisions, all pure: tag normalisation, template application, image-reference parsing, whether an entry moved, and resolving a tracked path against the config document.
- **`versions.test.ts`** — 23 new tests (46 total).
- **`update-apps.ts`** — the IO: release lookups, registry checks, git, the issue.

## Load-bearing decisions

- **Tracked entries name their config location as a list of keys** rather than a `yq` expression, which is what drops the `yq` dependency (also removed from `mise.toml` — nothing else used it). A `{ id: tfl }` segment still picks a list entry by field rather than position, so reordering `mcps` stays harmless.
- **Rewrites mutate the existing YAML scalar** instead of replacing the node, so the value keeps its quoting. Without that an unquoted `41.0` would come back as a **float** on the next read. A test covers it.
- **`toString` is pinned to `{ lineWidth: 0, flowCollectionPadding: false }`.** On defaults the serialiser re-wraps long strings and pads flow collections, which turned a one-line bump into a 182-line reformat of the whole config. A test asserts an untouched document round-trips byte for byte.
- **The registry is still asked whether the image actually published**, including for entries already up to date — a release tag does not prove a build succeeded, and a pin that stopped resolving should be reported rather than found by the next pod restart. Docker Hub official images now resolve under `library/`, which the bash got wrong but never hit.
- **`no-await-in-loop` is disabled file-wide with a reason.** Every loop is sequential on purpose: entries commit to the same branch in turn, and the push retry must see whether the previous attempt worked.

## One extra commit, deliberately

`ci: run the version updater on main only` adds a `branches: [main]` filter to the push trigger. **This is a pre-existing bug that this PR tripped over.** The job commits and pushes to whatever branch it runs on, so pushing this branch — which touches the tracked paths — ran the updater against the branch and wrote that day's version bumps into this very PR, plus opened #153. Those commits have been removed from the branch; #153 is a spurious record and can be ignored.

It is one line, in a file this PR already rewrites, and without it the same thing happens to the next PR that touches these paths. `--dry-run` and `workflow_dispatch` cover the "verify a change" case the unfiltered trigger was serving.

## Verifying

`./packages/infra/src/update-apps.ts --dry-run` — new, and the answer to "this could not be run without pushing to main". Against current main:

```
Navidrome — up to date (0.63.2)
Traefik — up to date (41.0.2)
MCP Gateway — v0.5.1 -> v0.5.2
Fastmail MCP — up to date (ghcr.io/radiosilence/fastmail-cli:v3.3.0)
CalDAV MCP — up to date (ghcr.io/radiosilence/caldav-cli:v0.6.0)
Folk MCP — up to date (ghcr.io/radiosilence/mainlynorfolk-mcp:v1.1.0)
TfL MCP — up to date (ghcr.io/radiosilence/tfl-mcp:v1.3.1)
dry run — 1 update(s) not written
```

Working tree unchanged afterwards. That agrees exactly with the last bash run on main ([run 30211549388](https://github.com/radiosilence/jaritanet/actions/runs/30211549388), which bumped the gateway to v0.5.1) plus the v0.5.2 release published since — the old and new implementations see the same world.

The accidental branch run ([run 30215176860](https://github.com/radiosilence/jaritanet/actions/runs/30215176860)) also exercised the full path in CI — release lookups, both registries, git commits, push, issue create and close — before its commits were removed.

Gates: lint 0 warnings, `fmt:check`, `typecheck:infra`, 46 tests passing, re-run after merging current main (which changed `Pulumi.main.yaml`, so the round-trip and path tests were re-verified against it).

**Not covered by tests:** git, `gh`, and the network calls in `update-apps.ts`. The dry run and the CI run above are what exercise those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Unusj2hWcc6HarqBGVZade