### PR TITLE
fix(traefik): use the value name the chart actually reads for its rollout

### DIFF
--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -80,10 +80,19 @@ export function createIngress(
           enabled: true,
           size: "128Mi",
         },
-        // Single node with hostPort — can't rolling update because the
-        // old pod holds the port. Kill it first, then start the new one.
-        deployment: {
-          strategy: "Recreate",
+        // Single node with hostPort: the replacement pod cannot bind :80/:443
+        // while the old one holds them, so the chart's default (maxUnavailable
+        // 0, maxSurge 1) deadlocks — the new pod stays Pending forever and the
+        // old one is never allowed to leave. Traefik sat 20 days on a stale pod
+        // that way, silently ignoring chart bumps.
+        //
+        // Old pod goes first, then the new one binds. That is a few seconds of
+        // no ingress per deploy, which is the price of one node and a hostPort.
+        // This key is `updateStrategy`, NOT `deployment.strategy` — the latter
+        // is not in the chart's values and was accepted and ignored.
+        updateStrategy: {
+          type: "RollingUpdate",
+          rollingUpdate: { maxUnavailable: 1, maxSurge: 0 },
         },
         resources: {
           limits: {


### PR DESCRIPTION
## The bug

`ingress.ts` set this, with a comment describing the deadlock precisely:

```ts
deployment: { strategy: "Recreate" },
```

**That key does not exist in the Traefik chart.** The strategy lives at top-level `updateStrategy` ([values.yaml](https://github.com/traefik/traefik-helm-chart/blob/v41.0.2/traefik/values.yaml#L268)). Helm accepted the unknown key, ignored it, and applied the chart default:

```yaml
updateStrategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 0
    maxSurge: 1
```

On a single node with `hostPort: 80/443` that can never converge. The replacement pod cannot bind the ports while the old pod holds them, and `maxUnavailable: 0` forbids removing the old one first. Deadlock, permanently.

## Observed

```
traefik-56a791f2-6d9db7df8f-4j6b8   0/1   Pending   0   20d
traefik-56a791f2-7d6c5c8d88-wkdwq   1/1   Running   37  40d
```

```
0/1 nodes are available: 1 node(s) didn't have free ports for the requested pod ports.
```

The consequence is not cosmetic: **Traefik has been serving from a 40-day-old pod for the last 20 days, and chart version bumps have silently not taken effect.** The `chartVersion: 41.0.2` in config is aspirational — whatever is running predates it. Your July notes flagged the same Pending pod at 11 days; it was read as cosmetic then, and it isn't.

## The fix

```ts
updateStrategy: {
  type: "RollingUpdate",
  rollingUpdate: { maxUnavailable: 1, maxSurge: 0 },
},
```

Old pod terminates first, then the new one binds. `RollingUpdate` with those numbers rather than `Recreate` because it keeps every key inside the chart's own schema — `Recreate` would need `rollingUpdate: null` to avoid emitting a spec the API rejects, and relying on null-means-delete through Pulumi's Helm values is exactly the kind of assumption that produced this bug.

**This deploy will briefly drop ingress** — a few seconds while Traefik restarts — and it is the first time in 20 days the chart will genuinely roll. Worth watching: it is also the first time 41.0.2 actually gets applied, so any breaking change between the running version and that one arrives now rather than whenever it was merged.

## Verify

- After deploy: only one Traefik pod, `Running`, age measured in minutes.
- `kubectl get rs | grep traefik` — the stuck ReplicaSet should scale to 0. If the Pending pod survives, delete it once by hand; it belongs to a ReplicaSet that could never schedule.
- `curl -I https://music.blit.cc/` returns 302 (or 200 for blit.cc) once it settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD