### PR TITLE
fix(cilium): point k8sServiceHost at the API server, not loopback

### DIFF
--- a/packages/hetzner/src/cilium.ts
+++ b/packages/hetzner/src/cilium.ts
@@ -26,6 +26,12 @@ import type * as pulumi from "@pulumi/pulumi";
  * the supervisor load balancer instead, so Cilium could not reach an apiserver
  * and the node stayed NotReady with the CNI uninitialised — a failure that
  * reads as a CNI fault while the cause is a value belonging to another machine.
+ *
+ * That ties this to `apiViaTailnet`: with it on, `apiHost` is a MagicDNS name,
+ * and this value has to resolve before there is a CNI — so before CoreDNS, from
+ * whatever the host's resolver happens to be. An IP has no such requirement.
+ * Turning that flag on is therefore a change to how Cilium bootstraps, not only
+ * to how the kubeconfig is addressed.
  */
 export function createCilium(
   provider: k8s.Provider,

--- a/packages/hetzner/src/cilium.ts
+++ b/packages/hetzner/src/cilium.ts
@@ -19,12 +19,18 @@ import type * as pulumi from "@pulumi/pulumi";
  * component rather than running two that overlap.
  *
  * `k8sServiceHost` — with no kube-proxy there is no ClusterIP for the API
- * server yet, so Cilium has to be told where it is directly. It is on this same
- * node, hence loopback.
+ * server yet, so Cilium has to be told where it is directly. It takes the same
+ * address the kubeconfig does, because this has to be true on every node rather
+ * than only on the one serving the API. Loopback was correct on the control
+ * plane and nowhere else: an agent runs no API server, listening on 6444 for
+ * the supervisor load balancer instead, so Cilium could not reach an apiserver
+ * and the node stayed NotReady with the CNI uninitialised — a failure that
+ * reads as a CNI fault while the cause is a value belonging to another machine.
  */
 export function createCilium(
   provider: k8s.Provider,
   version: string,
+  apiHost: pulumi.Input<string>,
   dependsOn: pulumi.Resource[] = [],
 ) {
   return new k8s.helm.v3.Release(
@@ -42,7 +48,7 @@ export function createCilium(
         // than running its own allocator.
         ipam: { mode: "kubernetes" },
         kubeProxyReplacement: true,
-        k8sServiceHost: "127.0.0.1",
+        k8sServiceHost: apiHost,
         k8sServicePort: 6443,
         // What Traefik needs; see above.
         hostPort: { enabled: true },

--- a/packages/infra/src/gateway.ts
+++ b/packages/infra/src/gateway.ts
@@ -353,6 +353,7 @@ k3s kubectl label node "$(hostname)" ${entryLabel}=true --overwrite`,
     : undefined;
 
   return {
+    apiHost,
     hysteria,
     k3s,
     vpnEntryLabel,

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -44,6 +44,9 @@ export default async function () {
   let gatewayK3s: ReturnType<typeof createGateway>["k3s"];
   let gatewayConf: z.infer<typeof GatewayConfSchema> | undefined;
   let gatewayIp: pulumi.Output<string> | undefined;
+  // Where the API server answers. Cilium needs it too, and must agree with the
+  // kubeconfig — see createCilium.
+  let gatewayApiHost: ReturnType<typeof createGateway>["apiHost"] | undefined;
   // Ordering for the transport DaemonSets: the legacy daemons must be gone
   // before anything tries to bind their ports, and the node must carry the
   // entry label before a DaemonSet has anywhere to schedule.
@@ -95,6 +98,7 @@ export default async function () {
     ratholeToken = gw.ratholeToken.result;
     gatewayProvider = "hetzner";
     gatewayK3s = gw.k3s;
+    gatewayApiHost = gw.apiHost;
     transportDeps = [gw.vpnEntryLabel].filter((r) => r !== undefined);
 
     if (gw.xray && gatewayConf.xray) {
@@ -203,8 +207,8 @@ export default async function () {
   // --flannel-backend=none so Cilium can own networking and the
   // NetworkPolicies in this repo finally mean something.
   const cilium =
-    gatewayK3s && gatewayConf?.k3s
-      ? createCilium(provider, gatewayConf.k3s.ciliumVersion, [
+    gatewayK3s && gatewayConf?.k3s && gatewayApiHost
+      ? createCilium(provider, gatewayConf.k3s.ciliumVersion, gatewayApiHost, [
           gatewayK3s.install,
         ])
       : undefined;


### PR DESCRIPTION
Fixes #213.

Cilium was configured with `k8sServiceHost: 127.0.0.1`. With `kubeProxyReplacement` there is no ClusterIP for the API server yet, so Cilium has to be told where it is directly — but loopback is only ever correct on the node serving the API. A k3s agent runs no API server at all; it listens on `127.0.0.1:6444` for the supervisor load balancer. So on any joining node Cilium's init container fails:

```
Unable to contact k8s api-server ipAddr=https://127.0.0.1:6443
  dial tcp 127.0.0.1:6443: connect: connection refused
```

and the node stays `NotReady` with `NetworkPluginNotReady: cni plugin not initialized`. **The cluster could not accept an agent node at all** — the first remaining item of #189.

## The change

`createCilium` takes `apiHost`, which `gateway.ts` already computes for the kubeconfig: the tailnet MagicDNS name when the API is reached that way, otherwise the server's public IP. The certificate already covers whichever is used. This makes "where is the API server" one answer rather than two, the second of which only worked on one machine.

## How this was found, and how to confirm it

A throwaway Lima VM joined as an agent (`scripts/lima-node` in #214) reproduces it exactly — the failure is in this comment's log excerpt, taken from that node. The same VM is the verification: after this deploys it should go `Ready` with no change to the VM itself.

That matters more than usual right now. Without this, the home node in #189 would have been flashed, joined, and died the same way — on hardware with no SSH access (#212), with a symptom that reads as a CNI fault while the cause is a Helm value belonging to a different machine.

## Risk

Changing the value rolls the Cilium DaemonSet. Existing pods keep their programmed networking across an agent restart, but this touches the CNI on the box serving the sites and the VPN, so it is worth watching rather than merging blind.

Not touched: `operator.replicas: 1`, whose comment records a single-node assumption that stops being true once a node can actually join. Noted in #213, deliberately left out to keep this diff to the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSoVxv2DpGgAV6mEsu1TWH