### PR TITLE
feat(services): allow restricting ingress, and try it on files first

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -248,6 +248,11 @@ config:
         # dropping: nginx binds :80 inside the container, which needs
         # NET_BIND_SERVICE even as root once ALL is dropped.
         networkPolicy: true
+        # The guinea pig for ingress restriction (#172): static nginx over a
+        # read-only mount, so if Calico drops the kubelet's probes and the pod
+        # restart-loops, nobody notices. Extend to blit/navidrome only once this
+        # has stayed Ready through several probe cycles.
+        restrictIngress: true
         strategy:
           type: Recreate
         image:

--- a/packages/infra/src/templates/service.schemas.ts
+++ b/packages/infra/src/templates/service.schemas.ts
@@ -38,6 +38,20 @@ export const ServiceArgsSchema = z.object({
    * probes and the pod restart-loops.
    */
   networkPolicy: z.boolean().default(false),
+  /**
+   * Also restrict *ingress* to Traefik and the node, on top of `networkPolicy`.
+   *
+   * Separate from `networkPolicy` because the risk is different in kind. Egress
+   * rules cannot break a pod that is already serving; an ingress rule can, if
+   * the CNI also drops the kubelet's health probes — which arrive from the node
+   * rather than from a pod — and the pod is then killed for failing readiness.
+   * Whether Calico here does that is an empirical question, so this is opt-in
+   * per service and wants proving on something harmless first.
+   *
+   * What it buys: a compromised pod cannot reach a sibling. That is the lateral
+   * step after any egress control fails, and pod-to-pod is otherwise wide open.
+   */
+  restrictIngress: z.boolean().default(false),
   image: ImageSchema,
   limits: LimitsSchema.optional(),
   persistence: z.array(PersistenceSchema).default([]),

--- a/packages/infra/src/templates/service.test.ts
+++ b/packages/infra/src/templates/service.test.ts
@@ -217,6 +217,36 @@ describe("service template", () => {
       ]);
     });
 
+    it("keeps the kubelet reachable when ingress is restricted", async () => {
+      const { createService } = await import("./service.ts");
+      createService(
+        mockProvider,
+        "fenced",
+        args({ networkPolicy: true, restrictIngress: true }),
+      );
+
+      const { spec } = (await waitFor("NetworkPolicy", "fenced-netpol")).inputs;
+      expect(spec.policyTypes).toEqual(["Ingress", "Egress"]);
+
+      const from = spec.ingress[0].from;
+      expect(from[0].podSelector.matchLabels).toEqual({
+        "app.kubernetes.io/name": "traefik",
+      });
+      // Probes originate from the node. Without this the pod fails readiness
+      // and gets killed — the exact failure this option is gated behind.
+      expect(from[1].ipBlock.cidr).toBe("192.168.0.0/16");
+    });
+
+    it("leaves ingress alone unless asked", async () => {
+      const { createService } = await import("./service.ts");
+      createService(mockProvider, "egressonly", args({ networkPolicy: true }));
+
+      const { spec } = (await waitFor("NetworkPolicy", "egressonly-netpol"))
+        .inputs;
+      expect(spec.policyTypes).toEqual(["Egress"]);
+      expect(spec.ingress).toBeUndefined();
+    });
+
     it("drops capabilities only where asked", async () => {
       const { createService } = await import("./service.ts");
       createService(mockProvider, "caps", args());

--- a/packages/infra/src/templates/service.ts
+++ b/packages/infra/src/templates/service.ts
@@ -42,6 +42,7 @@ export function createService(
     persistence,
     ports,
     replicas,
+    restrictIngress,
     securityContext,
     strategy,
   }: z.infer<typeof ServiceArgsSchema>,
@@ -251,7 +252,26 @@ export function createService(
         metadata: { name: serviceName },
         spec: {
           podSelector: { matchLabels: { app: serviceName } },
-          policyTypes: ["Egress"],
+          policyTypes: restrictIngress ? ["Ingress", "Egress"] : ["Egress"],
+          ...(restrictIngress && {
+            ingress: [
+              {
+                from: [
+                  // The only intended caller.
+                  {
+                    podSelector: {
+                      matchLabels: { "app.kubernetes.io/name": "traefik" },
+                    },
+                  },
+                  // The kubelet's probes come from the node, not from a pod, so
+                  // without this the pod fails readiness and gets killed. Pod
+                  // IPs are 10.1.x, so allowing the node's LAN still shuts out
+                  // every sibling — which is the whole point of the rule.
+                  { ipBlock: { cidr: "192.168.0.0/16" } },
+                ],
+              },
+            ],
+          }),
           egress: [
             {
               to: [

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -406,6 +406,10 @@
                     "default": false,
                     "type": "boolean"
                   },
+                  "restrictIngress": {
+                    "default": false,
+                    "type": "boolean"
+                  },
                   "image": {
                     "$ref": "#/$defs/__schema3"
                   },


### PR DESCRIPTION
Closes #172 — either by holding, or by recording the answer if it doesn't.

## The value

The egress policies from #168/#170 stop a compromised pod reaching the node, the LAN, the tailnet or the API server. They do **nothing** about it reaching a sibling pod, and pod-to-pod is currently wide open. That is the lateral step an attacker takes after any egress control fails: pop the internet-facing service, then walk sideways to Postgres, the MCP backends, or Navidrome's data.

Restricting ingress closes that. It is the difference between "one compromised pod is confined" and "one compromised pod is a foothold".

## Why it was skipped until now, and how that is handled

An ingress rule allowing only Traefik **also excludes the kubelet's health probes**, which arrive from the node rather than from a pod. A pod failing readiness is killed and restart-loops — a hardening change causing an outage, which is a bad trade for a control this size.

Whether Calico on microk8s actually drops those probes is an empirical question, not one to reason out from first principles. Two things follow:

1. **The rule allows the node's LAN alongside Traefik.** Pod IPs are `10.1.x`, so permitting `192.168.0.0/16` still shuts out every sibling pod — the LAN was never the threat this addresses. The node is where probes come from and nowhere else.
2. **It lands enabled on exactly one service.** `files` is static nginx over a read-only mount: if it restart-loops, nobody notices, and the answer is known for `blit` and `navidrome` without risking either.

This is deliberately the opposite of how the last few hardening changes went in — assumption first, outage second. Here the assumption is isolated to the service where being wrong is free.

## What to watch after deploy

```bash
kubectl get pod -l app=files -w
```

- **Stays `1/1 Running` through several probe cycles** → it works. Extend `restrictIngress: true` to `blit` and `navidrome`, and #172 closes.
- **Goes `0/1` and restarts** → Calico drops kubelet probes under an ingress policy. Revert this one line, and #172 closes with that recorded rather than rediscovered in a year.

`curl -I` the files host either way, since a policy that starves Traefik shows up there rather than in pod status.

## Verify

- 63 tests pass, two new: with `restrictIngress` the policy carries both types and lists Traefik *and* the node CIDR; without it, ingress is absent entirely and only egress is restricted.
- The option is per-service and defaults off, so nothing else changes shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD