### PR TITLE
feat(ansible): install the HWE kernel and show the GRUB menu before the reboot

### DIFF
--- a/ansible/group_vars/homeservers.yml
+++ b/ansible/group_vars/homeservers.yml
@@ -19,3 +19,9 @@ syncthing:
 
 samba:
   enabled: true
+
+# Roll the kernel forward within the LTS. The GA series (6.8 on 24.04) is pinned
+# for the life of the release, so this is the only way to a newer kernel short of
+# a distro upgrade. Takes effect on the next reboot; the GA kernel stays in /boot
+# as a fallback.
+hwe_kernel: true

--- a/ansible/group_vars/homeservers.yml
+++ b/ansible/group_vars/homeservers.yml
@@ -25,3 +25,8 @@ samba:
 # a distro upgrade. Takes effect on the next reboot; the GA kernel stays in /boot
 # as a fallback.
 hwe_kernel: true
+
+# Draw the GRUB menu for a few seconds before booting the newest kernel, so an
+# older one can be picked when a new kernel and 2014 hardware disagree. This box
+# reboots roughly twice a year; the seconds are not worth optimising away.
+grub_timeout: 5

--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: update grub
+  ansible.builtin.command: update-grub
+  changed_when: true
+  listen: update grub
+
 - name: restart sshd
   ansible.builtin.systemd:
     name: ssh

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -51,6 +51,19 @@
       - ffmpeg
     state: present
 
+# The GA kernel series is pinned for the life of the release (24.04 stays on
+# 6.8, patched but never moved), so the only way to a newer kernel without a
+# distro upgrade is the HWE stack. Version comes from the host rather than a
+# literal, so this keeps meaning the right thing across a release upgrade.
+#
+# Installing it does not remove the GA kernel: both stay in /boot and GRUB can
+# fall back, which matters on hardware old enough to dislike a new one.
+- name: Install the HWE kernel
+  ansible.builtin.apt:
+    name: "linux-generic-hwe-{{ ansible_distribution_version }}"
+    state: present
+  when: hwe_kernel | default(false) | bool
+
 - name: Enable BBR congestion control + fq qdisc
   # Matches the gateway VPS. Default cubic collapses on loss; BBR holds the pipe
   # open — helps the rathole client→gateway leg and the exit's own egress.

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -64,6 +64,29 @@
     state: present
   when: hwe_kernel | default(false) | bool
 
+# Boots the newest kernel unattended (GRUB_DEFAULT=0 sorts newest first) but
+# draws the menu first, so an older entry can be chosen when a new kernel does
+# not agree with the hardware.
+#
+# Both keys have to move together: the style here is `hidden`, which waits out
+# GRUB_TIMEOUT without ever drawing the menu — setting the timeout alone looks
+# like it worked right up until the boot where it matters.
+#
+# Not strictly required (a failed boot leaves recordfail set, which forces the
+# menu regardless) but this box reboots about twice a year, so a few seconds is
+# not a cost worth optimising away.
+- name: Show the GRUB menu briefly before booting the default kernel
+  ansible.builtin.lineinfile:
+    path: /etc/default/grub
+    regexp: "^{{ item.key }}="
+    line: "{{ item.key }}={{ item.value }}"
+    state: present
+  loop:
+    - { key: "GRUB_TIMEOUT_STYLE", value: "menu" }
+    - { key: "GRUB_TIMEOUT", value: "{{ grub_timeout }}" }
+  when: grub_timeout is defined
+  notify: update grub
+
 - name: Enable BBR congestion control + fq qdisc
   # Matches the gateway VPS. Default cubic collapses on loss; BBR holds the pipe
   # open — helps the rathole client→gateway leg and the exit's own egress.

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -87,6 +87,14 @@
   when: grub_timeout is defined
   notify: update grub
 
+# Run the handler here rather than at play end. /etc/default/grub is only input;
+# without update-grub the running config keeps whatever it had. If the play
+# failed in between, the next run would find the file already correct, report no
+# change, never notify — and grub.cfg would stay stale forever while the source
+# of truth claims otherwise.
+- name: Apply the GRUB change before anything else can fail
+  ansible.builtin.meta: flush_handlers
+
 - name: Enable BBR congestion control + fq qdisc
   # Matches the gateway VPS. Default cubic collapses on loss; BBR holds the pipe
   # open — helps the rathole client→gateway leg and the exit's own egress.


### PR DESCRIPTION
Do this **before** the reboot — then one restart picks up the new kernel *and* the 17 weeks of pending updates, instead of two.

## Why the kernel looks ancient

```
Ubuntu 24.04.4 LTS
linux-generic            6.8.0-136.136       ← GA series
linux-generic-hwe-24.04  candidate 7.0.0-28  ← available, not installed
```

6.8 is 24.04's **GA kernel series**, pinned for the life of the release. It never moves; fixes are backported instead, which is what `-136` means — 136 rounds of SRU updates. So it is current on security despite the version number. The **HWE stack** is the supported route to a newer kernel without a distro upgrade: 7.0, still on the LTS supported to 2029.

## What ends up on the box

All three kernels, newest booting by default:

| | role |
| --- | --- |
| `7.0.0-x` (new) | boots by default — `GRUB_DEFAULT=0` sorts newest first |
| `6.8.0-136` | patched-to-current fallback; the one to live on if 7.0 misbehaves |
| `6.8.0-31` | *known* to boot on this hardware — it has for 122 days |

Nothing is removed: `apt install` adds alongside. `/boot` is 2.0G with 1.6G free and each kernel costs ~90M, so three is not close to tight — which is worth stating, because a full `/boot` is the classic way an HWE install goes wrong.

## The GRUB half, and the trap in it

The menu is currently invisible: `GRUB_TIMEOUT=0` **and** `GRUB_TIMEOUT_STYLE=hidden`. So this sets both — with `hidden`, a timeout alone waits out the delay without ever drawing the menu, which would have looked correct right up until the boot where it mattered.

Strictly it is belt-and-braces. A failed boot leaves `recordfail` set, which forces the menu regardless, and `grub-initrd-fallback` is enabled to clear it after a good boot — so there is already a safety net. But this box reboots about twice a year, so five seconds buys a guarantee that does not depend on the previous boot having failed in a way GRUB noticed.

## Load-bearing decisions

**The HWE package name is derived, not written out.** `linux-generic-hwe-{{ ansible_distribution_version }}` rather than `…-24.04`, so after a release upgrade it keeps meaning "the HWE kernel for whatever this box runs" instead of silently pinning a stale name — the kind of rot only noticed years later.

**Both settings are opt-in per group** (`hwe_kernel`, `grub_timeout`, both unset by default). `common` also applies to the gateway VPS, and HWE exists for *newer* hardware — there is no reason to put a 2014 laptop's kernel choice into a role shared with a cloud box, nor to slow that box's boot.

## Sequence

1. Merge → `run-playbook.yml` runs the changed `common` role, installs the kernel, rewrites GRUB.
2. Reboot (pending since 18 July for libc6, apparmor, dbus and two kernels).
3. `uname -r` should report 7.0.x.

If it does not boot: the menu is now visible for five seconds — pick `6.8.0-136`.

## Related

#181 covers the rest — the eventual 26.04 upgrade (not offered until 26.04.1), microk8s still on 1.31/stable, and `/` at 83% full, which wants attention before any release upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD