### PR TITLE
fix(rathole): raise the memory limit that has been OOMKilling the tunnel

### DIFF
--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -167,10 +167,16 @@ ${exitClientEntries}`;
                   command: ["/app/rathole"],
                   image: "rapiz1/rathole:latest",
                   name: "rathole",
+                  // 64Mi got this OOMKilled (exit 137) roughly every few days.
+                  // Every restart drops the tunnel, and with it all public
+                  // ingress and every exit — this one pod is the whole path
+                  // home. Buffers scale with concurrent streams, so a media
+                  // service plus exit traffic is nothing like the idle
+                  // footprint the original limit was presumably sized from.
                   resources: {
                     limits: {
                       cpu: "100m",
-                      memory: "64Mi",
+                      memory: "256Mi",
                     },
                   },
                   volumeMounts: [


### PR DESCRIPTION
## Found while auditing pod restarts

```
$ kubectl get pod -l app=rathole-client -o jsonpath='{...lastState.terminated.reason} {...exitCode}'
OOMKilled 137
```

```
rathole-client-2891619c-667c48c6bd-mbqxh   1/1   Running   4 (5d17h ago)   14d
```

The rathole client is capped at `memory: 64Mi` and has been OOMKilled four times in fourteen days.

## Why this matters more than a restart count

Rathole is not one service among several — **it is the entire path home**. Every public hostname (`blit.cc`, `music.blit.cc`, the files host) and every selectable exit rides that one tunnel. When it dies, the sites go down and all exit egress breaks until it restarts.

From the outside that looks like an intermittent network wobble, not a pod being killed, which is presumably why it has gone unremarked for a fortnight. It is also the kind of thing that would be blamed on the VPN.

## The fix

`64Mi` → `256Mi`. Buffers scale with concurrent streams, and a media service plus exit traffic is nothing like the idle footprint the original limit was presumably sized from. CPU is untouched at `100m` — it has never been throttled into trouble.

No requests are set anywhere in this codebase, so limits double as requests (Guaranteed QoS). On a box with 8Gi allocated to Navidrome alone, 256Mi here is not a scheduling concern.

## Verify

- After deploy: `kubectl get pod -l app=rathole-client` — one fresh pod, and the restart count should stay at 0 rather than creeping.
- Worth checking again in a week; if it still OOMs at 256Mi the real answer is a leak, not a limit, and that is a different investigation.
- Note the deploy itself drops the tunnel briefly as the pod rolls, so the public sites blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD