### PR TITLE
docs(exits): record that exit-oldboy is IPv4-only and why that is fine

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -370,6 +370,20 @@ through (`entry-select`). Egress = where your traffic leaves the internet
 (`exit-select`): either **direct** (at the gateway) or via an **exit node** that
 NATs out its own IP — e.g. the home cluster, egressing the residential IP.
 
+**`exit-oldboy` is IPv4-only, by circumstance rather than choice.** The house
+has no IPv6 at all — oldboy holds two ULAs (one of them Tailscale's) and no
+global-unicast address, and v6 egress fails with *Network is unreachable*, i.e.
+there is no route rather than a blocked one. So an application with a hardcoded
+IPv6 endpoint does not work through this exit and does work on direct egress,
+which reads as "the VPN is broken" and cost real debugging hours in July before
+the exit turned out to be the variable. Telegram was the observed casualty.
+
+Nothing in the cluster can fix that: dual-stack CNI would hand pods addresses
+with nowhere to route. The alternatives are NAT64/DNS64 at the gateway or IPv6
+from the ISP, and neither is worth it for an exit whose entire purpose is
+presenting a residential **IPv4** address. Accepted deliberately — if something
+you rely on breaks only through the exit, suspect this first.
+
 An exit is a substrate-agnostic unit — **rathole client + ss-rust** — as a k8s
 Deployment (`modules/exit.ts`) today, or a cloud-init VPS later. Add one via the
 `exits` config list:


### PR DESCRIPTION
Closes the IPv6 half of #175 by deciding it rather than building anything.

## What was measured

On oldboy, via a throwaway `hostNetwork` diagnostic pod:

```
inet6 fd2c:63d1:467c:415d:227b:d2ff:fe21:b17/64   ← ULA, not routable
inet6 fd7a:115c:a1e0::6201:810b/128               ← Tailscale's ULA
ping -6 2606:4700:4700::1111 → sendto: Network is unreachable
```

No global-unicast address anywhere on the host, and v6 egress fails to *route* rather than timing out. **The house has no IPv6.**

## Why this is a doc change and not a fix

The original issue assumed a cluster problem — give the exit pod a v6 address, make the CNI dual-stack. That would accomplish nothing: pods would get addresses with nowhere to route. The exit is v4-only because the building is.

The remaining options were NAT64/DNS64 at the gateway, or IPv6 from the ISP. Neither is worth it for an exit whose entire purpose is presenting a residential **IPv4** address. So: accepted, deliberately.

## Why write it down at all

The failure mode is nasty out of proportion to its impact. An app with hardcoded IPv6 works on direct egress and breaks through the exit — which reads as "the VPN is broken", not "this one egress path is v4-only". That cost real hours in July before the exit was suspected at all; Telegram was the casualty.

A future reader hitting it should find the answer in the architecture doc rather than re-running the diagnosis. The note says what to suspect first.

## Still open in #175

The oversized-UDP-reply half, which is unrelated and needs a client routed through the exit to reproduce. Worth noting `tailscale0` is MTU 1280 but is *not* on the exit path, so the obvious suspect is already ruled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD