### PR TITLE
chore(deploy): stop injecting hostnames for the services oldboy hosted

### DIFF
--- a/packages/infra/src/deploy.ts
+++ b/packages/infra/src/deploy.ts
@@ -32,8 +32,15 @@ const COMMENT_LIMIT = 60_000;
 const CONFIG_FROM_ENV = {
   "jaritanet:cloudflare.accountId": "CLOUDFLARE_ACCOUNT_ID",
   "jaritanet:traefik.acmeEmail": "ACME_EMAIL",
-  "jaritanet:services.navidrome.hostname": "NAVIDROME_HOSTNAME",
-  "jaritanet:services.files.hostname": "FILES_HOSTNAME",
+  // navidrome and files lived on oldboy, which is retired. Their config stays
+  // in Pulumi.main.yaml with a blank hostname — which main.ts skips — so it is
+  // ready for `lady` without being deployed onto a node that cannot host it:
+  // both pin volumes to `nodeAffinityHostname: oldboy`, so scheduling them
+  // anywhere else leaves a pod Pending until the deploy times out.
+  //
+  // Commented rather than deleted: uncomment when the disk has a machine again.
+  // "jaritanet:services.navidrome.hostname": "NAVIDROME_HOSTNAME",
+  // "jaritanet:services.files.hostname": "FILES_HOSTNAME",
   "jaritanet:services.blit.hostname": "BLIT_HOSTNAME",
   "jaritanet:mcpGateway.hostname": "MCP_HOSTNAME",
   "jaritanet:mcpGateway.authHostname": "MCP_AUTH_HOSTNAME",


### PR DESCRIPTION
Makes the disabling visible in the repo rather than living in deleted GitHub secrets.

## Why they must be off, not just broken

`navidrome` and `files` pin their volumes with `nodeAffinityHostname: oldboy`. That node no longer exists, so the PersistentVolumes are unschedulable and the pods sit `Pending` — and Pulumi waits for Deployments to become Ready, so they would hang until timeout and **fail the whole deploy**, taking Traefik and mcp-gateway down with them.

## What this changes

Nothing functional — the same gating, said out loud. `main.ts:217` already skips any service with a blank hostname, and `Pulumi.main.yaml` carries blanks. Deleting `NAVIDROME_HOSTNAME` and `FILES_HOSTNAME` achieved that, but invisibly: someone reading the repo would see two services configured and reasonably expect them to deploy.

Commented rather than deleted, and the service definitions stay in `Pulumi.main.yaml`, so bringing them back on `lady` is uncommenting two lines instead of reconstructing image tags, volumes and health checks from memory.

## Not required for tonight's deploy

The secrets are already gone, so the running deploy is unblocked either way. This is hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD