### PR TITLE
feat(tailnet): manage the tailnet policy in Pulumi, opt-in and non-destructive

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Everything lives in a single Pulumi package at `packages/infra/`:
 | `ACME_EMAIL` | Yes | Let's Encrypt account email (Traefik) |
 | `KUBE_HOST` / `KUBE_API_PORT` / `KUBE_TOKEN` | Yes | K8s API access (host = tailnet IP, token base64) |
 | `NAVIDROME_HOSTNAME` / `FILES_HOSTNAME` / `BLIT_HOSTNAME` | Yes | Service hostnames |
+| `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_CLIENT_SECRET` / `TS_TAILNET` | No | Manage the tailnet policy file as code (see below). Unset = policy stays hand-managed |
 
 **Tailscale**
 
@@ -198,3 +199,30 @@ Updates are auto-committed and trigger a deploy.
 ## Server Management
 
 Ansible playbooks provision and configure the homeserver (MicroK8s, Tailscale, Samba, Syncthing, SSH hardening). See `ansible/` directory.
+
+## Tailnet policy as code
+
+The tailnet policy is the last line of defence for anything that reaches the
+gateway. The gateway is a tailnet member so it can relay `100.x` over the
+tunnel, so whatever it may reach, a bug in Xray or Hysteria may also reach —
+grants contain that class of bug regardless of which layer above them is wrong.
+
+Managing it here is opt-in and cannot clobber an existing policy: the provider
+refuses to modify a policy file it has not imported. Bringing it under Pulumi:
+
+1. In the Tailscale admin console, create an **OAuth client** with the
+   `policy_file` read/write scope. Free on the Personal plan.
+2. Set `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_CLIENT_SECRET` and `TS_TAILNET` as
+   repository secrets.
+3. Copy the tailnet's **current** policy into
+   `packages/infra/tailnet-policy.hujson`, replacing the placeholder. Bring what
+   exists under version control before changing anything.
+4. Import it so Pulumi adopts the existing policy rather than replacing it:
+   `pulumi import tailscale:index/acl:Acl tailnet-policy acl`
+5. Only now start tightening. Give the gateway its own tag (`tagOwners`) instead
+   of the shared `tag:server`, set `gateway.tailnet.tag` to match, and grant it
+   only what the tunnel is actually used to reach.
+
+Step 5 is where the value is, and the order matters: a node cannot advertise a
+tag the policy does not define, and the gateway is a *relay* — whatever it
+cannot reach, you cannot reach over the VPN either.

--- a/README.md
+++ b/README.md
@@ -210,19 +210,36 @@ grants contain that class of bug regardless of which layer above them is wrong.
 Managing it here is opt-in and cannot clobber an existing policy: the provider
 refuses to modify a policy file it has not imported. Bringing it under Pulumi:
 
-1. In the Tailscale admin console, create an **OAuth client** with the
-   `policy_file` read/write scope. Free on the Personal plan.
-2. Set `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_CLIENT_SECRET` and `TS_TAILNET` as
-   repository secrets.
+1. **Create the OAuth client.** Admin console → *Settings* → *OAuth clients* →
+   *Generate OAuth client*. Tick **`policy_file`** with **write** access (read
+   alone lets Pulumi import but not apply). Nothing else is needed. The secret
+   is shown once — copy it there and then. Free on the Personal plan.
+2. **Set the secrets.** `gh secret set TS_OAUTH_CLIENT_ID`,
+   `gh secret set TS_OAUTH_CLIENT_SECRET`, and `gh secret set TS_TAILNET` —
+   the tailnet name is the one in the admin console's top-left switcher
+   (e.g. `example.com` or `tail1234.ts.net`), not the org display name.
 3. Copy the tailnet's **current** policy into
    `packages/infra/tailnet-policy.hujson`, replacing the placeholder. Bring what
    exists under version control before changing anything.
 4. Import it so Pulumi adopts the existing policy rather than replacing it:
    `pulumi import tailscale:index/acl:Acl tailnet-policy acl`
-5. Only now start tightening. Give the gateway its own tag (`tagOwners`) instead
-   of the shared `tag:server`, set `gateway.tailnet.tag` to match, and grant it
-   only what the tunnel is actually used to reach.
+5. Only now start tightening. This is where the value is, and it has its own
+   order — the gateway currently joins as `tag:server`, shared with every other
+   server, so no grant can single it out:
 
-Step 5 is where the value is, and the order matters: a node cannot advertise a
-tag the policy does not define, and the gateway is a *relay* — whatever it
-cannot reach, you cannot reach over the VPN either.
+   1. Uncomment `tag:gateway` in `tagOwners` and deploy. **A node cannot
+      advertise a tag the policy does not define**, so this must land first or
+      the gateway drops off the tailnet on its next `tailscale up`.
+   2. Mint a new auth key that is authorised for `tag:gateway` (admin console →
+      *Keys* → *Generate auth key* → set the tag) and replace `TS_AUTHKEY`. The
+      existing key can only assign the tags it was created with, so reusing it
+      cannot work.
+   3. Set `gateway.tailnet.tag` to `tag:gateway` and deploy. The node
+      re-registers with the new tag.
+   4. Write grants naming what the tunnel is actually used to reach.
+
+Step 5.4 is the trap: the gateway is a *relay*, so whatever it cannot reach,
+**you** cannot reach over the VPN either. The question is not how locked down it
+can be, but what you actually use the tailnet for — probably oldboy on a handful
+of ports. Getting it wrong locks you out of your own mesh, and a bad policy is
+recoverable only from the admin console, which is no fun from a train.

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -71,6 +71,10 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/ui@4.1.6)(vite@8.0.13(@types/node@25.8.0)(yaml@2.9.0))
 
   packages/infra:
+    dependencies:
+      '@pulumi/tailscale':
+        specifier: ^0.29.0
+        version: 0.29.0(typescript@6.0.3)
     devDependencies:
       ajv:
         specifier: ^8.20.0
@@ -444,6 +448,9 @@ packages:
 
   '@pulumi/random@4.20.0':
     resolution: {integrity: sha512-2jBPt+lR6XI6p87ALtznasNKU7Da247nW2g2MPCjd1JHKJwvtjyNrD2c4Wd3jgQ+kdKyvtUfiguTPi06m8JKpQ==}
+
+  '@pulumi/tailscale@0.29.0':
+    resolution: {integrity: sha512-95xhEC95wJN/t5CWbAAg4H/0+bJLb/6mqqShzHABAF6ZCxmqzJmoVNVna9L+N63wEAnlzqrFrtTYS+C7QzC+Uw==}
 
   '@pulumi/tls@5.4.0':
     resolution: {integrity: sha512-onLIie8deuZJHV8JkuDnY7nilIgGTr8HNyatg1FbgHikqo/HxU9yOwPM5Q7J0EAKtfHXuI9wkhnc4NReWIUfNg==}
@@ -2085,6 +2092,13 @@ snapshots:
       - supports-color
 
   '@pulumi/random@4.20.0(typescript@6.0.3)':
+    dependencies:
+      '@pulumi/pulumi': 3.239.0(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+
+  '@pulumi/tailscale@0.29.0(typescript@6.0.3)':
     dependencies:
       '@pulumi/pulumi': 3.239.0(typescript@6.0.3)
     transitivePeerDependencies:

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -2,6 +2,9 @@
   "name": "jaritanet-infra",
   "type": "module",
   "main": "./src/main.ts",
+  "dependencies": {
+    "@pulumi/tailscale": "^0.29.0"
+  },
   "devDependencies": {
     "ajv": "^8.20.0"
   }

--- a/packages/infra/src/env.schema.ts
+++ b/packages/infra/src/env.schema.ts
@@ -10,6 +10,14 @@ export const EnvSchema = z.object({
   KUBE_TOKEN: z.string().min(1, "KUBE_TOKEN is required"),
   TS_AUTHKEY: z.string().optional(),
 
+  // Tailnet policy-as-code. Absent, the policy stays hand-managed in the admin
+  // console and the Pulumi resource is never created — same idiom as
+  // TS_AUTHKEY gating the relay. Needs an OAuth client with the `policy_file`
+  // scope; see README.
+  TS_OAUTH_CLIENT_ID: z.string().optional(),
+  TS_OAUTH_CLIENT_SECRET: z.string().optional(),
+  TS_TAILNET: z.string().optional(),
+
   // MCP gateway: GitHub OAuth app creds + login allowlist. GH_ prefix because
   // GitHub Actions reserves GITHUB_. Absent → the gateway stack is skipped.
   GH_CLIENT_ID: z.string().optional(),

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -13,6 +13,7 @@ import {
 import { createEdge } from "./modules/edge.ts";
 import { createExit, deriveExitPort } from "./modules/exit.ts";
 import { createGateway } from "./modules/gateway.ts";
+import { createTailnetPolicy } from "./modules/tailnet-policy.ts";
 import {
   createIngress,
   createIngressRoute,
@@ -122,6 +123,17 @@ export default async function () {
     }
   } else if (conf.externalIp) {
     dnsTarget = pulumi.output(conf.externalIp);
+  }
+
+  // Tailnet policy as code — only once an OAuth client exists, so this is a
+  // no-op until the secrets are set (and even then the provider refuses to
+  // touch a policy nobody has imported).
+  if (env.TS_OAUTH_CLIENT_ID && env.TS_OAUTH_CLIENT_SECRET && env.TS_TAILNET) {
+    createTailnetPolicy(
+      pulumi.secret(env.TS_OAUTH_CLIENT_ID),
+      pulumi.secret(env.TS_OAUTH_CLIENT_SECRET),
+      env.TS_TAILNET,
+    );
   }
 
   // --- DNS: zone modules (fastmail, bluesky) ---

--- a/packages/infra/src/modules/tailnet-policy.ts
+++ b/packages/infra/src/modules/tailnet-policy.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tailscale from "@pulumi/tailscale";
+import type * as pulumi from "@pulumi/pulumi";
+
+/**
+ * Manages the tailnet's policy file as code.
+ *
+ * The tailnet is the last line of defence for anything that reaches the
+ * gateway: the gateway is a member so it can relay `100.x` over the tunnel, so
+ * whatever it may reach, a bug at the Xray or Hysteria layer may also reach.
+ * #162 was exactly that — guest routing rules that looked like they blocked the
+ * tailnet but did not, because IP rules never matched domain destinations. A
+ * grant limiting what the gateway can talk to would have contained it without
+ * anyone noticing the bug.
+ *
+ * The policy is a file rather than a JS object because HuJSON keeps comments,
+ * and a policy whose reasoning is stripped out is a policy nobody dares edit.
+ *
+ * `overwriteExistingContent` is deliberately left false. The provider then
+ * refuses to touch a policy it has not imported, so merging this cannot clobber
+ * a hand-maintained tailnet — the import is a conscious step, not a surprise.
+ * See README for the sequence.
+ */
+export function createTailnetPolicy(
+  clientId: pulumi.Input<string>,
+  clientSecret: pulumi.Input<string>,
+  tailnet: string,
+) {
+  const provider = new tailscale.Provider("tailscale", {
+    oauthClientId: clientId,
+    oauthClientSecret: clientSecret,
+    tailnet,
+  });
+
+  return new tailscale.Acl(
+    "tailnet-policy",
+    {
+      acl: readFileSync(
+        join(import.meta.dirname, "../../tailnet-policy.hujson"),
+        "utf8",
+      ),
+    },
+    { provider },
+  );
+}

--- a/packages/infra/tailnet-policy.hujson
+++ b/packages/infra/tailnet-policy.hujson
@@ -1,0 +1,38 @@
+// Tailnet policy file (HuJSON — comments are preserved when applied).
+//
+// NOT YET LIVE. This is a starting point, not the current policy. The Pulumi
+// resource refuses to touch a policy it has not imported, so nothing here
+// applies until someone runs the import in the README. Before that import,
+// replace everything below with the tailnet's *current* policy — the point is
+// to bring what exists under version control first and tighten afterwards, not
+// to swap a working policy for a guess.
+//
+// Why this is worth doing: the gateway is a tailnet member so it can relay
+// 100.x over the VPN tunnel. Anything it can reach, a bug in Xray or Hysteria
+// can also reach — see #162, where guest rules that looked like they blocked
+// the tailnet did not. Grants here are what contains that class of bug, and
+// they hold regardless of which layer above them is wrong.
+//
+// The catch worth understanding before tightening: the gateway is a *relay*, so
+// whatever it cannot reach, you cannot reach over the VPN either. The right
+// question is not "how locked down can this be" but "what do I actually use the
+// tunnel to reach" — likely oldboy on a handful of ports.
+{
+	"tagOwners": {
+		// The gateway wants its own tag. It currently joins as tag:server, which
+		// it shares with every other server, so no grant can distinguish it.
+		// Give it one here first — a node cannot advertise a tag the policy does
+		// not define — then set gateway.tailnet.tag to match.
+		// "tag:gateway": ["autogroup:admin"],
+	},
+
+	"grants": [
+		// Placeholder mirroring Tailscale's default: everything reaches
+		// everything. Replace with the imported policy, then narrow.
+		{
+			"src": ["*"],
+			"dst": ["*"],
+			"ip":  ["*"],
+		},
+	],
+}


### PR DESCRIPTION
Closes #164.

## The value

The tailnet policy is **the last line of defence for anything that reaches the gateway**. The gateway is a tailnet member so it can relay `100.x` over the tunnel — so whatever the gateway can reach, a bug in Xray or Hysteria can also reach.

Not hypothetical: #162 was exactly this. Guest routing rules that *looked* like they blocked the tailnet never matched, because IP rules do not match domain destinations under Xray's default `domainStrategy`. Anyone with a guest credential and a DNS record could walk into the mesh. A grant limiting what the gateway may talk to would have contained it **without anyone knowing the bug existed** — which is the point of a layer you don't have to be right about twice.

Today that layer is edited by hand in a web console: no history, no review, no relationship to the infrastructure it protects.

## Why this is safe to merge

Two independent guards, because a PR that can lock you out of your own tailnet isn't worth the tidiness:

1. **It does not exist without credentials.** No `TS_OAUTH_CLIENT_ID`/`SECRET`/`TS_TAILNET` → the resource is never created. The same idiom `TS_AUTHKEY` already uses to gate the relay.
2. **`overwriteExistingContent` stays false.** The provider then *refuses* to modify a policy file it hasn't imported. Merging cannot clobber a hand-maintained tailnet; adoption is a deliberate `pulumi import`, never a side effect.

Merging changes nothing until someone follows the README.

## Getting the tokens

Admin console → *Settings* → *OAuth clients* → *Generate OAuth client*. Tick **`policy_file`** with **write** access — read alone lets Pulumi import but not apply. The secret is shown once.

Then `gh secret set TS_OAUTH_CLIENT_ID`, `TS_OAUTH_CLIENT_SECRET`, `TS_TAILNET`. The tailnet name is the one in the admin console's top-left switcher (`example.com` or `tail1234.ts.net`), not the org display name.

## Why this PR can't also tag the gateway

Asked and worth answering precisely — it's an ordering constraint, not an oversight. The gateway joins as `tag:server`, shared with every other server, so no grant can single it out. Fixing that takes three steps that **cannot be collapsed into one deploy**:

1. `tag:gateway` must exist in `tagOwners` first. **A node cannot advertise a tag the policy does not define**, so changing the tag before the policy lands drops the gateway off the tailnet at its next `tailscale up`.
2. `TS_AUTHKEY` must be authorised for that tag. An auth key can only assign the tags it was created with, so the existing one cannot work — **this needs a new key, which only a human with console access can mint.** That is the step no PR can perform.
3. Only then does `gateway.tailnet.tag` change and the node re-register.

So the policy file ships with the `tagOwners` line ready to uncomment, and README spells out the sequence.

## Shape

The policy is a **HuJSON file**, not a JS object. Comments survive into the applied policy, and a policy whose reasoning has been stripped out is one nobody dares edit six months later. It ships as a placeholder saying, in as many words, *replace this with the current policy first* — version control what exists before changing behaviour.

## The trap when tightening

The gateway is a **relay**: whatever it cannot reach, *you* cannot reach over the VPN. The question isn't "how locked down can this be" but "what do I actually use the tailnet for" — probably oldboy on a handful of ports. A bad policy can't lock you out of the admin console, only device-to-device access, so it's recoverable — but not enjoyably, from a train.

## Verify

- 61 tests pass; typecheck and lint clean.
- `aube run preview` with the secrets unset: **no change at all** — the module isn't instantiated.
- With secrets set but no import: the provider errors rather than overwriting. That's the guard working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD