### PR TITLE
fix(ansible): retire NFS, which exported every share rw to the world

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Three-stage deployment targeting different host groups:
 
 2. **Homeserver Configuration** (`hosts: homeservers`)
    - MicroK8s cluster setup with configurable addons
-   - NFS and Samba file sharing
+   - Samba file sharing (read-only, tailnet + LAN only)
    - Syncthing for file synchronization
    - Media downloader services (yt-dlp, get-iplayer)
 
@@ -155,7 +155,7 @@ Three-stage deployment targeting different host groups:
 - **`users/`** - User accounts and SSH key management
 - **`github/`** - GitHub CLI and authentication setup
 - **`tailscale/`** - VPN mesh network connectivity
-- **`nfs/`** - Network file system exports
+- **`nfs/`** - Teardown only. NFS exported every share `rw` to `*`, so anything that could reach 2049 — including cluster pods, via an internet-facing service on the same host — could write all media and `/srv/files`. SMB covers the use case read-only; the role remains so the package stays gone.
 - **`samba/`** - SMB file sharing
 - **`syncthing/`** - P2P file sync service
 - **`downloader/`** - Media download tools (yt-dlp, get-iplayer, aria2)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ graph TB
 
             subgraph "Host Services"
                 Tailscale[Tailscale VPN]
-                Storage[NFS/Samba Storage]
+                Storage[Samba Storage]
                 Sync[Syncthing]
             end
         end
@@ -197,4 +197,4 @@ Updates are auto-committed and trigger a deploy.
 
 ## Server Management
 
-Ansible playbooks provision and configure the homeserver (MicroK8s, Tailscale, NFS/Samba, Syncthing, SSH hardening). See `ansible/` directory.
+Ansible playbooks provision and configure the homeserver (MicroK8s, Tailscale, Samba, Syncthing, SSH hardening). See `ansible/` directory.

--- a/ansible/roles/nfs/handlers/main.yml
+++ b/ansible/roles/nfs/handlers/main.yml
@@ -1,4 +1,0 @@
----
-- name: reload nfs exports
-  ansible.builtin.command: exportfs -ra
-  changed_when: true

--- a/ansible/roles/nfs/tasks/main.yml
+++ b/ansible/roles/nfs/tasks/main.yml
@@ -1,35 +1,37 @@
-- name: Install NFS server
-  ansible.builtin.package:
-    name: nfs-kernel-server
-    state: present
+---
+# NFS is retired: SMB serves the same shares read-only and confined to the
+# tailnet + LAN, so the export was surface with no remaining use.
+#
+# It exported every share `rw` to `*` with all_squash onto the media owner, so
+# authorisation was reachability and nothing else. The tailnet side of that is
+# unremarkable — those are the owner's own devices — but the export listened on
+# every interface, which included the cluster's pod network. Navidrome is
+# internet-facing on the same host with no NetworkPolicy, so a bug in it reached
+# 2049 and gained write access to all media and to /srv/files, the directory
+# serving the sing-box profiles. A read-only volumeMount on /music does not
+# survive that, which is what makes the export worth deleting rather than
+# narrowing.
+#
+# This is a teardown rather than a deleted role: dropping the role from the
+# playbook would leave the running server exporting exactly as before. It stays
+# afterwards as a cheap guard against the package returning.
 
-- name: Create share directories
-  ansible.builtin.file:
-    path: "{{ item.path }}"
-    state: directory
-    owner: "{{ item.owner }}"
-    group: "{{ item.owner }}"
-    mode: "0775"
-  with_items: "{{ shares }}"
-
-- name: Get UID for users
-  ansible.builtin.command: "id -u {{ item.owner }}"
-  register: user_uids
-  changed_when: false
-  with_items: "{{ shares }}"
-
-- name: Add NFS exports
-  ansible.builtin.lineinfile:
-    path: /etc/exports
-    line: "{{ item.0.path }} *(rw,sync,no_subtree_check,all_squash,anonuid={{ item.1.stdout }},anongid={{ item.1.stdout }})"
-    create: true
-  with_together:
-    - "{{ shares }}"
-    - "{{ user_uids.results }}"
-  notify: reload nfs exports
-
-- name: Enable and start NFS server
+- name: Stop and disable the NFS server
   ansible.builtin.systemd:
     name: nfs-kernel-server
