### PR TITLE
feat(rathole): build our own container instead of a 2023 amd64-only image

### DIFF
--- a/.github/workflows/build-rathole-container.yml
+++ b/.github/workflows/build-rathole-container.yml
@@ -1,0 +1,25 @@
+name: Build Rathole Container
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+    paths:
+      - "containers/rathole/**"
+      - ".github/workflows/build-rathole-container.yml"
+
+jobs:
+  publish:
+    name: Build and Publish
+    uses: radiosilence/blit-workflows/.github/workflows/build-publish-container.yml@28e962429b331f0e39905f70ae10211b1db66349 # main
+    with:
+      working-directory: "./containers/rathole"
+      image: "jaritanet-rathole"
+    secrets:
+      PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/containers/rathole/Dockerfile
+++ b/containers/rathole/Dockerfile
@@ -1,0 +1,31 @@
+# rathole, packaged ourselves.
+#
+# The upstream image (rapiz1/rathole) was last pushed in October 2023 and is
+# amd64-only, so it cannot run on arm64 at all — which blocks moving the home
+# side to a Pi, and leaves a three-year-old base on the pod that carries every
+# byte between the gateway and home.
+#
+# No fork needed: upstream publishes a static musl binary for every arch we
+# want, so this just fetches the pinned release for the target platform. The
+# version tracks the same RATHOLE_VERSION the gateway installs, so both ends of
+# the tunnel move together.
+FROM alpine:3.22 AS fetch
+ARG RATHOLE_VERSION=v0.5.0
+# Set by buildx per platform — amd64 | arm64.
+ARG TARGETARCH
+RUN apk add --no-cache curl unzip && \
+    case "$TARGETARCH" in \
+      amd64) TRIPLE=x86_64-unknown-linux-musl ;; \
+      arm64) TRIPLE=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL -o /tmp/rathole.zip \
+      "https://github.com/rapiz1/rathole/releases/download/${RATHOLE_VERSION}/rathole-${TRIPLE}.zip" && \
+    unzip -j /tmp/rathole.zip rathole -d /out && \
+    chmod +x /out/rathole
+
+# Statically linked, so it needs nothing around it. Nothing to patch, nothing to
+# scan, and no shell for anything that lands in the pod to use.
+FROM scratch
+COPY --from=fetch /out/rathole /app/rathole
+ENTRYPOINT ["/app/rathole"]

--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -174,7 +174,11 @@ ${exitClientEntries}`;
                 {
                   args: ["--client", "/etc/rathole/client.toml"],
                   command: ["/app/rathole"],
-                  image: "rapiz1/rathole:latest",
+                  // Ours, not rapiz1/rathole:latest — that image was last
+                  // pushed in Oct 2023 and is amd64-only, so it cannot run on
+                  // arm64 at all. Same upstream binary, built for both arches
+                  // from the pinned release (containers/rathole).
+                  image: "ghcr.io/radiosilence/jaritanet-rathole:latest",
                   name: "rathole",
                   // 64Mi got this OOMKilled (exit 137) roughly every few days.
                   // Every restart drops the tunnel, and with it all public


### PR DESCRIPTION
Needed for the Pi migration, and worth doing regardless.

## The problem

```
rapiz1/rathole:latest   last_updated 2023-10-01   arches: amd64
```

Three years old, and **amd64 only** — so it cannot run on arm64 at all. That alone blocks moving the home side to a Raspberry Pi. It is also a three-year-old base image on the pod that carries every byte between the gateway and home, pinned by a floating `:latest` tag in a repo whose own config comments say:

> Pinned to release tags, not `:main`. A floating tag with the default pull policy leaves a running pod on whatever it first pulled.

The MCP images follow that rule. rathole did not.

## Why not fork

Forking upstream means owning a Rust cross-compilation pipeline for a project we have no intention of modifying. Unnecessary — upstream already publishes static musl binaries for every arch we want:

```
rathole-aarch64-unknown-linux-musl.zip
rathole-x86_64-unknown-linux-musl.zip
```

So the Dockerfile fetches the pinned release for `TARGETARCH` and unpacks it. Same binary upstream ships, built for both arches, under our control.

## Shape

- **`scratch` base.** The binary is statically linked, so it needs nothing around it: nothing to patch, nothing for a scanner to find, and no shell for anything that lands in the pod to use.
- **`RATHOLE_VERSION` build arg** tracking the same version the gateway installs, so both ends of the tunnel move together rather than drifting.
- **Mirrors `containers/files`** — same layout, same shared workflow. That workflow already defaults to `linux/amd64,linux/arm64`, so multi-arch costs nothing and needs no new machinery.

## Verify

- Merging builds and publishes `ghcr.io/radiosilence/jaritanet-rathole`; the deploy then rolls the rathole client onto it.
- **The tunnel bounces during that roll** — every public hostname and every exit rides it, so expect a blip.
- Afterwards: `kubectl get pods -l app=rathole-client` running with 0 restarts, and the sites answering, which is the real signal since nothing reaches home without it.
- `docker manifest inspect ghcr.io/radiosilence/jaritanet-rathole:latest` should list both arches — the check that fails against the upstream image today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD