### PR TITLE
feat(gateway): move the cluster onto the gateway, and unblock deploys

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,15 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      deleteUnreachable:
+        description: >-
+          Drop Kubernetes resources from state when their cluster is
+          unreachable. For a cluster that has been replaced or retired — never
+          for one that is merely down, since it deletes live resources from
+          state.
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -194,6 +203,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          PULUMI_K8S_DELETE_UNREACHABLE: ${{ inputs.deleteUnreachable && 'true' || '' }}
           KUBE_HOST: ${{ secrets.KUBE_HOST }}
           KUBE_API_PORT: ${{ secrets.KUBE_API_PORT }}
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -131,6 +131,16 @@ config:
             required: false
             hint: "32 hex characters"
   jaritanet:gateway:
+    # sympathy — Ampere ARM. Every image we run publishes arm64, and CAX is both
+    # cheaper and actually in stock, unlike the CX line. 8GB because this box now
+    # carries the cluster as well as the transports.
+    serverType: cax21
+    # The cluster lives here now. One `pulumi up` creates the box, installs k3s,
+    # reads its kubeconfig and deploys into it — no ansible, no KUBE_* secrets.
+    # Cilium's version must match the k8s minor: 1.19 supports 1.33-1.36.
+    k3s:
+      version: v1.36.2+k3s1
+      ciliumVersion: 1.19.6
     # xray shares :443; traffic that doesn't match a client falls back to
     # dest (local rathole https), so real visitors still get the site.
     #
@@ -169,14 +179,10 @@ config:
   # just ss-rust + rathole; the gateway reaches it over the rathole tunnel.
   # `name` is all you set (drives the picker tag exit-<name> + resource names);
   # the loopback port is auto-derived from the name.
-  jaritanet:exits:
-    # oldboy — the home k8s cluster. Egresses your home residential IP.
-    - name: oldboy
-      # A Hetzner (or any) VPS exit is the same two daemons via cloud-init.
-      # NOT WIRED YET — substrate `vps` is unimplemented (k8s only for now):
-      # - name: fin
-      #   substrate: vps
-      #   location: hel1
+  # Exits were ss-rust in the home cluster, reached over rathole. oldboy is
+  # retired, so there are none until a second node exists — at which point an
+  # exit is just a pod on it, with no tunnel involved.
+  jaritanet:exits: []
   jaritanet:services:
     navidrome:
       hostname: ''

--- a/packages/infra/src/deploy.ts
+++ b/packages/infra/src/deploy.ts
@@ -100,10 +100,27 @@ if (mode !== "preview" && mode !== "up") {
   throw new Error(`expected "preview" or "up", got "${mode ?? ""}"`);
 }
 
