### PR TITLE
feat(navidrome): run as the uid that owns its data, then drop capabilities

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -185,14 +185,19 @@ config:
         # Public-facing, on the host that holds the media: confine egress to
         # DNS and the public internet, so a bug in it cannot walk to whatever
         # the node is serving and write the library by another route.
-        #
-        # dropCapabilities is deliberately NOT set. It looks safe — nothing
-        # here binds a privileged port — but Navidrome runs as root against a
-        # /data directory root does not own, so it relies on CAP_DAC_OVERRIDE
-        # to write its SQLite DB. Dropping ALL takes that away and the DB opens
-        # read-only, which is a crash loop, not a degradation. Dropping caps
-        # here means first giving /data an owner the container runs as.
         networkPolicy: true
+        # Run as the uid that already owns /data (1001:1002, 0755 on the host),
+        # rather than as root borrowing CAP_DAC_OVERRIDE to write a directory it
+        # does not own. That is what makes dropping capabilities safe here: the
+        # DB is writable by ownership, 4533 needs no NET_BIND_SERVICE, and
+        # /music (1000:1000, 0775) stays readable through its other bits.
+        #
+        # fsGroup is deliberately absent — see SecurityContextSchema. Setting it
+        # would hand kubelet ownership management over a 2Ti local PV.
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1002
+        dropCapabilities: true
         strategy:
           type: Recreate
         image:

--- a/packages/infra/src/templates/schemas.ts
+++ b/packages/infra/src/templates/schemas.ts
@@ -43,8 +43,16 @@ export const StrategySchema = z.object({
   type: z.enum(["Recreate", "RollingUpdate"]).default("RollingUpdate"),
 });
 
+/**
+ * Pod-level security context. Every field is optional and none is defaulted,
+ * because setting one has consequences: `fsGroup` in particular switches on
+ * kubelet volume ownership management, which walks and chowns the volume. On a
+ * 2Ti media library backed by a `local` PV that is not a default anyone wants
+ * to acquire by accident — so a service that only needs to run as a given uid
+ * sets exactly that and nothing else.
+ */
 export const SecurityContextSchema = z.object({
-  fsGroup: z.number().default(1000),
-  runAsGroup: z.number().default(1000),
-  runAsUser: z.number().default(1000),
+  fsGroup: z.number().optional(),
+  runAsGroup: z.number().optional(),
+  runAsUser: z.number().optional(),
 });

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -476,15 +476,12 @@
                     "type": "object",
                     "properties": {
                       "fsGroup": {
-                        "default": 1000,
                         "type": "number"
                       },
                       "runAsGroup": {
-                        "default": 1000,
                         "type": "number"
                       },
                       "runAsUser": {
-                        "default": 1000,
                         "type": "number"
                       }
                     }


### PR DESCRIPTION
⚠️ **Do not merge while you want music.** This restarts Navidrome, and if the reasoning below is wrong it crash-loops exactly as #166 did. Revert is one line. Everything else in this batch is safe to merge whenever.

Finishes what #166 got wrong and #168 deliberately left open.

## What #166 got wrong

It dropped capabilities on the theory that a service listening on 4533 needs none. Wrong capability: Navidrome runs as **root** against a `/data` it does not own, so it wrote its SQLite DB purely on `CAP_DAC_OVERRIDE`. Dropping ALL made the DB read-only and the container exited on startup.

## The facts, from the box

```
$ kubectl exec deploy/navidrome-deployment -- sh -c 'id; stat -c "%u %g %a %n" /data /music'
uid=0(root) gid=0(root)
1001 1002 755 /data
1000 1000 775 /music
```

So the fix is not to grant a capability back — it is to remove the need for one:

- **`runAsUser: 1001, runAsGroup: 1002`** → Navidrome owns `/data` (0755, owner rwx), so the DB is writable by ownership rather than by override.
- **`/music` stays readable** — 0775 means other-bits `r-x`, and it is mounted read-only anyway.
- **`dropCapabilities: true` is now safe** — 4533 needs no `NET_BIND_SERVICE`, and nothing else requires a capability once the uid owns its data.

## fsGroup is deliberately absent, and no longer defaulted

`SecurityContextSchema` defaulted all three fields to 1000. Setting `fsGroup` switches on kubelet **volume ownership management**, which walks and chowns the volume — on a 2Ti `local` PV holding the music library that is minutes-to-hours of I/O on every pod start, acquired by accident simply because a default existed.

All three fields are now optional. Nothing set a `securityContext` before this PR, so removing the defaults changes nothing that exists.

## Risk, stated honestly

This is the same *shape* of change that broke things, now made from measured facts instead of inference. What could still go wrong: if the image's entrypoint does anything requiring root before dropping to the app, running as 1001 fails. I cannot see the entrypoint from here.

The failure mode is loud and immediate — CrashLoopBackOff within a minute, 503 on `music.blit.cc`, and `kubectl logs --previous` says exactly what happened. Not a silent degradation.

## Verify

- After deploy: `kubectl exec deploy/navidrome-deployment -- id` → `uid=1001`, and the pod stays `Running` past a minute.
- Library still browsable and playing (proves `/music` readable as the new uid).
- Something that writes — favourite a track, or wait for a scan — proves `/data` writable without `DAC_OVERRIDE`.
- `kubectl get pod -o jsonpath='{...securityContext}'` shows `capabilities.drop: ["ALL"]` and no `fsGroup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD