### PR TITLE
fix(ansible): stop DKMS auto-building the Broadcom driver that broke the kernel

### DIFF
--- a/ansible/group_vars/homeservers.yml
+++ b/ansible/group_vars/homeservers.yml
@@ -24,6 +24,11 @@ samba:
 # for the life of the release, so this is the only way to a newer kernel short of
 # a distro upgrade. Takes effect on the next reboot; the GA kernel stays in /boot
 # as a fallback.
+# Its DKMS build fails on 7.0 and takes the kernel package's postinst down with
+# it. Disabled rather than removed, so wifi still works on the 6.8 kernels where
+# the module is already built — and this box is wired regardless.
+disable_broadcom_sta: true
+
 hwe_kernel: true
 
 # Draw the GRUB menu for a few seconds before booting the newest kernel, so an

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -31,6 +31,31 @@
     path: /etc/apt/sources.list
     state: absent
 
+# broadcom-sta is a proprietary Broadcom blob for this laptop's wifi chip, last
+# released upstream around 2015. It fails to build against 7.0, and a DKMS
+# failure aborts the *kernel package's* postinst — so one dead driver leaves the
+# new kernel unconfigured, dpkg half-broken, and zz-update-grub never run.
+#
+# Disabled rather than purged: the module is already built for both 6.8 kernels,
+# so wifi keeps working there and only 7.0 goes without — and this box is wired
+# anyway (USB ethernet; wlp3s0 has never held carrier). Reversible by deleting
+# one file. Note a modprobe blacklist would NOT do: the build is the problem,
+# not the load.
+#
+# Ordered before dist-upgrade deliberately. Upgrading is what re-triggers the
+# failing build, so a run that wrote this afterwards would abort before reaching
+# it and never fix anything.
+- name: Stop DKMS auto-building the Broadcom wifi driver
+  ansible.builtin.copy:
+    dest: /etc/dkms/broadcom-sta.conf
+    content: |
+      # Managed by ansible — see roles/common/tasks/main.yml.
+      AUTOINSTALL="no"
+    owner: root
+    group: root
+    mode: "0644"
+  when: disable_broadcom_sta | default(false) | bool
+
 - name: Update all packages to the latest version (dist-upgrade)
   ansible.builtin.apt:
     upgrade: dist


### PR DESCRIPTION
Fixes the failed #182 run, and repairs the box on the next playbook run without manual intervention.

## What actually failed

Not the kernel:

```
dkms autoinstall on 7.0.0-28-generic/x86_64 failed for broadcom-sta(10)
run-parts: /etc/kernel/postinst.d/dkms exited with return code 11
dpkg: error processing linux-image-7.0.0-28-generic (--configure)
```

`broadcom-sta` is a proprietary Broadcom blob for the laptop's wifi chip, last released upstream around 2015. It does not build against 7.0 — and a DKMS build failure **aborts the kernel package's postinst**. So one unmaintained driver left four kernel packages unconfigured (`iF`/`iU`), dpkg half-broken, and `zz-update-grub` never run because `dkms` runs before it in `run-parts` and took the whole sequence down.

## Disabled, not purged

`/etc/dkms/broadcom-sta.conf` with `AUTOINSTALL="no"`. Verified the mechanism exists rather than assumed it — `/usr/sbin/dkms` line 484 reads `/etc/dkms/$module.conf` as an override.

This is strictly better than removing the package:

```
broadcom-sta/6.30.223.271, 6.8.0-136-generic: installed
broadcom-sta/6.30.223.271, 6.8.0-31-generic:  installed
```

The module is **already built for both 6.8 kernels**, so wifi keeps working if you ever boot one; only 7.0 goes without. And the box is wired regardless — USB ethernet carries everything and `wlp3s0` has never held carrier. Reversing it is deleting one file.

**A modprobe blacklist would not have worked.** The build is what breaks the kernel install, not the load, so blacklisting `wl` would have left the exact same failure.

## The ordering is the load-bearing part

The task sits **before** `dist-upgrade`, not next to the kernel install. Upgrading is what re-triggers the failing build, so a run that wrote this config afterwards would abort before reaching the task — and fail identically on every subsequent run, forever.

With this order the playbook repairs the current state by itself:

1. Write the DKMS override.
2. `dist-upgrade` — now configures the four stuck packages instead of dying on them.
3. HWE install completes.
4. GRUB tasks run (they never got to in the failed run), `flush_handlers` regenerates `grub.cfg` with the 7.0 entry.

## Verify

Before rebooting, check the menu actually knows about it:

```bash
awk -F\' '/^menuentry|^submenu/ {print $2}' /boot/grub/grub.cfg | head
dkms status          # broadcom-sta should list 6.8 kernels only, never 7.0
dpkg -l | grep -E "^i[UF]"   # should be empty
```

If 7.0 misbehaves on the hardware, the GRUB menu now displays for five seconds and `6.8.0-136` is one keypress away — with its wifi driver intact, since this disabled the build rather than removing the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD