### PR TITLE
feat(services): confine Navidrome's egress, drop its capabilities, no SA token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Three-stage deployment targeting different host groups:
 
 2. **Homeserver Configuration** (`hosts: homeservers`)
    - MicroK8s cluster setup with configurable addons
-   - NFS and Samba file sharing
+   - Samba file sharing (read-only, tailnet + LAN only)
    - Syncthing for file synchronization
    - Media downloader services (yt-dlp, get-iplayer)
 
@@ -155,7 +155,7 @@ Three-stage deployment targeting different host groups:
 - **`users/`** - User accounts and SSH key management
 - **`github/`** - GitHub CLI and authentication setup
 - **`tailscale/`** - VPN mesh network connectivity
-- **`nfs/`** - Network file system exports
+- **`nfs/`** - Teardown only. NFS exported every share `rw` to `*`, so anything that could reach 2049 — including cluster pods, via an internet-facing service on the same host — could write all media and `/srv/files`. SMB covers the use case read-only; the role remains so the package stays gone.
 - **`samba/`** - SMB file sharing
 - **`syncthing/`** - P2P file sync service
 - **`downloader/`** - Media download tools (yt-dlp, get-iplayer, aria2)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ graph TB
 
             subgraph "Host Services"
                 Tailscale[Tailscale VPN]
-                Storage[NFS/Samba Storage]
+                Storage[Samba Storage]
                 Sync[Syncthing]
             end
         end
@@ -197,4 +197,4 @@ Updates are auto-committed and trigger a deploy.
 
 ## Server Management
 
-Ansible playbooks provision and configure the homeserver (MicroK8s, Tailscale, NFS/Samba, Syncthing, SSH hardening). See `ansible/` directory.
+Ansible playbooks provision and configure the homeserver (MicroK8s, Tailscale, Samba, Syncthing, SSH hardening). See `ansible/` directory.

--- a/ansible/roles/nfs/handlers/main.yml
+++ b/ansible/roles/nfs/handlers/main.yml
@@ -1,4 +1,0 @@
----
-- name: reload nfs exports
-  ansible.builtin.command: exportfs -ra
-  changed_when: true

--- a/ansible/roles/nfs/tasks/main.yml
+++ b/ansible/roles/nfs/tasks/main.yml
@@ -1,35 +1,37 @@
-- name: Install NFS server
-  ansible.builtin.package:
-    name: nfs-kernel-server
-    state: present
+---
+# NFS is retired: SMB serves the same shares read-only and confined to the
+# tailnet + LAN, so the export was surface with no remaining use.
+#
+# It exported every share `rw` to `*` with all_squash onto the media owner, so
+# authorisation was reachability and nothing else. The tailnet side of that is
+# unremarkable — those are the owner's own devices — but the export listened on
+# every interface, which included the cluster's pod network. Navidrome is
+# internet-facing on the same host with no NetworkPolicy, so a bug in it reached
+# 2049 and gained write access to all media and to /srv/files, the directory
+# serving the sing-box profiles. A read-only volumeMount on /music does not
+# survive that, which is what makes the export worth deleting rather than
+# narrowing.
+#
+# This is a teardown rather than a deleted role: dropping the role from the
+# playbook would leave the running server exporting exactly as before. It stays
+# afterwards as a cheap guard against the package returning.
 
-- name: Create share directories
-  ansible.builtin.file:
-    path: "{{ item.path }}"
-    state: directory
-    owner: "{{ item.owner }}"
-    group: "{{ item.owner }}"
-    mode: "0775"
-  with_items: "{{ shares }}"
-
-- name: Get UID for users
-  ansible.builtin.command: "id -u {{ item.owner }}"
-  register: user_uids
-  changed_when: false
-  with_items: "{{ shares }}"
-
-- name: Add NFS exports
-  ansible.builtin.lineinfile:
-    path: /etc/exports
-    line: "{{ item.0.path }} *(rw,sync,no_subtree_check,all_squash,anonuid={{ item.1.stdout }},anongid={{ item.1.stdout }})"
-    create: true
-  with_together:
-    - "{{ shares }}"
-    - "{{ user_uids.results }}"
-  notify: reload nfs exports
-
-- name: Enable and start NFS server
+- name: Stop and disable the NFS server
   ansible.builtin.systemd:
     name: nfs-kernel-server
-    enabled: true
-    state: started
+    state: stopped
+    enabled: false
+  # Absent on a rebuilt host, where there is nothing to stop.
+  failed_when: false
+
+- name: Remove NFS exports
+  ansible.builtin.file:
+    path: /etc/exports
+    state: absent
+
+- name: Remove the NFS server package
+  ansible.builtin.apt:
+    name: nfs-kernel-server
+    state: absent
+    purge: true
+    autoremove: true

--- a/ansible/roles/samba/tasks/main.yml
+++ b/ansible/roles/samba/tasks/main.yml
@@ -5,6 +5,18 @@
       - samba-common
     state: present
 
+# Inherited from the retired NFS role, which is where the shared `shares` var
+# used to be turned into directories. Without this a rebuilt host has smb.conf
+# pointing at paths that do not exist.
+- name: Create share directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.owner }}"
+    mode: "0775"
+  with_items: "{{ shares }}"
+
 # Anonymous, read-only access — no logins. Unknown users map to guest (which
 # runs as the media owner so reads succeed), and connections are restricted to
 # the tailnet + LAN so the open shares aren't reachable from anywhere else.

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -182,6 +182,12 @@ config:
       hostname: ''
       args:
         httpPort: 4533
+        # Public-facing, on the host that holds the media. Confine it: no
+        # private-space egress (so a bug in it cannot walk to whatever the node
+        # is serving and write the library by another route), and no
+        # capabilities, which it needs none of on a port above 1024.
+        networkPolicy: true
+        dropCapabilities: true
         strategy:
           type: Recreate
         image:

--- a/packages/infra/src/templates/service.schemas.ts
+++ b/packages/infra/src/templates/service.schemas.ts
@@ -10,10 +10,34 @@ import {
 } from "./schemas.ts";
 
 export const ServiceArgsSchema = z.object({
+  /**
+   * Drop every Linux capability from the container.
+   *
+   * Off by default rather than always-on because dropping ALL takes
+   * NET_BIND_SERVICE with it, and an image serving on `:80` *inside* the
+   * container needs that to bind. Safe for anything listening above 1024.
+   */
+  dropCapabilities: z.boolean().default(false),
   env: z.record(z.string(), z.string()).default({}),
   healthCheck: HealthCheckConfigSchema.optional(),
   hostVolumes: z.array(HostVolumeSchema).default([]),
   httpPort: z.uint32().default(80),
+  /**
+   * Confine the pod's egress to DNS and the public internet — no private
+   * space, so it cannot reach the node, the LAN, the tailnet, other pods or
+   * the API server.
+   *
+   * This is the control that decides what an RCE in a public-facing service
+   * is worth. A read-only volumeMount protects the path it covers and nothing
+   * else; unrestricted egress lets a compromised pod walk to whatever the host
+   * happens to be serving and write the same data by another route.
+   *
+   * Ingress is deliberately left alone. Restricting it adds little (Traefik is
+   * the only intended caller, and pod-to-pod reach is not the threat here)
+   * while risking the classic failure where the CNI also drops the kubelet's
+   * probes and the pod restart-loops.
+   */
+  networkPolicy: z.boolean().default(false),
   image: ImageSchema,
   limits: LimitsSchema.optional(),
   persistence: z.array(PersistenceSchema).default([]),

--- a/packages/infra/src/templates/service.test.ts
+++ b/packages/infra/src/templates/service.test.ts
@@ -1,9 +1,11 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, describe, expect, it } from "vitest";
+import { ServiceArgsSchema } from "./service.schemas.ts";
 
 describe("service template", () => {
   let mockProvider: k8s.Provider;
+  const created: pulumi.runtime.MockResourceArgs[] = [];
 
   beforeAll(() => {
     // Set up mocks first
@@ -14,17 +16,22 @@ describe("service template", () => {
       ): {
         id: string;
         state: any;
-      } => ({
-        id: `${args.inputs.name || args.name || "test"}_id`,
-        state: {
-          ...args.inputs,
+      } => {
+        // Recorded so tests can assert on resources the template creates but
+        // does not return — the NetworkPolicy and the Deployment.
+        created.push(args);
+        return {
           id: `${args.inputs.name || args.name || "test"}_id`,
-          metadata: {
-            name: args.inputs.name || args.name || "test",
-            ...args.inputs.metadata,
+          state: {
+            ...args.inputs,
+            id: `${args.inputs.name || args.name || "test"}_id`,
+            metadata: {
+              name: args.inputs.name || args.name || "test",
+              ...args.inputs.metadata,
+            },
           },
-        },
-      }),
+        };
+      },
     });
 
     mockProvider = new k8s.Provider("test-provider", {
@@ -34,7 +41,7 @@ describe("service template", () => {
 
   it("creates service with basic configuration", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       hostVolumes: [],
       httpPort: 80,
@@ -42,7 +49,7 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "test-service", serviceArgs);
 
@@ -55,7 +62,7 @@ describe("service template", () => {
 
   it("creates service with environment variables", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: { NODE_ENV: "production", PORT: "3000" },
       hostVolumes: [],
       httpPort: 3000,
@@ -63,7 +70,7 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "test-app", serviceArgs);
 
@@ -72,7 +79,7 @@ describe("service template", () => {
 
   it("creates service with persistence volumes", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       hostVolumes: [],
       httpPort: 5432,
@@ -90,7 +97,7 @@ describe("service template", () => {
       ],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "postgres", serviceArgs);
 
@@ -99,7 +106,7 @@ describe("service template", () => {
 
   it("creates service with health checks", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       healthCheck: {
         path: "/health",
@@ -120,7 +127,7 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "web-app", serviceArgs);
 
@@ -129,7 +136,7 @@ describe("service template", () => {
 
   it("creates service with resource limits", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       hostVolumes: [],
       httpPort: 80,
@@ -141,10 +148,90 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 2,
-    };
+    });
 
     const service = createService(mockProvider, "limited-app", serviceArgs);
 
     expect(service).toBeDefined();
+  });
+
+  describe("hardening", () => {
+    const args = (over: Record<string, unknown> = {}) =>
+      ServiceArgsSchema.parse({
+        image: { repository: "nginx", tag: "latest" },
+        httpPort: 4533,
+        ...over,
+      });
+    const find = (type: string, name: string) =>
+      created.find((r) => r.type.endsWith(type) && r.name === name);
+    // Registration is async even under mocks, and resolving the returned
+    // Service's urn is not enough — the Deployment and NetworkPolicy register
+    // after it. So wait for the resource under test to actually appear.
+    const waitFor = async (type: string, name: string) => {
+      for (let i = 0; i < 100; i++) {
+        const found = find(type, name);
+        if (found) return found;
+        // Sequential is the point — polling for something to appear.
+        // oxlint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      throw new Error(`${name} was never registered`);
+    };
+
+    it("never mounts a service account token", async () => {
+      const { createService } = await import("./service.ts");
+      createService(mockProvider, "plain", args());
+
+      const deployment = await waitFor("Deployment", "plain-deployment");
+      expect(
+        deployment.inputs.spec.template.spec.automountServiceAccountToken,
+      ).toBe(false);
+    });
+
+    it("confines egress only where asked, and never to private space", async () => {
+      const { createService } = await import("./service.ts");
+      createService(mockProvider, "open", args());
+      createService(mockProvider, "confined", args({ networkPolicy: true }));
+
+      const { inputs } = await waitFor("NetworkPolicy", "confined-netpol");
+      await waitFor("Deployment", "open-deployment");
+      // Opt-in: the unconfined service gets no policy at all, rather than one
+      // that happens to allow everything.
+      expect(find("NetworkPolicy", "open-netpol")).toBeUndefined();
+
+      const spec = inputs.spec;
+      expect(spec.policyTypes).toEqual(["Egress"]);
+      // The tailnet and the node's own LAN are the addresses that turn an RCE
+      // into host access, so their absence here is the whole point.
+      expect(spec.egress[1].to[0].ipBlock.except).toEqual(
+        expect.arrayContaining([
+          "10.0.0.0/8",
+          "192.168.0.0/16",
+          "100.64.0.0/10",
+        ]),
+      );
+      // DNS has to survive the deny above, or the pod resolves nothing.
+      expect(spec.egress[0].ports).toEqual([
+        { protocol: "UDP", port: 53 },
+        { protocol: "TCP", port: 53 },
+      ]);
+    });
+
+    it("drops capabilities only where asked", async () => {
+      const { createService } = await import("./service.ts");
+      createService(mockProvider, "caps", args());
+      createService(mockProvider, "nocaps", args({ dropCapabilities: true }));
+
+      const sc = async (name: string) =>
+        (await waitFor("Deployment", `${name}-deployment`)).inputs.spec.template
+          .spec.containers[0].securityContext;
+
+      expect((await sc("caps")).capabilities).toBeUndefined();
+      expect((await sc("nocaps")).capabilities).toEqual({ drop: ["ALL"] });
+      // Applied regardless — it costs nothing and breaks nothing.
+      expect((await sc("caps")).seccompProfile).toEqual({
+        type: "RuntimeDefault",
+      });
+    });
   });
 });

--- a/packages/infra/src/templates/service.ts
+++ b/packages/infra/src/templates/service.ts
@@ -31,12 +31,14 @@ export function createService(
   provider: k8s.Provider,
   serviceName: string,
   {
+    dropCapabilities,
     env,
     healthCheck,
     hostVolumes,
     httpPort,
     image,
     limits,
+    networkPolicy,
     persistence,
     ports,
     replicas,
@@ -177,6 +179,9 @@ export function createService(
             labels: { app: serviceName },
           },
           spec: {
+            // None of these talk to the API server, so the token is a free
+            // foothold for anything that lands in the container.
+            automountServiceAccountToken: false,
             containers: [
               {
                 name: serviceName,
@@ -209,6 +214,8 @@ export function createService(
                 ...probes,
                 securityContext: {
                   allowPrivilegeEscalation: false,
+                  seccompProfile: { type: "RuntimeDefault" },
+                  ...(dropCapabilities && { capabilities: { drop: ["ALL"] } }),
                 },
               },
             ],
@@ -232,6 +239,57 @@ export function createService(
     },
     { deleteBeforeReplace: persistence.length > 0, provider },
   );
+
+  // Egress only — see `networkPolicy` in the schema for why ingress is left
+  // alone. DNS needs its own rule because the cluster resolver's ClusterIP
+  // sits inside the private space the second rule excludes; policy rules are
+  // OR'd, so the narrow allow survives the broad deny.
+  if (networkPolicy) {
+    new k8s.networking.v1.NetworkPolicy(
+      `${serviceName}-netpol`,
+      {
+        metadata: { name: serviceName },
+        spec: {
+          podSelector: { matchLabels: { app: serviceName } },
+          policyTypes: ["Egress"],
+          egress: [
+            {
+              to: [
+                {
+                  namespaceSelector: {
+                    matchLabels: {
+                      "kubernetes.io/metadata.name": "kube-system",
+                    },
+                  },
+                },
+              ],
+              ports: [
+                { protocol: "UDP", port: 53 },
+                { protocol: "TCP", port: 53 },
+              ],
+            },
+            {
+              to: [
+                {
+                  ipBlock: {
+                    cidr: "0.0.0.0/0",
+                    except: [
+                      "10.0.0.0/8", // pod + service CIDRs, and any LAN using it
+                      "172.16.0.0/12",
+                      "192.168.0.0/16", // the node's own LAN
+                      "169.254.0.0/16",
+                      "100.64.0.0/10", // tailnet
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      { provider },
+    );
+  }
 
   return service;
 }

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -269,6 +269,10 @@
               "args": {
                 "type": "object",
                 "properties": {
+                  "dropCapabilities": {
+                    "default": false,
+                    "type": "boolean"
+                  },
                   "env": {
                     "default": {},
                     "type": "object",
@@ -397,6 +401,10 @@
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 4294967295
+                  },
+                  "networkPolicy": {
+                    "default": false,
+                    "type": "boolean"
                   },
                   "image": {
                     "$ref": "#/$defs/__schema3"


### PR DESCRIPTION
Stacked conceptually on #165 but independent of it — that removes today's instance of the problem, this removes the category. Either can merge first.

## What

Three controls, driven by config so nothing else changes shape:

| | Applies to | Why not everything |
| --- | --- | --- |
| `networkPolicy: true` | Navidrome | Opt-in — a service with an internal caller would break |
| `dropCapabilities: true` | Navidrome | Dropping ALL removes `NET_BIND_SERVICE`, which the nginx-based services need to bind `:80` |
| `seccompProfile: RuntimeDefault` | every service | Costs nothing |
| `automountServiceAccountToken: false` | every service | None of them talk to the API server |

## Why

Navidrome is internet-facing (`music.blit.cc`, with `ND_ENABLESHARING`) and runs on the host holding the media. Its `/music` mount is correctly `readOnly: true` and the kubelet enforces it — but **a mount only protects the path it covers.** With unrestricted egress, a compromised pod reaches whatever the node happens to be serving and writes the same data by another route. #165 removes the route that existed today (rw NFS on `*`); this removes the ability to go looking for the next one.

The policy confines egress to DNS and the public internet, excluding private space: the node, the LAN, the tailnet, other pods, the API server. DNS needs its own rule because the cluster resolver's ClusterIP sits inside the range the broad rule denies — policy rules are OR'd, so the narrow allow survives the broad deny.

## Load-bearing decisions

**Ingress is deliberately untouched.** Traefik is the only intended caller, so restricting ingress buys little — and it risks the classic failure where the CNI also drops the kubelet's probes and the pod restart-loops. Trading a working music server for a control with no real benefit here is a bad deal. Egress is where the blast radius actually lives.

**Capability dropping is opt-in, not template-wide.** `drop: ["ALL"]` takes `NET_BIND_SERVICE` with it. The `files` and `blit` containers serve on `:80` *inside* the container and would fail to bind. Navidrome listens on 4533 and needs no capability at all.

**Not included: `runAsNonRoot` and `readOnlyRootFilesystem`.** Both need facts I do not have — the uid owning `/home/navidrome/data` on the host, and where the container writes at runtime (the transcoding cache in particular). Guessing either converts a hardening change into an outage. `SecurityContextSchema` already supports the uid/gid side, so it is a config change once someone checks `stat /home/navidrome/data` on oldboy.

## Verify

- 61 tests pass, three new: no SA token on any deployment, the policy created only where asked with the tailnet/LAN/pod ranges excluded and DNS still allowed, and capabilities dropped only where asked.
- `aube run preview` — one new NetworkPolicy plus a Navidrome pod respec; no PV/PVC churn.
- After deploy, the check that matters: `kubectl exec` into the Navidrome pod and confirm the node's own LAN address is unreachable while `https://ws.audioscrobbler.com` still resolves and connects — metadata lookups must keep working.

## Note on the tests

Fixtures now go through `ServiceArgsSchema.parse` instead of being hand-built literals. Two new schema fields broke three unrelated tests, which is exactly the brittleness worth removing while I was in there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD