### PR TITLE
212 feat(hetzner): break-glass SSH access to the fleet

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,6 +40,8 @@ on:
         required: true
       HCLOUD_TOKEN:
         required: false
+      SSH_PUBLIC_KEY:
+        required: false
       TS_OAUTH_CLIENT_ID:
         required: true
       TS_OAUTH_SECRET:
@@ -213,6 +215,9 @@ jobs:
           MCP_HOSTNAME: ${{ secrets.MCP_HOSTNAME }}
           MCP_AUTH_HOSTNAME: ${{ secrets.MCP_AUTH_HOSTNAME }}
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          # Break-glass admin key installed on the gateway and every edge, over
+          # SSH rather than at creation so rotating it never replaces a box.
+          SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
           TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
           # Per-user VPN roster (RBAC). "jc+,guest1" → jc admin, guest1 guest.
           # Unset → single implicit owner-admin.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -69,6 +69,7 @@ jobs:
           # produce a diff — and one produced from different inputs than the
           # deploy predicts nothing anyway.
           VPN_ENTRY_LABEL: ${{ secrets.VPN_ENTRY_LABEL }}
+          SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
           TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
           SINGBOX_SLUG: ${{ secrets.SINGBOX_SLUG }}
           TAILNET_MAGICDNS_SUFFIX: ${{ secrets.TAILNET_MAGICDNS_SUFFIX }}

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ emit and `@pulumi/pulumi` moved to a peer dependency.
 | `ACME_EMAIL` | Yes | Let's Encrypt account email (Traefik) |
 | `BLIT_HOSTNAME` / `MCP_HOSTNAME` / `MCP_AUTH_HOSTNAME` | Yes | Service hostnames |
 | `HCLOUD_TOKEN` | Yes | Hetzner API token. The cluster runs on the VPS it provisions, so this is not optional |
+| `SSH_PUBLIC_KEY` | No | Break-glass admin key, installed on the gateway and every edge (see below). Unset = nobody but Pulumi can SSH to them |
 | `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_CLIENT_SECRET` / `TS_TAILNET` | No | Manage the tailnet policy file as code (see below). Unset = policy stays hand-managed |
 
 **Tailscale**
@@ -228,6 +229,28 @@ Next deploy provisions the VPS, installs k3s on it and deploys everything into
 it. Removing the secret does not fall back to anything: there is no cluster
 without the box.
 
+### Break-glass SSH
+
+```bash
+gh secret set SSH_PUBLIC_KEY < ~/.ssh/id_ed25519.pub
+```
+
+Installs that key on the gateway and every edge, so `ssh root@<ip>` works. Only
+worth having for one case: k3s failing to come up. Everything else — host files,
+host networking, `systemctl` — is already reachable through a privileged pod
+with `hostPID` and `nsenter`, and none of that exists without an API server. The
+mechanism for adding a key is the broken thing at that moment, so the key has to
+be there beforehand.
+
+It arrives over SSH rather than through the server's `sshKeys` or `userData`,
+both of which Hetzner applies only at creation: setting either would replace the
+box, and with it the IP and the REALITY keypair every client profile carries.
+Rotating the key is therefore a normal deploy. Unsetting the secret removes it.
+
+The key lands in `/etc/ssh/admin_authorized_keys`, selected by an
+`sshd_config.d` drop-in, never in the `authorized_keys` Pulumi authenticates
+with — a mistake in that file locks the deploy out of the box it is deploying to.
+
 ## Development
 
 ```bash
@@ -259,8 +282,9 @@ See #197.
 
 Ansible provisions the *home* box only — Samba, Syncthing, SSH hardening and
 the media tooling. It has nothing to do with the gateway, which is configured
-entirely by Pulumi: the only thing that touches it over SSH is the k3s install,
-and that hands its kubeconfig straight back to the program. See `ansible/`.
+entirely by Pulumi, over an SSH key it generates itself — the k3s install (which
+hands its kubeconfig straight back to the program), the network sysctls, and the
+break-glass admin key. See `ansible/`.
 
 ## Tailnet policy as code
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -375,7 +375,8 @@ route → the relay and every service riding it go dark.
 
 On the gateway this runs as a pod, which means the tailnet goes with the
 cluster. That is accepted rather than defended against: sshd on the public IP is
-the way back in, so nothing is built to keep tailscale up while k3s is down.
+the way back in (see Break-glass SSH), so nothing is built to keep tailscale up
+while k3s is down.
 
 Node state lives in a Kubernetes Secret, not on the node's disk, so the identity
 survives reprovisioning the box. The Secret is created empty by Pulumi and never
@@ -572,6 +573,41 @@ Delivery is owner-relayed: a bot can't cold-DM a handle, so on change the owner
 gets one Telegram message grouping users under Admins / Guests, each URL a
 tap-to-copy `<code>` block plus a `copy_text` inline-keyboard button.
 
+## Break-glass SSH
+
+Each box's only key is the ED25519 pair Pulumi generates for it, which lives in
+stack state and is never exported. `SSH_PUBLIC_KEY` adds a human's key on top,
+on the gateway and every edge.
+
+It buys one thing, and it is worth being precise about which. Reading host
+files, host networking and even `systemctl` are all reachable from a privileged
+pod with `hostPID` and `nsenter` — SSH adds nothing there. The case it exists
+for is **k3s failing to come up**: no API server, no kubectl, no privileged pod.
+The mechanism for adding a key is the broken thing at that moment, which is why
+the key is installed on every deploy rather than when it is wanted.
+
+Three decisions hold it up:
+
+**It arrives over SSH, not through `sshKeys` or `userData`.** Hetzner applies
+both only at creation, so changing either forces a replacement — a new IP, a new
+REALITY keypair, and every client profile rotating. `createAdminSshAccess` is a
+`command.remote.Command` over the connection Pulumi already holds, the same
+idiom as `createNetworkTuning`. Rotating the key is an ordinary deploy.
+
+**It never touches the `authorized_keys` Pulumi authenticates with.** The key
+goes in `/etc/ssh/admin_authorized_keys`, selected by an `sshd_config.d` drop-in
+that lists root's own file first. A mistake in the shared file locks the deploy
+out of the box it is deploying to, with no way back in. `sshd -t` runs before
+anything is reloaded and the drop-in is removed if it rejects, so a bad config
+fails the Pulumi resource rather than the daemon.
+
+**Absent secret means no resource**, matching how `TS_AUTHKEY` gates the tailnet
+relay. Removing the secret deletes the key from the boxes on the next deploy.
+
+The reload is conditional on `ssh.service` being active: Ubuntu 24.04 activates
+sshd from `ssh.socket`, where each connection is a fresh process that reads the
+config anyway, and starting `ssh.service` there would fight the socket for `:22`.
+
 ## Hardening notes
 
 Live tradeoffs worth knowing, not necessarily bugs:
@@ -622,8 +658,10 @@ Live tradeoffs worth knowing, not necessarily bugs:
 - **SSH (22) and rathole control (2333) are open to the world.** Both are
   authenticated (SSH is key-only ED25519; rathole is 64-char token). Tailnet-
   gating SSH would shrink the attack surface but adds lockout risk on a box
-  whose whole job is being reachable, so it's left open by choice. 2333 must
-  stay open regardless: the home client dials in from a dynamic NATed IP.
+  whose whole job is being reachable — and the tailnet is a pod on that cluster,
+  so gating it would remove exactly the access needed when the cluster is the
+  thing that broke. Left open by choice. 2333 must stay open regardless: the
+  home client dials in from a dynamic NATed IP.
 - **The NetworkPolicies are enforced now, and the first thing they caught was
   ours.** The old home cluster ran flannel, a pure overlay with **no policy
   engine at all**: a NetworkPolicy was accepted by the API server, stored,

--- a/packages/hetzner/src/index.ts
+++ b/packages/hetzner/src/index.ts
@@ -2,6 +2,7 @@ export { createCilium } from "./cilium.ts";
 export { createK3s } from "./k3s.ts";
 export { K3sConfSchema } from "./k3s.schemas.ts";
 export {
+  createAdminSshAccess,
   createNetworkTuning,
   inboundRule,
   resourcePrefix,

--- a/packages/hetzner/src/vps.ts
+++ b/packages/hetzner/src/vps.ts
@@ -30,6 +30,76 @@ export const inboundRule = (
 });
 
 /**
+ * Break-glass SSH access for a human, over SSH so the box is never rebuilt.
+ *
+ * Everything routine is reachable with kubectl alone — host files, host
+ * networking, even `systemctl`, via a privileged pod with `hostPID` and
+ * `nsenter`. The case that isn't is k3s failing to come up: no API server means
+ * no kubectl, which means no privileged pod, which is exactly when getting onto
+ * the box is the only remaining move. The mechanism for adding a key is the
+ * thing that is broken at that moment, so the key has to already be there.
+ *
+ * Not via the server's `sshKeys` or `userData`: Hetzner applies both only at
+ * creation, so changing either replaces the box — a new IP, a new REALITY
+ * keypair, and every client profile rotating.
+ *
+ * The key lands in its own file rather than root's `authorized_keys`, which is
+ * the one Pulumi authenticates with: a mistake in the shared file locks the
+ * deploy out of the box it is deploying to, with no way back in. `sshd -t` runs
+ * before anything is reloaded and the drop-in is removed if it fails, so a bad
+ * config fails this command rather than the daemon.
+ */
+export function createAdminSshAccess(
+  name: string,
+  connection: SshConnection,
+  server: hcloud.Server,
+  publicKey: string,
+) {
+  const dropIn = "/etc/ssh/sshd_config.d/60-jaritanet-admin.conf";
+  const keyFile = "/etc/ssh/admin_authorized_keys";
+
+  // Socket-activated sshd (the Ubuntu 24.04 default) starts a fresh process per
+  // connection and so reads the config anyway; where ssh.service holds port 22
+  // the running daemon has the old config loaded and must be told. Starting
+  // ssh.service unconditionally would fight ssh.socket for the port.
+  const reload = `systemctl is-active --quiet ssh.service && systemctl reload ssh.service || true`;
+
+  return new command.remote.Command(
+    `${name}-admin-ssh`,
+    {
+      connection,
+      create: `set -euo pipefail
+install -m 0600 -o root -g root /dev/null ${keyFile}
+cat > ${keyFile} << 'KEY_EOF'
+${publicKey}
+KEY_EOF
+# Root's own authorized_keys stays first and untouched — it is the key this
+# command is running over.
+cat > ${dropIn} << 'EOF'
+AuthorizedKeysFile .ssh/authorized_keys ${keyFile}
+EOF
+if ! sshd -t; then
+  rm -f ${dropIn}
+  echo "sshd rejected the admin drop-in; rolled back" >&2
+  exit 1
+fi
+${reload}`,
+      delete: `rm -f ${dropIn} ${keyFile}
+${reload}`,
+      triggers: [publicKey, "admin-ssh-v1"],
+    },
+    {
+      dependsOn: [server],
+      // A trigger change replaces this resource, and the default order is
+      // create-then-delete: the new key would be written and then the old
+      // resource's delete would remove both files, leaving no key at all.
+      // Rotating the key has to delete first.
+      deleteBeforeReplace: true,
+    },
+  );
+}
+
+/**
  * Network sysctls the transports need, over SSH so the box is never rebuilt.
  *
  * BBR + fq: default cubic collapses throughput on packet loss; BBR holds the

--- a/packages/infra/src/edge.ts
+++ b/packages/infra/src/edge.ts
@@ -1,4 +1,8 @@
-import { createNetworkTuning, inboundRule } from "@jaritanet/hetzner";
+import {
+  createAdminSshAccess,
+  createNetworkTuning,
+  inboundRule,
+} from "@jaritanet/hetzner";
 import {
   createHysteriaSystemd,
   createTailscaleSystemd,
@@ -31,6 +35,7 @@ export function createEdge(
   edge: z.infer<typeof EdgeConfSchema>,
   users: VpnUser[],
   authKey: pulumi.Output<string> | undefined,
+  adminSshKey: string | undefined,
 ) {
   const { name } = edge;
 
@@ -68,6 +73,10 @@ export function createEdge(
   };
 
   createNetworkTuning(name, connection, server);
+
+  if (adminSshKey) {
+    createAdminSshAccess(name, connection, server, adminSshKey);
+  }
 
   const opts = { name, dependsOn: [server] };
 

--- a/packages/infra/src/env.schema.ts
+++ b/packages/infra/src/env.schema.ts
@@ -5,6 +5,22 @@ export const EnvSchema = z.object({
   DEPLOY_TOKEN: z.string().optional(),
   GITHUB_REPOSITORY: z.string().default("radiosilence/jaritanet"),
   HCLOUD_TOKEN: z.string().optional(),
+
+  // Break-glass admin key, installed on the gateway and every edge. Absent →
+  // no resource, same idiom as TS_AUTHKEY gating the tailnet relay.
+  //
+  // Shape-checked because the failure is silent and badly timed: a mangled key
+  // installs cleanly and is only discovered to be useless when k3s is down and
+  // SSH is the last way in. Empty is allowed — an unset repository secret
+  // reaches the program as "".
+  SSH_PUBLIC_KEY: z
+    .string()
+    .refine(
+      (key) => key === "" || /^(ssh|ecdsa|sk)-\S+\s+\S+/.test(key),
+      "SSH_PUBLIC_KEY must be an OpenSSH public key line (`ssh-ed25519 AAAA…`)",
+    )
+    .optional(),
+
   TS_AUTHKEY: z.string().optional(),
 
   // Tailnet policy-as-code. Absent, the policy stays hand-managed in the admin

--- a/packages/infra/src/gateway.ts
+++ b/packages/infra/src/gateway.ts
@@ -1,4 +1,5 @@
 import {
+  createAdminSshAccess,
   createK3s,
   createNetworkTuning,
   inboundRule,
@@ -42,10 +43,12 @@ export function createGateway(
   users: VpnUser[],
   exits: { name: string; port: number }[] = [],
   {
+    adminSshKey,
     entryLabel,
     magicdnsSuffix = "",
     tailnetAuthKey,
   }: {
+    adminSshKey?: string;
     entryLabel: string;
     magicdnsSuffix?: string;
     tailnetAuthKey?: string;
@@ -165,6 +168,10 @@ systemctl enable rathole
   };
 
   createNetworkTuning("gateway", connection, server);
+
+  if (adminSshKey) {
+    createAdminSshAccess("gateway", connection, server, adminSshKey);
+  }
 
   // With a cluster on this box the transports are pods (see modules/*-pod.ts);
   // without one they are systemd units installed over SSH, which is also what

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -89,6 +89,7 @@ export default async function () {
     gatewayConf = conf.gateway ?? GatewayConfSchema.parse({});
     // Exits surface on the gateway's rathole loopback (name + port).
     const gw = createGateway(gatewayConf, users, resolvedExits, {
+      adminSshKey: env.SSH_PUBLIC_KEY,
       entryLabel: env.VPN_ENTRY_LABEL,
       magicdnsSuffix: env.TAILNET_MAGICDNS_SUFFIX,
       tailnetAuthKey: env.TS_AUTHKEY,
@@ -125,7 +126,7 @@ export default async function () {
       ? pulumi.secret(env.TS_AUTHKEY)
       : undefined;
     for (const edge of conf.edges) {
-      const e = createEdge(edge, users, edgeAuthKey);
+      const e = createEdge(edge, users, edgeAuthKey, env.SSH_PUBLIC_KEY);
       const hostname = `${edge.name}.${edge.zone}`;
       const zone = conf.zones.find((z) => z.name === edge.zone);
       if (zone) {


### PR DESCRIPTION
Closes #212.

## What this does

Installs a human's SSH public key (`SSH_PUBLIC_KEY`) on the gateway and every edge, so `ssh root@<ip>` works when nothing else does.

Before this, the only key on any box is the ED25519 pair Pulumi generates for it — it lives in stack state, is never exported, and no other key is ever installed. No human can reach any of them.

That only matters for one case. Host files, host networking and `systemctl` are all already reachable via a privileged pod with `hostPID` and `nsenter`. The case that isn't is **k3s failing to come up**: no API server, no kubectl, no privileged pod. The mechanism for adding a key is the broken thing at that moment, so it has to be installed ahead of time, on every deploy.

## Load-bearing decisions

**Over SSH, not `sshKeys`/`userData`.** Hetzner applies both only at creation, so changing either forces a replacement — new IP, new REALITY keypair, every client profile rotating. `createAdminSshAccess` is a `command.remote.Command` over the connection Pulumi already holds, the same idiom as the adjacent `createNetworkTuning`. Rotating the key is an ordinary deploy.

**Never touches the `authorized_keys` Pulumi authenticates with.** The key goes in `/etc/ssh/admin_authorized_keys`, selected by `/etc/ssh/sshd_config.d/60-jaritanet-admin.conf` which lists root's own file *first*. A mistake in the shared file would lock the deploy out of the box it is deploying to, with no way back in.

**`sshd -t` before any reload, with rollback.** If the drop-in is rejected it is removed and the command exits non-zero — a bad config fails the Pulumi resource, not the daemon.

**`deleteBeforeReplace: true`.** A trigger change replaces the resource, and the default create-then-delete order would write the new key and then have the *old* resource's delete handler remove both files — ending with no key at all. Rotation has to delete first.

**Conditional reload.** Ubuntu 24.04 activates sshd from `ssh.socket`, where each connection is a fresh process that reads the config anyway; starting `ssh.service` there would fight the socket for `:22`. So: reload only if `ssh.service` is actually active.

**Absent secret means no resource**, matching how `TS_AUTHKEY` gates the tailnet relay. Unsetting it removes the key from the boxes on the next deploy.

**Shape-checked in `EnvSchema`.** A mangled key installs cleanly and is discovered useless at the worst possible moment. Empty is allowed — an unset repository secret reaches the program as `""`.

Edges get this for free: they take the same `SshConnection` shape.

## How to confirm it works

- **Preview** — the diff should show one new `gateway-admin-ssh` command resource (plus one per edge, of which there are currently none) and **no server replacement**. A replacement here would mean the key went in via `sshKeys`/`userData` after all, which is the thing this PR is written to avoid.
- **After deploy** — `ssh root@<gateway-ip>` with the key matching `SSH_PUBLIC_KEY`.
- **Rotation** — set a different `SSH_PUBLIC_KEY`, deploy; the resource replaces (delete-then-create) and the old key stops working while the new one starts.
- `aube run typecheck` / `lint` / `test` pass (75 tests). The 6 lint warnings in `scripts/check-profiles.ts` are pre-existing and untouched.

## Not covered

`SSH_PUBLIC_KEY` was already set as a repository secret, so no secret needs creating — only the workflow wiring, which is in this diff (`ci-cd.yml` `workflow_call` + deploy env, `preview.yml` env).

Context: #189.