-const stack = await automation.LocalWorkspace.createOrSelectStack({
-  stackName: STACK,
-  workDir: WORK_DIR,
-});
+const stack = await automation.LocalWorkspace.createOrSelectStack(
+  {
+    stackName: STACK,
+    workDir: WORK_DIR,
+  },
+  {
+    // Off unless a run explicitly asks for it. Refresh reads every Kubernetes
+    // resource, so when a cluster is gone — replaced, rebuilt, or simply
+    // switched off — refresh fails and no deploy can proceed at all, even for
+    // resources that have nothing to do with Kubernetes.
+    //
+    // Set for one run, this drops the unreachable resources from state so they
+    // are recreated on the new cluster. Left on permanently it would do the
+    // same for a cluster that was briefly unreachable, quietly deleting live
+    // resources from state — which is why it is an input rather than a default.
+    envVars: {
+      PULUMI_K8S_DELETE_UNREACHABLE:
+        process.env.PULUMI_K8S_DELETE_UNREACHABLE ?? "",
+    },
+  },
+);
 
 await stack.setAllConfig(
   Object.fromEntries(

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -20,6 +20,7 @@ import {
   createIpWatcher,
   createRedirectMiddleware,
 } from "./modules/ingress.ts";
+import { createCilium } from "./modules/cilium.ts";
 import { createMcpGateway } from "./modules/mcp-gateway.ts";
 import { createSingboxDelivery, type SingboxNode } from "./modules/singbox.ts";
 import { createService } from "./templates/service.ts";
@@ -32,6 +33,7 @@ export default async function () {
   // Set when the gateway runs its own control plane; its kubeconfig then
   // replaces the KUBE_* secrets below.
   let gatewayK3s: ReturnType<typeof createGateway>["k3s"];
+  let gatewayConfForCilium: { ciliumVersion: string } | undefined;
   let xray: ReturnType<typeof createGateway>["xray"];
 
   // sing-box nodes (primary gateway + every edge). Pulumi builds a per-user
@@ -73,6 +75,7 @@ export default async function () {
     ratholeToken = gw.ratholeToken.result;
     gatewayProvider = "hetzner";
     gatewayK3s = gw.k3s;
+    gatewayConfForCilium = gatewayConf.k3s;
     xray = gw.xray;
 
     // The primary is a node too: clients connect by IP, and its REALITY decoy
@@ -185,6 +188,15 @@ export default async function () {
     },
   );
 
+  // The cluster has no CNI until this exists — k3s runs with
+  // --flannel-backend=none so Cilium can own networking and the
+  // NetworkPolicies in this repo finally mean something.
+  if (gatewayK3s && gatewayConfForCilium) {
+    createCilium(provider, gatewayConfForCilium.ciliumVersion, [
+      gatewayK3s.install,
+    ]);
+  }
+
   new k8s.core.v1.Namespace(
     namespace,
     {
@@ -204,13 +216,16 @@ export default async function () {
   // punches each one's port out to the gateway loopback.
   const exits = resolvedExits.map((e) => createExit(provider, namespace, e));
 
-  // --- Ingress: Traefik always on hostPort 443 + rathole client if gateway exists ---
+  // --- Ingress: Traefik, plus a rathole client only when the cluster is
+  // somewhere other than the gateway. Co-located, rathole would tunnel a box to
+  // itself: xray relays straight to Traefik's hostPort instead.
+  const clusterOnGateway = Boolean(gatewayK3s);
   createIngress(
     provider,
     namespace,
     conf.traefik,
-    dnsTarget,
-    ratholeToken,
+    clusterOnGateway ? undefined : dnsTarget,
+    clusterOnGateway ? undefined : ratholeToken,
     env.CLOUDFLARE_API_TOKEN,
     resolvedExits,
   );

--- a/packages/infra/src/modules/cilium.ts
+++ b/packages/infra/src/modules/cilium.ts
@@ -1,0 +1,60 @@
+import * as k8s from "@pulumi/kubernetes";
+import type * as pulumi from "@pulumi/pulumi";
+
+/**
+ * Cilium as the cluster's CNI.
+ *
+ * Not optional: k3s is installed with `--flannel-backend=none`, so until this
+ * exists the node is NotReady and nothing schedules. That is deliberate —
+ * flannel has no policy engine, which is why every NetworkPolicy in this repo
+ * was decorative on the old cluster (proved empirically: a pod reached the
+ * node's LAN address straight through a policy that denied it).
+ *
+ * Two settings are load-bearing rather than taste:
+ *
+ * `kubeProxyReplacement` — Traefik binds hostPort 80/443, and Cilium only
+ * implements hostPort when it owns service routing. With kube-proxy in charge
+ * instead, hostPort silently does nothing and the ingress path dies. k3s is
+ * therefore installed with `--disable-kube-proxy`, which also removes a
+ * component rather than running two that overlap.
+ *
+ * `k8sServiceHost` — with no kube-proxy there is no ClusterIP for the API
+ * server yet, so Cilium has to be told where it is directly. It is on this same
+ * node, hence loopback.
+ */
+export function createCilium(
+  provider: k8s.Provider,
+  version: string,
+  dependsOn: pulumi.Resource[] = [],
+) {
+  return new k8s.helm.v3.Release(
+    "cilium",
+    {
+      chart: "cilium",
+      namespace: "kube-system",
+      repositoryOpts: { repo: "https://helm.cilium.io/" },
+      version,
+      values: {
+        // Single node — the default of two operator replicas leaves one pending
+        // forever, which looks like a broken cluster to anyone reading pods.
+        operator: { replicas: 1 },
+        // k3s allocates each node a podCIDR, so Cilium can follow that rather
+        // than running its own allocator.
+        ipam: { mode: "kubernetes" },
+        kubeProxyReplacement: true,
+        k8sServiceHost: "127.0.0.1",
+        k8sServicePort: 6443,
+        // What Traefik needs; see above.
+        hostPort: { enabled: true },
+        nodePort: { enabled: true },
+        // k3s keeps its CNI plugins and config outside the usual /opt and /etc
+        // locations, and Cilium writes its conflist to whatever it is told.
+        cni: {
+          binPath: "/var/lib/rancher/k3s/data/current/bin",
+          confPath: "/var/lib/rancher/k3s/agent/etc/cni/net.d",
+        },
+      },
+    },
+    { dependsOn, provider },
+  );
+}

--- a/packages/infra/src/modules/ingress.ts
+++ b/packages/infra/src/modules/ingress.ts
@@ -52,7 +52,12 @@ export function createIngress(
           websecure: {
             expose: { default: true },
             port: 8443,
-            hostPort: 443,
+            // 8443, not 443: xray owns :443 on this host and relays anything
+            // that is not a VPN client to `dest` — which is this. Binding 443
+            // here would collide with it and take both down. When the cluster
+            // was on a different machine, rathole bridged that gap; co-located,
+            // the gap does not exist.
+            hostPort: 8443,
           },
         },
         service: {

--- a/packages/infra/src/modules/k3s.ts
+++ b/packages/infra/src/modules/k3s.ts
@@ -27,6 +27,10 @@ import { type Connection, resourcePrefix } from "./vps.ts";
  * firewall's inbound rules. That matches how the home cluster was already
  * reached and keeps a control plane off the public internet.
  *
+ * `--disable-kube-proxy` is not an optimisation: Cilium only implements
+ * hostPort when it owns service routing, and Traefik binds one. Running both
+ * would also mean two components doing the same job.
+ *
  * Note k3s comes up with **no CNI**: `--flannel-backend=none` is what allows
  * Cilium to own networking, and until Cilium is installed the node is NotReady
  * and pods stay Pending. The API server runs on the host network, so Pulumi can
@@ -52,6 +56,7 @@ curl -sfL https://get.k3s.io | \
   INSTALL_K3S_EXEC="server \
     --flannel-backend=none \
     --disable-network-policy \
+    --disable-kube-proxy \
     --disable=traefik \
     --disable=servicelb \
     --tls-san ${apiHost} \


### PR DESCRIPTION
Two things, because neither works without the other.

## 1. #190 only half-merged

The squash took the first commit, so the k3s module landed but **nothing enables it** — `gateway.k3s` is unset, the module is inert, and the box is unchanged (`vpsIp` is still the old one, same `xrayPublicKey`).

This carries the config that actually moves the cluster:

| | |
| --- | --- |
| `serverType` | **cax21** — Ampere ARM, 8GB, ~€8, and in stock |
| `k3s` | v1.36.2+k3s1, Cilium 1.19.6 |
| Traefik | hostPort **8443**, behind xray |
| rathole client | not deployed — co-located, it would tunnel the box to itself |
| exits | `[]` — oldboy is retired; the next one is a pod on a second node |

**This replaces the gateway.** New IP, new REALITY keypair. Save a working profile to disk first.

## 2. Every deploy is currently failing

Including ones with nothing to do with Kubernetes — the blit image bump died with:

```
error: failed to read resource state due to unreachable cluster.
If the cluster was deleted, you can remove this resource from Pulumi state
by rerunning the operation with PULUMI_K8S_DELETE_UNREACHABLE
```

Pulumi's state still holds every resource from the **microk8s cluster on `oldboy`**, which is switched off. `deploy.ts` runs with `refresh: true`, so it reads all of them *before* doing anything — and one dead cluster blocks the entire pipeline.

`PULUMI_K8S_DELETE_UNREACHABLE` drops those from state so they get recreated on the new cluster.

**Exposed as a `workflow_dispatch` input, not a default**, and that distinction matters: left on permanently it would do the same thing to a cluster that was merely *briefly* unreachable — silently deleting live resources from state during a blip, then recreating them. One deliberate run; never a standing setting.

## How to land it

1. Merge — the push-triggered deploy will still fail on the unreachable cluster, which is expected.
2. Then **Actions → CI/CD → Run workflow**, with **`deleteUnreachable` ticked**.

That run drops the dead microk8s resources, provisions `sympathy`, installs k3s + Cilium, and deploys Traefik, the MCP stack and the rest onto it.

## Verify afterwards

- `pulumi stack output vpsIp` — a **new** address; the old one means the replace did not happen.
- `kubectl get nodes` Ready (NotReady until Cilium is up is expected, not a fault).
- `mcp.blit.cc` answers; `blit.cc` only once its arm64 image exists.
- VPN needs a **freshly installed profile** — the REALITY key changed with the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD