### PR TITLE
ci: drop the tailscale step from deploy and preview

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -196,13 +196,6 @@ jobs:
           run-install: true
           install-args: --frozen-lockfile
 
-      - name: Connect to Tailscale
-        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
-
       # Stack configuration, external-IP detection and the update itself all
       # happen inside deploy.ts, so preview.yml runs the identical code path.
       - name: Deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,13 +39,6 @@ jobs:
           run-install: true
           install-args: --frozen-lockfile
 
-      - name: Connect to Tailscale
-        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
-
       # Identical entrypoint to the deploy in ci-cd.yml, differing only in the
       # verb — which is the point. Config is written to the checked-out
       # Pulumi.main.yaml, not the shared stack, so PRs can't leak into each


### PR DESCRIPTION
CI joined the tailnet so it could reach the home cluster's API server over MagicDNS. That cluster is gone — the control plane is now the gateway's own k3s, reached on its public IP with 6443 open in the Hetzner firewall — so neither workflow needs the tailnet at all. The step remained as a dependency that could fail for reasons unrelated to anything being deployed, which it did repeatedly tonight.

## Verifying

Both workflows should still deploy and preview with no tailnet. The deploy's only cluster access is the kubeconfig produced by `modules/k3s.ts`, whose server address is the gateway's public IPv4 (`apiViaTailnet` is false), and the only SSH is to that same public address.

## Kept deliberately

`TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` remain declared. They are the action's credentials and distinct from the `TS_OAUTH_CLIENT_ID`/`TS_OAUTH_CLIENT_SECRET`/`TS_TAILNET` triple Pulumi reads for `createTailnetPolicy`. Removing them is a separate question.

## Trap worth knowing

`gateway.k3s.apiViaTailnet` points the kubeconfig at a MagicDNS name. With this step gone CI cannot resolve that, so enabling it means restoring the step. It defaults to `false` and nothing sets it.

`[skip ci]` on the commit: this changes only workflow definitions and there is a deploy in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADUPAX3zqXMvqvMSatmvD