-    enabled: true
-    state: started
+    state: stopped
+    enabled: false
+  # Absent on a rebuilt host, where there is nothing to stop.
+  failed_when: false
+
+- name: Remove NFS exports
+  ansible.builtin.file:
+    path: /etc/exports
+    state: absent
+
+- name: Remove the NFS server package
+  ansible.builtin.apt:
+    name: nfs-kernel-server
+    state: absent
+    purge: true
+    autoremove: true

--- a/ansible/roles/samba/tasks/main.yml
+++ b/ansible/roles/samba/tasks/main.yml
@@ -5,6 +5,18 @@
       - samba-common
     state: present
 
+# Inherited from the retired NFS role, which is where the shared `shares` var
+# used to be turned into directories. Without this a rebuilt host has smb.conf
+# pointing at paths that do not exist.
+- name: Create share directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.owner }}"
+    mode: "0775"
+  with_items: "{{ shares }}"
+
 # Anonymous, read-only access — no logins. Unknown users map to guest (which
 # runs as the media owner so reads succeed), and connections are restricted to
 # the tailnet + LAN so the open shares aren't reachable from anywhere else.


### PR DESCRIPTION
## What

NFS is removed. The role becomes a teardown (stop, disable, unexport, purge) and Samba inherits the share-directory creation the NFS role happened to own.

## Why

Every share was exported like this:

```
/mnt/kontent/music *(rw,sync,no_subtree_check,all_squash,anonuid=<jc>,anongid=<jc>)
```

`rw`, to `*`, squashing every client onto the user who owns the data. There is no authentication anywhere in that path — reachability *is* the authorisation. That covers all five shares, `/srv/files` included.

**The tailnet exposure is not the interesting part** — those are the owner's own devices. The export listened on every interface, which includes the cluster's pod network. Navidrome runs on that host, is internet-facing via Traefik with `ND_ENABLESHARING`, and has no NetworkPolicy (the only ones in the repo are for `mcp-gateway`). So the reachable path is:

```
0day in music.blit.cc  →  oldboy:2049  →  write all media + /srv/files
```

and `/srv/files` is what serves the sing-box profiles. Navidrome's `/music` volumeMount is correctly `readOnly: true` and the kubelet enforces it — but an attacker just mounts around it. A read-only mount on a host that also offers unauthenticated rw NFS is decoration.

Tightening the export was the alternative. Deleting removes the class of problem instead of leaving me to get an options string right, and costs nothing: SMB already serves the same shares `read only = yes`, guest-only, `hosts allow = 100.64.0.0/10 192.168.0.0/16 127.0.0.1`.

## Load-bearing decisions

**Teardown, not deletion.** Removing the role from the playbook would leave `nfs-kernel-server` running and exporting exactly as before — the code would look fixed while the box stayed wide open. The role stays afterwards as a cheap guard against the package returning. It is a no-op on a host that never had it.

**Samba inherits `Create share directories`.** That task lived in the NFS role, and both roles read the same `shares` var. Without moving it, a rebuilt host gets an `smb.conf` pointing at paths that do not exist — a latent break that would not show up until the next rebuild.

**Nothing referenced NFS.** Cluster storage is `hostpath-storage` (`group_vars/homeservers.yml`); the only mention anywhere was the playbook role line.

## Verify

- `run-playbook.yml` diffs the push and runs changed roles by tag, so this run executes `nfs` (teardown) and `samba` (directory creation).
- After it lands, on oldboy: `showmount -e localhost` should fail, `systemctl status nfs-kernel-server` should report the unit gone, `/etc/exports` should not exist.
- SMB unaffected: `smbclient -L //oldboy -N` should still list all five shares.

## Not in this PR

The rest of the blast-radius work this came out of, worth their own changes:

- **NetworkPolicy on the media pods.** Unrestricted pod egress is what turned a Navidrome bug into host access; the pattern already exists in `mcp-gateway.ts`.
- **`automountServiceAccountToken: false`** — every pod currently carries a default SA token.
- **Pod `securityContext` for Navidrome** — the schema supports it (`service.schemas.ts:22`), it is simply unset, so the container runs as whatever the image declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD