### PR TITLE
feat(services): confine blit and files egress too

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -238,6 +238,11 @@ config:
     files:
       hostname: ''
       args:
+        # Serves a read-only mount to the internet and nothing else — it has no
+        # business reaching the node, the LAN or another pod. No capability
+        # dropping: nginx binds :80 inside the container, which needs
+        # NET_BIND_SERVICE even as root once ALL is dropped.
+        networkPolicy: true
         strategy:
           type: Recreate
         image:
@@ -268,6 +273,11 @@ config:
     blit:
       hostname: ''
       args:
+        # Public-facing, so confine egress to DNS and the internet. No
+        # capability dropping: the image is distroless, so what it needs at
+        # runtime cannot be checked from here, and guessing that is what took
+        # Navidrome down (see #166/#168).
+        networkPolicy: true
         replicas: 2
         healthCheck: {}
         limits:


### PR DESCRIPTION
Extends #168's egress policy to the other two public services. One config line each; the template already supports it.

## Why these two

Same condition that made Navidrome worth confining: internet-facing, running on the host that holds the data. `files` serves a read-only mount of `/srv/files` — the directory that distributes sing-box profiles — and `blit` is a public web app. Neither has any business reaching the node, the LAN, the tailnet, another pod or the API server, so egress is confined to DNS and the public internet.

## What they deliberately do NOT get

`dropCapabilities`, for reasons I checked in the running cluster rather than inferred:

- **`files` runs as `uid=0` and nginx binds `:80` inside the container.** Once ALL is dropped, even root cannot bind a port below 1024 — it needs `NET_BIND_SERVICE`. This would crash-loop exactly like Navidrome did.
- **`blit` is distroless** — no shell, so `kubectl exec` cannot tell me what uid it runs as or what it writes. What cannot be established should not be guessed; that guess is what produced #166 → #167 → #168.

The capability flag stays available for a service that has been verified to need nothing. Neither of these has been.

## Risk

The one thing that could bite: if `blit` makes server-side requests to another pod in the cluster, this policy breaks them, since only DNS and public addresses are allowed. Nothing in its config suggests an internal dependency — no env pointing at a cluster service — but it is distroless and I could not inspect it directly. The failure would be visible immediately on `blit.cc` rather than silent.

`files` is pure static nginx over a read-only mount, so it has no egress needs at all.

## Verify

- `aube run preview` — two new NetworkPolicies, no pod respec (egress policy does not change the pod spec, so no restarts).
- `curl -I https://blit.cc/` and the files host after deploy.
- `kubectl get networkpolicy` should list `navidrome`, `blit`, `files` alongside the two `mcp-gateway` ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD