### PR TITLE
fix(xray): make the guest blackhole match domains, not just literal IPs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -432,18 +432,30 @@ their profile JSON; the restrictions still hold because they live at the gateway
 
 - **Guests are reality-only by design** — and that's what makes the rest hard.
   Reality is their sole entry, and Xray tags each inbound flow with the client's
-  `email` (= user name), so per-user routing rules are airtight. hy2 has no such
-  per-user routing, so giving guests hy2 would open an unpoliced door — hence
-  they get none (no hy2 credential exists for them).
+  `email` (= the user name, an arbitrary label, not an address), so rules can
+  match on `"user"` — a genuine per-user dimension. hy2 has no equivalent: its
+  ACL matches addresses, ports and protocols and never sees who authenticated,
+  so giving guests hy2 would open an unpoliced door — hence they get none (no
+  hy2 credential exists for them).
 - **Identity + revocation** — one REALITY UUID per user in Xray's `clients`;
   admins additionally in hy2's `userpass` map. Drop the user → the credential
   vanishes → locked out. Since exits and tailnet are only reachable *through* an
   entry, killing the entry kills everything downstream.
 - **Exits** — gated by the ss-rust PSK, which is simply omitted from guest
   profiles, so a guest has no exit outbound to select even if they edit the JSON.
-- **Tailnet + exit loopbacks** — an Xray routing rule blackholes guest emails'
-  flows to `100.64.0.0/10` (+ the v6 ULA) and to `127.0.0.0/8:20000-29999` (the
-  exit loopback range). Belt-and-braces on top of the PSK omission.
+- **Everything that isn't the public internet** — an Xray routing rule blackholes
+  guest flows to the tailnet, loopback and RFC1918. Enumerating what a guest may
+  *not* touch is the losing side of the argument, so the rule denies every
+  address that isn't the internet rather than the exit port range alone.
+
+  **This only works because `routing.domainStrategy` is `IPIfNonMatch`.** These
+  are IP rules, and under Xray's default `AsIs` an IP rule never matches a
+  request whose destination is a *domain* — so a guest editing their profile to
+  dial a hostname they control, with an A record pointing into the tailnet, fell
+  through to `direct` and reached the mesh. `IPIfNonMatch` resolves after a
+  non-matching round and matches again. An IP deny-list in front of a
+  non-resolving strategy is decoration; if the strategy is ever changed back,
+  these rules quietly stop meaning anything.
 
 Delivery is owner-relayed: a bot can't cold-DM a handle, so on change the owner
 gets one Telegram message grouping users under Admins / Guests, each URL a

--- a/packages/infra/src/modules/xray.ts
+++ b/packages/infra/src/modules/xray.ts
@@ -7,10 +7,24 @@ import type { XrayConfSchema } from "../conf.schemas.ts";
 import type { VpnUser } from "../env.schema.ts";
 import { type Connection, resourcePrefix } from "./vps.ts";
 
-// Exit ss-rust loopbacks live in this range (see deriveExitPort in exit.ts).
-// Guests are blackholed to it at the Xray layer — belt-and-braces on top of the
-// ss PSK being omitted from their profile.
-const EXIT_PORT_RANGE = "20000-29999";
+// A guest may address the public internet and nothing else. Narrower rules were
+// a mistake: the exit loopbacks were blocked only on their own port range
+// (20000-29999, see deriveExitPort in exit.ts), which left 0.0.0.0 — a synonym
+// for localhost on Linux — reachable, and said nothing about the rest of the
+// gateway's own stack. Enumerating what a guest may not touch is the losing
+// side of that argument, so this is every address that isn't the internet.
+const GUEST_DENY_CIDRS = [
+  "100.64.0.0/10", // tailnet
+  "fd7a:115c:a1e0::/48",
+  "127.0.0.0/8", // the gateway itself, incl. the exit loopbacks
+  "0.0.0.0/8",
+  "::1/128",
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+  "169.254.0.0/16",
+  "fc00::/7",
+];
 
 /**
  * Provisions Xray-core (VLESS-Vision-REALITY) on the gateway VPS.
@@ -62,15 +76,21 @@ export function createXray(
       ),
     );
 
-  // Guest hard-block: reality is their only entry, so routing keyed on their
-  // client email is airtight — the tailnet mesh and the exit loopbacks both go
-  // to the blackhole. Admins match no guest rule and fall through to `direct`.
+  // Guest hard-block, keyed on the client's `email` (= user name), which is the
+  // per-user dimension Xray gives us and hy2 does not. Admins match no guest
+  // rule and fall through to `direct`.
+  //
+  // These are IP rules, so they are only worth anything with a domainStrategy
+  // that resolves: under `AsIs` an IP rule never matches a request whose
+  // destination is a *domain*, and a guest editing their own profile to dial a
+  // hostname they control — A record pointing into the tailnet — walked straight
+  // past this into the mesh. `IPIfNonMatch` resolves after a non-matching round
+  // and matches again, which is what makes the rule mean what it looks like.
   const guests = clients.filter((c) => c.role === "guest").map((c) => c.name);
   const guestsList = JSON.stringify(guests);
   const guestRules = guests.length
     ? `
-      { "user": ${guestsList}, "ip": ["100.64.0.0/10", "fd7a:115c:a1e0::/48"], "outboundTag": "block" },
-      { "user": ${guestsList}, "ip": ["127.0.0.0/8"], "port": "${EXIT_PORT_RANGE}", "outboundTag": "block" },`
+      { "user": ${guestsList}, "ip": ${JSON.stringify(GUEST_DENY_CIDRS)}, "outboundTag": "block" },`
     : "";
 
   const install = new command.remote.Command(
@@ -152,7 +172,7 @@ cat > /usr/local/etc/xray/config.json << XRAY_EOF
     { "protocol": "blackhole", "tag": "block" }
   ],
   "routing": {
-    "domainStrategy": "AsIs",
+    "domainStrategy": "IPIfNonMatch",
     "rules": [${guestRules}
       { "network": "tcp,udp", "outboundTag": "direct" }
     ]
@@ -163,6 +183,7 @@ systemctl restart xray`,
       triggers: [
         clientsJson,
         guestsList,
+        GUEST_DENY_CIDRS.join(),
         shortId.hex,
         xray.serverNames.join(),
         xray.dest,


### PR DESCRIPTION
## The bug

The guest restrictions are **IP rules**:

```json
{ "user": ["guest1"], "ip": ["100.64.0.0/10", "fd7a:115c:a1e0::/48"], "outboundTag": "block" },
{ "user": ["guest1"], "ip": ["127.0.0.0/8"], "port": "20000-29999", "outboundTag": "block" }
```

and routing ran on Xray's default `"domainStrategy": "AsIs"`. From the Xray docs:

> **AsIs** (default): "No extra operation. Uses the domain in the destination address or the sniffed domain."
> **IPIfNonMatch**: "When no rule is matched after a full round of matching, resolve the domain to an IP and perform a second round of matching."

Under `AsIs`, **an IP rule never matches a request whose destination is a domain.** A guest edits their profile to dial `whatever.example.com` — an A record they control, pointing at `100.64.x.x` — it matches no rule, falls through to the catch-all `direct`, and the freedom outbound resolves it and connects. The blackhole was decoration against anyone who thought about it for a minute.

This is the same class of hole that made the hy2 ACL in #161 untrustworthy. It was worth checking rather than repeating the "airtight" claim in the comment.

## Impact

- **Tailnet: open.** Reaching `100.x` needs nothing but a TCP connection. Bounded only by what your Tailscale ACLs let the gateway node itself reach.
- **Exits: not fully open.** Egressing as the owner also needs the ss-rust PSK, which is never written into a guest profile. The IP rule was belt-and-braces and the braces held. Still worth fixing — it is the layer that is supposed to stop a guest who obtains a PSK some other way.
- Admin traffic: unaffected either way, since it matches no guest rule.

## The fix

`domainStrategy` → `IPIfNonMatch`, so a non-matching round is retried against resolved addresses. Resolution happens at the gateway, which runs unbound locally, so the extra lookup is a local cache hit. Per the docs, resolution affects *matching only* — "the routing system will not affect the actual destination address" — so nothing else about the connection changes.

**Also widens the deny list**, which had its own gap: `127.0.0.0/8` was blocked only on `20000-29999`, so `0.0.0.0` — a synonym for localhost on Linux — was reachable on any port, including the exit loopbacks. Enumerating what a guest may not reach is the losing side of that argument, so the rule is now every address that isn't the public internet (tailnet, loopback, `0.0.0.0/8`, RFC1918, link-local, ULA).

## Verify

- `aube run preview` — an xray config rewrite and nothing else. `GUEST_DENY_CIDRS` is in the command triggers, so later edits to the list re-render rather than silently persisting the old config.
- The real check is by hand, from a guest profile, since no unit test covers a shell-templated config: point an A record at `100.64.0.1`, dial it over the guest's REALITY outbound, and confirm it is blackholed rather than connected. Same with `0.0.0.0:20000`.
- 53 tests pass, unchanged — none of them cover xray's config, which is worth knowing about this file generally.

## Related

- #161 (guest hy2) is the mirror of this and should be closed or re-cut: hy2's ACL has the same domain-resolution question plus no per-user dimension at all. If guest hy2 comes back, the boundary wants to be systemd `IPAddressDeny=` — kernel-level, packet-layer, indifferent to how the address was arrived at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD