### PR TITLE
fix(ansible): AUTOINSTALL must be empty, not "no"

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -50,7 +50,11 @@
     dest: /etc/dkms/broadcom-sta.conf
     content: |
       # Managed by ansible — see roles/common/tasks/main.yml.
-      AUTOINSTALL="no"
+      #
+      # Empty, NOT "no". dkms autoinstall tests `[[ ! $AUTOINSTALL ]]` and skips
+      # the module only when the value is an empty string — so AUTOINSTALL="no"
+      # is a non-empty string and means yes. (/usr/sbin/dkms, autoinstall().)
+      AUTOINSTALL=""
     owner: root
     group: root
     mode: "0644"


### PR DESCRIPTION
#183 did not work. The override file was written correctly and DKMS read it — the **value** was wrong.

## The bug

From `autoinstall()` in `/usr/sbin/dkms`:

```bash
read_conf_or_die "$kernelver" "$arch" "$dkms_tree/$m/$v/source/dkms.conf"
if [[ ! $AUTOINSTALL ]]; then
    continue
```

It skips the module only when `AUTOINSTALL` is an **empty string**. `"no"` is a perfectly good non-empty string, so `[[ ! $AUTOINSTALL ]]` is false and the module builds regardless.

**In this config, `"no"` means yes.**

Verified the file landed and was correct otherwise:

```
-rw-r--r-- 1 root root 75 Jul 27 19:22 /etc/dkms/broadcom-sta.conf
# Managed by ansible — see roles/common/tasks/main.yml.
AUTOINSTALL="no"
```

…and the run failed on the same `dkms autoinstall … failed for broadcom-sta(10)` as before.

## Why I got it wrong

I assumed a knob named `AUTOINSTALL` takes a boolean-ish word, because that is what such a knob almost always takes. It takes emptiness. The fix came from reading `/usr/sbin/dkms` instead — which is what I should have done before the first attempt, having spent the day saying exactly that about `deployment.strategy` and `dropCapabilities`.

## Why not BUILD_EXCLUSIVE_KERNEL_MAX

It is the more surgical option — keep building for 6.x, skip 7.x — and it exists (`/usr/sbin/dkms:651`). But whether an exclusion is treated as a *skip* or a *failure* is not evidenced in the part of the source I read, and this has already cost two playbook runs. Empty `AUTOINSTALL` is directly evidenced by the `continue` above.

Nothing in use is lost: the module is already built for both 6.8 kernels, so wifi still works there if it were ever wanted. Only 7.0 goes without, on a box that is wired.

## What happens on merge

The playbook should now repair itself in one run:

1. Write the override (`AUTOINSTALL=""`).
2. `dist-upgrade` — `dkms autoinstall` skips broadcom-sta, so the four stuck kernel packages finally configure.
3. HWE install completes.
4. GRUB tasks run for the first time; `flush_handlers` regenerates `grub.cfg` with the 7.0 entry.

## Verify before rebooting

```bash
dpkg -l | grep -E "^i[UF]"        # empty
dkms status                        # broadcom-sta on 6.8 kernels only
awk -F\' '/^menuentry|^submenu/ {print $2}' /boot/grub/grub.cfg | head
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD