### PR TITLE
docs: the NetworkPolicies are declared but nothing enforces them

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -527,6 +527,32 @@ Live tradeoffs worth knowing, not necessarily bugs:
   gating SSH would shrink the attack surface but adds lockout risk on a box
   whose whole job is being reachable, so it's left open by choice. 2333 must
   stay open regardless: the home client dials in from a dynamic NATed IP.
+- **The NetworkPolicies are declared but not enforced, because the CNI is
+  flannel.** `microk8s` here runs flannel (`/var/snap/microk8s/current/args/
+  cni-network/flannel.conflist`, and no Calico or Cilium pods exist). Flannel is
+  a pure overlay: it provides pod networking and has **no policy engine at all**,
+  so a NetworkPolicy is accepted by the API server, stored, listed by `kubectl
+  get netpol` — and implemented by nothing.
+
+  Everything the pods carry is therefore latent: the egress confinement on
+  navidrome, blit and files, and the ingress restriction on files. They are
+  correct, and they begin working the moment an enforcing CNI is installed,
+  without a change to this repo. Until then they must not be counted as a
+  control, and in particular the "ingress restriction did not break the kubelet
+  probes" result proves nothing — nothing was being applied.
+
+  What *is* enforced, and was never in doubt, is everything the kubelet and
+  container runtime own: `runAsUser`, dropped capabilities, `seccompProfile`,
+  `automountServiceAccountToken: false`, and read-only volume mounts. Those did
+  not need a CNI. Removing the unauthenticated NFS export was likewise real —
+  that was the concrete path a compromised pod had to the host, and it is gone.
+
+  The fix is an enforcing CNI. `microk8s enable ha-cluster` brings Calico but
+  also converts the datastore to dqlite for an HA property that means nothing on
+  one node. `microk8s enable cilium` is the narrower option — eBPF-based policy,
+  no datastore change. Either is a live CNI swap on the box that serves
+  everything, so it is its own piece of work, not a side effect of a hardening
+  PR.
 - **hy2 uses adaptive congestion control (BBR) everywhere; Brutal is not
   offered.** Setting bandwidth hints switches Hysteria2 to Brutal, which paces
   to a fixed rate and ignores loss — it stomps through lossy censored *fat*

--- a/packages/infra/src/templates/service.schemas.ts
+++ b/packages/infra/src/templates/service.schemas.ts
@@ -32,10 +32,11 @@ export const ServiceArgsSchema = z.object({
    * else; unrestricted egress lets a compromised pod walk to whatever the host
    * happens to be serving and write the same data by another route.
    *
-   * Ingress is deliberately left alone. Restricting it adds little (Traefik is
-   * the only intended caller, and pod-to-pod reach is not the threat here)
-   * while risking the classic failure where the CNI also drops the kubelet's
-   * probes and the pod restart-loops.
+   * ⚠️ NOT CURRENTLY ENFORCED. microk8s here runs **flannel**, a pure overlay
+   * with no policy engine, so these objects are accepted by the API server and
+   * implemented by nothing. They are correct and latent: install an enforcing
+   * CNI and they start working with no change here. Until then do not count
+   * this as a control — see docs/architecture.md, Hardening notes.
    */
   networkPolicy: z.boolean().default(false),
   /**
@@ -45,11 +46,14 @@ export const ServiceArgsSchema = z.object({
    * rules cannot break a pod that is already serving; an ingress rule can, if
    * the CNI also drops the kubelet's health probes — which arrive from the node
    * rather than from a pod — and the pod is then killed for failing readiness.
-   * Whether Calico here does that is an empirical question, so this is opt-in
-   * per service and wants proving on something harmless first.
+   * So this is opt-in per service and wants proving on something harmless.
    *
-   * What it buys: a compromised pod cannot reach a sibling. That is the lateral
-   * step after any egress control fails, and pod-to-pod is otherwise wide open.
+   * ⚠️ Same caveat as `networkPolicy`: flannel enforces neither. `files` staying
+   * healthy after this was enabled proved nothing about probes — nothing was
+   * being applied. That test has to be re-run against a real policy engine.
+   *
+   * What it would buy: a compromised pod cannot reach a sibling. That is the
+   * lateral step after any egress control fails, and pod-to-pod is wide open.
    */
   restrictIngress: z.boolean().default(false),
   image: ImageSchema,


### PR DESCRIPTION
## The finding

```
/var/snap/microk8s/current/args/cni-network/flannel.conflist
(no calico daemonset, no cilium pods, no policy engine of any kind)
```

microk8s here runs **flannel**. Flannel is a pure overlay — it gives pods addresses and routes between them, and has **no policy engine at all**. A NetworkPolicy is accepted by the API server, stored in etcd, listed happily by `kubectl get netpol`, and implemented by nothing.

So the egress confinement on `navidrome` (#168), `blit`/`files` (#170) and the ingress restriction on `files` (#178) currently do nothing.

## A claim I made that was wrong

When #178 landed I reported that `files` staying `Ready` meant "Calico kept the kubelet's probes — the experiment passed". **It proved nothing.** The pod stayed healthy because no policy was being applied to it. I never checked which CNI was running before asserting the conclusion I wanted, having spent the same day narrating that exact failure about `deployment.strategy` and `dropCapabilities`.

The ingress-probe question is therefore still open, and has to be re-run against a real policy engine.

## Recorded, not deleted

The policies are correct and **latent**: they begin working the moment an enforcing CNI is installed, with no change to this repo. Deleting them would mean re-deriving them later.

But recorded *loudly*, in both the architecture doc and the schema docblocks where someone would reach for them — because an object that looks like a control and is not is worse than no object at all. That is how you end up trusting a boundary that was never there.

## What was never in doubt

Everything the kubelet and container runtime own, none of which needs a CNI:

- `runAsUser: 1001` and dropped capabilities on Navidrome
- `seccompProfile: RuntimeDefault`
- `automountServiceAccountToken: false` on every service
- read-only volume mounts

And **removing the unauthenticated `rw` NFS export** (#165) was the concrete path a compromised pod had to the host — that one was real, and it is gone. So today's hardening is not undone; the network-layer half of it is pending a CNI.

## Making them real

- `microk8s enable ha-cluster` — brings Calico, but also converts the datastore to dqlite for an HA property that is meaningless on a single node.
- `microk8s enable cilium` — the narrower option: eBPF policy enforcement, no datastore change. Available and disabled today.

Either is a live CNI swap on the box that serves everything, so it is its own piece of work with its own downtime, not a side effect of a hardening PR. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD