### PR TITLE
test(singbox): run the real sing-box core over every profile we deliver

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,6 +149,13 @@ jobs:
       - name: Run Tests
         run: aube run test
 
+      # The unit tests validate profile *shape* against sing-box's published
+      # (latest) schema. This runs the real binary of the oldest core the fleet
+      # is on, which is the only thing that answers "will the devices accept
+      # this" — the question July's outage turned on.
+      - name: Check profiles against the minimum sing-box core
+        run: aube run check:profiles
+
   deploy:
     name: Deploy
     needs: [test, lint, format, typecheck]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ Everything deploys in one `pulumi up` from `packages/infra/`:
 
 All config uses Zod V4 schemas for runtime validation. Configuration lives in `Pulumi.main.yaml`. Schema definitions in `*.schemas.ts` files, regenerated via gen-schemas script.
 
+`aube run check:profiles` runs the **real** sing-box binary (pinned to the oldest core the fleet is on, `MIN_CORE` in the script) over every profile shape via docker `check`. That is the only test that answers "will the devices accept this" — a schema cannot, since the published one is always the latest. Skips silently without a docker daemon.
+
 `schemas/sing-box.json` is different: it is sing-box's own published schema, vendored (`curl -o schemas/sing-box.json https://sing-box.sagernet.org/schema.json`) so `singbox.schema.test.ts` can validate every generated profile offline. A profile that fails to parse fails on every device at once, so this check belongs in CI rather than on the fleet.
 
 ### Service Flow

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "fmt:check": "oxfmt --check",
     "typecheck:infra": "tsc -p ./packages/infra/tsconfig.json",
     "gen:schemas": "./scripts/gen-schemas.ts",
+    "check:profiles": "./scripts/check-profiles.ts",
     "update:apps": "./packages/infra/src/update-apps.ts",
     "deploy": "./packages/infra/src/deploy.ts up",
     "preview": "./packages/infra/src/deploy.ts preview",

--- a/scripts/check-profiles.ts
+++ b/scripts/check-profiles.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * Runs the real sing-box binary over every profile shape we deliver.
+ *
+ * `singbox.schema.test.ts` validates against the *published* schema, which is
+ * always the latest release — so it cannot answer the question that actually
+ * costs us: will the core our devices run accept this? July's outage was
+ * `store_dns`, valid in current sing-box and rejected by the 1.13 cores every
+ * device was on, and every device fetches the same file, so the whole fleet
+ * went down at once.
+ *
+ * `check` is a stronger test than any schema: it runs the version's own parser
+ * and initialises the outbounds, so it rejects a malformed REALITY key or an
+ * unknown field alike. The cost is that fixtures must be plausible rather than
+ * merely well-shaped.
+ */
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { buildProfile } from "../packages/infra/src/modules/singbox.ts";
+
+/**
+ * The oldest core a delivered profile must work on. Raising it is a deliberate
+ * act: every device has to be on the new version first, or the next profile
+ * change is free to use a field that bricks the ones that aren't. Note that
+ * SagerNet does not publish a container image for every release — pick one that
+ * has one.
+ */
+const MIN_CORE = "v1.14.0-alpha.47";
+const IMAGE = `ghcr.io/sagernet/sing-box:${MIN_CORE}`;
+
+// Well-formed rather than real: `check` initialises outbounds, so a REALITY
+// key has to be 32 bytes of base64url and a UUID has to parse.
+const node = {
+  name: "primary",
+  server: "1.2.3.4",
+  hysteria: {
+    altPorts: [3478, 4500],
+    obfsPassword: "obfs-password",
+    passwords: { guest1: "guest-pw", jc: "admin-pw" },
+    port: 443,
+    sni: "www.bing.com",
+  },
+  reality: {
+    publicKey: "VQw0Oi7DtJ4Ck_-cPdrjma1wlbCzpkQe_AE3UzjmY5Y",
+    serverNames: ["www.google.co.uk", "www.bing.com", "www.apple.com"],
+    shortId: "0123456789abcdef",
+    uuids: {
+      guest1: "22222222-2222-2222-2222-222222222222",
+      jc: "11111111-1111-1111-1111-111111111111",
+    },
+  },
+};
+const edge = { ...node, name: "helsinki", server: "5.6.7.8" };
+const exits = [
+  { name: "oldboy", port: 9000, method: "aes-128-gcm", password: "ss-psk" },
+];
+
+const profiles = [
+  ["admin-single", { name: "jc", role: "admin" } as const, [node]],
+  ["guest-single", { name: "guest1", role: "guest" } as const, [node]],
+  ["admin-multi", { name: "jc", role: "admin" } as const, [node, edge]],
+  ["guest-multi", { name: "guest1", role: "guest" } as const, [node, edge]],
+] as const;
+
+const run = promisify(execFile);
+
+const hasDocker = async () => {
+  try {
+    await run("docker", ["version", "--format", "{{.Server.Version}}"]);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+if (!(await hasDocker())) {
+  // CI always has one; locally this is a convenience, not a gate.
+  console.log("no docker daemon — skipping sing-box check");
+  process.exit(0);
+}
+
+const dir = await mkdtemp(join(tmpdir(), "jaritanet-profiles-"));
+let failed = 0;
+
+for (const [label, user, nodes] of profiles) {
+  const file = join(dir, `${label}.json`);
+  await writeFile(
+    file,
+    JSON.stringify(buildProfile(user, [...nodes], "ts.net", exits), null, 2),
+  );
+  try {
+    await run("docker", [
+      "run",
+      "--rm",
+      "-v",
+      `${file}:/config.json:ro`,
+      "--entrypoint",
+      "sing-box",
+      IMAGE,
+      "check",
+      "-c",
+      "/config.json",
+    ]);
+    console.log(`  ok    ${label}`);
+  } catch (err) {
+    failed++;
+    const { stderr, stdout } = err as { stderr?: string; stdout?: string };
+    console.error(`  FAIL  ${label}\n${(stderr || stdout || "").trim()}`);
+  }
+}
+
+console.log(
+  failed
+    ? `\n${failed}/${profiles.length} profiles rejected by sing-box ${MIN_CORE}`
+    : `\nall ${profiles.length} profiles accepted by sing-box ${MIN_CORE}`,
+);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closes #173.

## The value, plainly

**This is the test that would have caught July's outage.** #163 cannot, and says so in its own description.

That outage was `store_dns` — a field valid in current sing-box and rejected by the 1.13 cores every device was actually running. Because every device subscribes to the same generated file, the entire fleet broke simultaneously, and it took three days and a full infrastructure investigation to find, because the symptom (VPN connects, nothing passes) looks exactly like a server problem. The published schema #163 validates against is always the *latest* release, so it would have cheerfully approved the profile that did it.

`sing-box check`, run from a pinned version, answers the real question: **will the core our devices run accept this file?**

## Stronger than a schema, not just different

`check` runs that version's own parser *and initialises the outbounds*. Demonstrated while writing this — the first run failed with:

```
FATAL initialize outbound[0]: invalid public_key
```

because my fixture used `"pk"` as a REALITY public key. No JSON Schema would ever catch that: it is a well-formed string in the right place. The binary knows it has to be 32 bytes of base64url. The same applies to UUIDs, shortIds, cipher names and every other value a schema can only see as "a string".

The cost is that fixtures must be plausible rather than merely well-shaped, which is a fair trade.

## Version choice

`MIN_CORE = v1.14.0-alpha.47` — the oldest core in the fleet, and 1.14 is where `store_dns`/`optimistic` landed, so it is also the floor implied by the profile's current contents.

Raising it is deliberate and is the point of the constant: every device has to be on the newer version *first*, or the next profile change is free to use a field that bricks whatever lags. A note in the script says so.

One practical wrinkle recorded in the comments: SagerNet does not publish a container image for every release. `v1.14.0-beta.2` has none; `alpha.47` does. Pick a version with an image when bumping.

## Coverage

All four delivered shapes — admin and guest, single and multi node:

```
  ok    admin-single
  ok    guest-single
  ok    admin-multi
  ok    guest-multi

all 4 profiles accepted by sing-box v1.14.0-alpha.47
```

## Verify

- `aube run check:profiles` locally (needs docker; skips silently without it, so it is a convenience locally and a gate in CI).
- Runs in CI after the unit tests.
- To see it work: add a junk key to `buildProfile`'s output and watch it fail with the core's own error message rather than a schema path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD