### PR TITLE
fix(services): fix mount ownership before a pod that runs as a set uid starts

### DIFF
--- a/packages/infra/src/templates/service.test.ts
+++ b/packages/infra/src/templates/service.test.ts
@@ -217,6 +217,58 @@ describe("service template", () => {
       ]);
     });
 
+    it("fixes ownership of writable mounts, never read-only ones", async () => {
+      const { createService } = await import("./service.ts");
+      const withVolumes = (over: Record<string, unknown> = {}) =>
+        ServiceArgsSchema.parse({
+          image: { repository: "navidrome", tag: "1" },
+          httpPort: 4533,
+          persistence: [
+            {
+              name: "music",
+              storage: "2Ti",
+              hostPath: "/mnt/music",
+              mountPath: "/music",
+              readOnly: true,
+              nodeAffinityHostname: "oldboy",
+            },
+            {
+              name: "data",
+              storage: "20Gi",
+              hostPath: "/home/nd/data",
+              mountPath: "/data",
+              readOnly: false,
+              nodeAffinityHostname: "oldboy",
+            },
+          ],
+          ...over,
+        });
+
+      createService(mockProvider, "asroot", withVolumes());
+      createService(
+        mockProvider,
+        "asuser",
+        withVolumes({ securityContext: { runAsUser: 1001, runAsGroup: 1002 } }),
+      );
+
+      const spec = async (name: string) =>
+        (await waitFor("Deployment", `${name}-deployment`)).inputs.spec.template
+          .spec;
+
+      // Nothing to fix when the pod runs as whatever the image says.
+      expect((await spec("asroot")).initContainers).toBeUndefined();
+
+      const init = (await spec("asuser")).initContainers[0];
+      const cmd = init.command[2];
+      expect(cmd).toContain("/data");
+      // A recursive chown across a 2Ti library on every start would be a
+      // catastrophe, and the mount would reject the write anyway.
+      expect(cmd).not.toContain("/music");
+      expect(cmd).toContain("1001:1002");
+      // Must stay root: it is the thing granting the app its ownership.
+      expect(init.securityContext.runAsUser).toBe(0);
+    });
+
     it("drops capabilities only where asked", async () => {
       const { createService } = await import("./service.ts");
       createService(mockProvider, "caps", args());

--- a/packages/infra/src/templates/service.ts
+++ b/packages/infra/src/templates/service.ts
@@ -141,6 +141,17 @@ export function createService(
     { provider },
   );
 
+  // Writable mounts only, and only when the pod runs as a specific uid — those
+  // are exactly the paths whose existing contents can be owned by someone else.
+  const writable = [...hostVolumes, ...persistence].filter((v) => !v.readOnly);
+  const ownershipFixes =
+    securityContext?.runAsUser === undefined
+      ? []
+      : writable.map((v) => v.mountPath);
+  const ownershipMounts = ownershipFixes.length
+    ? writable.map(({ name, mountPath }) => ({ name, mountPath }))
+    : [];
+
   const probes = healthCheck
     ? {
         ...(healthCheck.enableLiveness && {
@@ -182,6 +193,45 @@ export function createService(
             // None of these talk to the API server, so the token is a free
             // foothold for anything that lands in the container.
             automountServiceAccountToken: false,
+            ...(ownershipFixes.length && {
+              // A service that switches to running as a given uid inherits
+              // directories created by whatever it ran as before — Navidrome's
+              // /data was root-owned inside, so it opened its DB fine (the
+              // mount point matched) and then died on a root-owned cache
+              // subdirectory. Ownership of the mount point says nothing about
+              // its contents, and nothing outside the cluster is going to fix
+              // that on a rebuilt host.
+              //
+              // Read-only mounts are excluded, which is load-bearing: chown -R
+              // across a 2Ti music library on every pod start is not a thing
+              // anyone wants, and a read-only mount would reject it anyway.
+              initContainers: [
+                {
+                  name: "fix-ownership",
+                  image: "busybox:1.37",
+                  command: [
+                    "sh",
+                    "-c",
+                    // Only touches what is already wrong, so a correct tree
+                    // costs a stat pass rather than a full rewrite.
+                    ownershipFixes
+                      .map(
+                        (path) =>
+                          `find ${path} ! -user ${securityContext?.runAsUser} -exec chown ${securityContext?.runAsUser}:${securityContext?.runAsGroup} {} +`,
+                      )
+                      .join(" && "),
+                  ],
+                  // Overrides the pod-level uid, and keeps the capabilities
+                  // chown needs — the app container is the one that gets to be
+                  // unprivileged.
+                  securityContext: {
+                    runAsUser: 0,
+                    allowPrivilegeEscalation: false,
+                  },
+                  volumeMounts: ownershipMounts,
+                },
+              ],
+            }),
             containers: [
               {
                 name: serviceName,


### PR DESCRIPTION
Fixes the Navidrome crash loop from #171. **Nothing needs changing in Navidrome** — it is behaving correctly; the filesystem it inherited is what is wrong.

## What happened

#171 moved Navidrome to `runAsUser: 1001` because `/data` is owned by `1001:1002`. It got much further than #166 did — DB opened, library watcher started, `----> Navidrome server is ready!` — and then:

```
level=error msg="Failed to create wazero compilation cache" error="stat /data/cache/plugins/wazero-v1.12.0-amd64-linux: permission denied"
level=error msg="Fatal error in Navidrome. Aborting" error="creating wazero compilation cache: ... permission denied"
```

`/data` is `1001:1002`. **Its contents are not.** `/data/cache/plugins/` was created by the container back when it ran as root, and years of running that way left root-owned directories inside a mount point that happens to be owned by someone else. The `stat` that justified #171 was of the mount point, which said nothing about what was in it.

## The fix

An initContainer that runs as root and chowns writable mounts to the uid the app will run as, before the app starts.

In code rather than as a one-off `chown -R` on the host, because a rebuilt host would need it again and nobody would remember it existed. It is also idempotent — it runs on every start and does nothing when there is nothing to do.

Two details that matter:

- **Read-only mounts are excluded.** A recursive chown across the 2Ti music library on every pod start would be a catastrophe, and the mount would reject the write anyway. Only `/data` is touched, never `/music`.
- **It only touches files whose owner is already wrong** (`find ! -user <uid> -exec chown`), so a correct tree costs a stat pass, not a full rewrite.

The initContainer keeps `runAsUser: 0` and its capabilities — it is the thing granting the app its ownership. The app container is the one that gets to be unprivileged.

## Generality

This triggers only when a service sets `securityContext.runAsUser` and has a writable mount. Navidrome is currently the only one. Any future service switching to a fixed uid gets the same treatment automatically, which is the correct default: changing the uid a container runs as almost always means inheriting files owned by the old one.

## Verify

- 62 tests pass, one new: writable mounts appear in the chown command, read-only ones do not, the uid/gid are right, and the initContainer runs as root. Also asserts a pod with no `runAsUser` gets no initContainer at all.
- After deploy: `kubectl get pod -l app=navidrome` should go `Init:0/1` → `Running` and stay there.
- `kubectl exec deploy/navidrome-deployment -- id` → `uid=1001`, and `music.blit.cc` back to 302.
- The pipeline is currently jammed behind the crash-looping pod — Pulumi waits for the Deployment to be Ready — so this also unblocks the queued `blit` image update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD