### PR TITLE
feat(services): confine Navidrome's egress (re-land of #166 without the caps)

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -182,6 +182,17 @@ config:
       hostname: ''
       args:
         httpPort: 4533
+        # Public-facing, on the host that holds the media: confine egress to
+        # DNS and the public internet, so a bug in it cannot walk to whatever
+        # the node is serving and write the library by another route.
+        #
+        # dropCapabilities is deliberately NOT set. It looks safe — nothing
+        # here binds a privileged port — but Navidrome runs as root against a
+        # /data directory root does not own, so it relies on CAP_DAC_OVERRIDE
+        # to write its SQLite DB. Dropping ALL takes that away and the DB opens
+        # read-only, which is a crash loop, not a degradation. Dropping caps
+        # here means first giving /data an owner the container runs as.
+        networkPolicy: true
         strategy:
           type: Recreate
         image:

--- a/packages/infra/src/templates/service.schemas.ts
+++ b/packages/infra/src/templates/service.schemas.ts
@@ -10,10 +10,34 @@ import {
 } from "./schemas.ts";
 
 export const ServiceArgsSchema = z.object({
+  /**
+   * Drop every Linux capability from the container.
+   *
+   * Off by default rather than always-on because dropping ALL takes
+   * NET_BIND_SERVICE with it, and an image serving on `:80` *inside* the
+   * container needs that to bind. Safe for anything listening above 1024.
+   */
+  dropCapabilities: z.boolean().default(false),
   env: z.record(z.string(), z.string()).default({}),
   healthCheck: HealthCheckConfigSchema.optional(),
   hostVolumes: z.array(HostVolumeSchema).default([]),
   httpPort: z.uint32().default(80),
+  /**
+   * Confine the pod's egress to DNS and the public internet — no private
+   * space, so it cannot reach the node, the LAN, the tailnet, other pods or
+   * the API server.
+   *
+   * This is the control that decides what an RCE in a public-facing service
+   * is worth. A read-only volumeMount protects the path it covers and nothing
+   * else; unrestricted egress lets a compromised pod walk to whatever the host
+   * happens to be serving and write the same data by another route.
+   *
+   * Ingress is deliberately left alone. Restricting it adds little (Traefik is
+   * the only intended caller, and pod-to-pod reach is not the threat here)
+   * while risking the classic failure where the CNI also drops the kubelet's
+   * probes and the pod restart-loops.
+   */
+  networkPolicy: z.boolean().default(false),
   image: ImageSchema,
   limits: LimitsSchema.optional(),
   persistence: z.array(PersistenceSchema).default([]),

--- a/packages/infra/src/templates/service.test.ts
+++ b/packages/infra/src/templates/service.test.ts
@@ -1,9 +1,11 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, describe, expect, it } from "vitest";
+import { ServiceArgsSchema } from "./service.schemas.ts";
 
 describe("service template", () => {
   let mockProvider: k8s.Provider;
+  const created: pulumi.runtime.MockResourceArgs[] = [];
 
   beforeAll(() => {
     // Set up mocks first
@@ -14,17 +16,22 @@ describe("service template", () => {
       ): {
         id: string;
         state: any;
-      } => ({
-        id: `${args.inputs.name || args.name || "test"}_id`,
-        state: {
-          ...args.inputs,
+      } => {
+        // Recorded so tests can assert on resources the template creates but
+        // does not return — the NetworkPolicy and the Deployment.
+        created.push(args);
+        return {
           id: `${args.inputs.name || args.name || "test"}_id`,
-          metadata: {
-            name: args.inputs.name || args.name || "test",
-            ...args.inputs.metadata,
+          state: {
+            ...args.inputs,
+            id: `${args.inputs.name || args.name || "test"}_id`,
+            metadata: {
+              name: args.inputs.name || args.name || "test",
+              ...args.inputs.metadata,
+            },
           },
-        },
-      }),
+        };
+      },
     });
 
     mockProvider = new k8s.Provider("test-provider", {
@@ -34,7 +41,7 @@ describe("service template", () => {
 
   it("creates service with basic configuration", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       hostVolumes: [],
       httpPort: 80,
@@ -42,7 +49,7 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "test-service", serviceArgs);
 
@@ -55,7 +62,7 @@ describe("service template", () => {
 
   it("creates service with environment variables", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: { NODE_ENV: "production", PORT: "3000" },
       hostVolumes: [],
       httpPort: 3000,
@@ -63,7 +70,7 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "test-app", serviceArgs);
 
@@ -72,7 +79,7 @@ describe("service template", () => {
 
   it("creates service with persistence volumes", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       hostVolumes: [],
       httpPort: 5432,
@@ -90,7 +97,7 @@ describe("service template", () => {
       ],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "postgres", serviceArgs);
 
@@ -99,7 +106,7 @@ describe("service template", () => {
 
   it("creates service with health checks", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       healthCheck: {
         path: "/health",
@@ -120,7 +127,7 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 1,
-    };
+    });
 
     const service = createService(mockProvider, "web-app", serviceArgs);
 
@@ -129,7 +136,7 @@ describe("service template", () => {
 
   it("creates service with resource limits", async () => {
     const { createService } = await import("./service.ts");
-    const serviceArgs = {
+    const serviceArgs = ServiceArgsSchema.parse({
       env: {},
       hostVolumes: [],
       httpPort: 80,
@@ -141,10 +148,90 @@ describe("service template", () => {
       persistence: [],
       ports: [],
       replicas: 2,
-    };
+    });
 
     const service = createService(mockProvider, "limited-app", serviceArgs);
 
     expect(service).toBeDefined();
+  });
+
+  describe("hardening", () => {
+    const args = (over: Record<string, unknown> = {}) =>
+      ServiceArgsSchema.parse({
+        image: { repository: "nginx", tag: "latest" },
+        httpPort: 4533,
+        ...over,
+      });
+    const find = (type: string, name: string) =>
+      created.find((r) => r.type.endsWith(type) && r.name === name);
+    // Registration is async even under mocks, and resolving the returned
+    // Service's urn is not enough — the Deployment and NetworkPolicy register
+    // after it. So wait for the resource under test to actually appear.
+    const waitFor = async (type: string, name: string) => {
+      for (let i = 0; i < 100; i++) {
+        const found = find(type, name);
+        if (found) return found;
+        // Sequential is the point — polling for something to appear.
+        // oxlint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      throw new Error(`${name} was never registered`);
+    };
+
+    it("never mounts a service account token", async () => {
+      const { createService } = await import("./service.ts");
+      createService(mockProvider, "plain", args());
+
+      const deployment = await waitFor("Deployment", "plain-deployment");
+      expect(
+        deployment.inputs.spec.template.spec.automountServiceAccountToken,
+      ).toBe(false);
+    });
+
+    it("confines egress only where asked, and never to private space", async () => {
+      const { createService } = await import("./service.ts");
+      createService(mockProvider, "open", args());
+      createService(mockProvider, "confined", args({ networkPolicy: true }));
+
+      const { inputs } = await waitFor("NetworkPolicy", "confined-netpol");
+      await waitFor("Deployment", "open-deployment");
+      // Opt-in: the unconfined service gets no policy at all, rather than one
+      // that happens to allow everything.
+      expect(find("NetworkPolicy", "open-netpol")).toBeUndefined();
+
+      const spec = inputs.spec;
+      expect(spec.policyTypes).toEqual(["Egress"]);
+      // The tailnet and the node's own LAN are the addresses that turn an RCE
+      // into host access, so their absence here is the whole point.
+      expect(spec.egress[1].to[0].ipBlock.except).toEqual(
+        expect.arrayContaining([
+          "10.0.0.0/8",
+          "192.168.0.0/16",
+          "100.64.0.0/10",
+        ]),
+      );
+      // DNS has to survive the deny above, or the pod resolves nothing.
+      expect(spec.egress[0].ports).toEqual([
+        { protocol: "UDP", port: 53 },
+        { protocol: "TCP", port: 53 },
+      ]);
+    });
+
+    it("drops capabilities only where asked", async () => {
+      const { createService } = await import("./service.ts");
+      createService(mockProvider, "caps", args());
+      createService(mockProvider, "nocaps", args({ dropCapabilities: true }));
+
+      const sc = async (name: string) =>
+        (await waitFor("Deployment", `${name}-deployment`)).inputs.spec.template
+          .spec.containers[0].securityContext;
+
+      expect((await sc("caps")).capabilities).toBeUndefined();
+      expect((await sc("nocaps")).capabilities).toEqual({ drop: ["ALL"] });
+      // Applied regardless — it costs nothing and breaks nothing.
+      expect((await sc("caps")).seccompProfile).toEqual({
+        type: "RuntimeDefault",
+      });
+    });
   });
 });

--- a/packages/infra/src/templates/service.ts
+++ b/packages/infra/src/templates/service.ts
@@ -31,12 +31,14 @@ export function createService(
   provider: k8s.Provider,
   serviceName: string,
   {
+    dropCapabilities,
     env,
     healthCheck,
     hostVolumes,
     httpPort,
     image,
     limits,
+    networkPolicy,
     persistence,
     ports,
     replicas,
@@ -177,6 +179,9 @@ export function createService(
             labels: { app: serviceName },
           },
           spec: {
+            // None of these talk to the API server, so the token is a free
+            // foothold for anything that lands in the container.
+            automountServiceAccountToken: false,
             containers: [
               {
                 name: serviceName,
@@ -209,6 +214,8 @@ export function createService(
                 ...probes,
                 securityContext: {
                   allowPrivilegeEscalation: false,
+                  seccompProfile: { type: "RuntimeDefault" },
+                  ...(dropCapabilities && { capabilities: { drop: ["ALL"] } }),
                 },
               },
             ],
@@ -232,6 +239,57 @@ export function createService(
     },
     { deleteBeforeReplace: persistence.length > 0, provider },
   );
+
+  // Egress only — see `networkPolicy` in the schema for why ingress is left
+  // alone. DNS needs its own rule because the cluster resolver's ClusterIP
+  // sits inside the private space the second rule excludes; policy rules are
+  // OR'd, so the narrow allow survives the broad deny.
+  if (networkPolicy) {
+    new k8s.networking.v1.NetworkPolicy(
+      `${serviceName}-netpol`,
+      {
+        metadata: { name: serviceName },
+        spec: {
+          podSelector: { matchLabels: { app: serviceName } },
+          policyTypes: ["Egress"],
+          egress: [
+            {
+              to: [
+                {
+                  namespaceSelector: {
+                    matchLabels: {
+                      "kubernetes.io/metadata.name": "kube-system",
+                    },
+                  },
+                },
+              ],
+              ports: [
+                { protocol: "UDP", port: 53 },
+                { protocol: "TCP", port: 53 },
+              ],
+            },
+            {
+              to: [
+                {
+                  ipBlock: {
+                    cidr: "0.0.0.0/0",
+                    except: [
+                      "10.0.0.0/8", // pod + service CIDRs, and any LAN using it
+                      "172.16.0.0/12",
+                      "192.168.0.0/16", // the node's own LAN
+                      "169.254.0.0/16",
+                      "100.64.0.0/10", // tailnet
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      { provider },
+    );
+  }
 
   return service;
 }

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -269,6 +269,10 @@
               "args": {
                 "type": "object",
                 "properties": {
+                  "dropCapabilities": {
+                    "default": false,
+                    "type": "boolean"
+                  },
                   "env": {
                     "default": {},
                     "type": "object",
@@ -397,6 +401,10 @@
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 4294967295
+                  },
+                  "networkPolicy": {
+                    "default": false,
+                    "type": "boolean"
                   },
                   "image": {
                     "$ref": "#/$defs/__schema3"


### PR DESCRIPTION
Re-lands #166 minus the one line that broke it. Reverted in #167.

## What went wrong

```
level=fatal msg="Database could not be opened!" error="attempt to write a readonly database"
```

`dropCapabilities: true`. Navidrome runs as **root** against a `/data` directory root does not own — it writes its SQLite DB purely on `CAP_DAC_OVERRIDE`, the capability that lets root bypass file permission checks. `drop: ["ALL"]` removed it, root became an ordinary user against someone else's directory, and SQLite reported the mount read-only. Container exits on startup, CrashLoopBackOff, Traefik 503.

I reasoned about the wrong capability. The check I applied was "does it bind a privileged port" — it listens on 4533, so no. The capability it actually needed was for *filesystem access*, which is invisible from the config and only shows up at runtime.

## What is unchanged from #166

Everything else, because nothing else was implicated:

- **The NetworkPolicy** is egress-only and this was a filesystem failure — it cannot cause a crash loop. It is also the control worth having: it is what stops a compromised pod walking to whatever the node is serving.
- `seccompProfile: RuntimeDefault` and `automountServiceAccountToken: false` — both applied cleanly.
- The `dropCapabilities` option itself stays in the schema. It is correct for a service that does not need it; Navidrome simply is not one.

The config now carries a comment saying why it is absent, because `dropCapabilities: true` on a service listening above 1024 looks obviously safe. That is how it got merged in the first place.

## Doing it properly later

Dropping capabilities on Navidrome means removing the need for `DAC_OVERRIDE` rather than removing the capability and hoping: `chown` `/home/navidrome/data` to a fixed uid, set `securityContext.runAsUser` to match (`SecurityContextSchema` already supports it), then drop everything. That needs `stat -c '%u %g' /home/navidrome/data` on oldboy — a fact about the host, not a guess.

## Verify

- 61 tests pass, unchanged from #166.
- The failure mode is loud and immediate: if this is wrong again, the pod crash-loops within a minute of deploy rather than degrading quietly.
- Post-deploy, the check that matters is that Navidrome still reaches the internet for metadata — the node's LAN address should be unreachable from the pod while `ws.audioscrobbler.com` still resolves and connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD