### PR TITLE
feat(hetzner): rebuild the gateway on 26.04, with patches that apply

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,6 +42,8 @@ on:
         required: false
       SSH_PUBLIC_KEY:
         required: false
+      UBUNTU_PRO_TOKEN:
+        required: false
       TS_OAUTH_CLIENT_ID:
         required: true
       TS_OAUTH_SECRET:
@@ -218,6 +220,8 @@ jobs:
           # Break-glass admin key installed on the gateway and every edge, over
           # SSH rather than at creation so rotating it never replaces a box.
           SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+          # Livepatch on the gateway and every edge. Free for personal use.
+          UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
           TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
           # Per-user VPN roster (RBAC). "jc+,guest1" → jc admin, guest1 guest.
           # Unset → single implicit owner-admin.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -70,6 +70,8 @@ jobs:
           # deploy predicts nothing anyway.
           VPN_ENTRY_LABEL: ${{ secrets.VPN_ENTRY_LABEL }}
           SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+          # Livepatch on the gateway and every edge. Free for personal use.
+          UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
           TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
           SINGBOX_SLUG: ${{ secrets.SINGBOX_SLUG }}
           TAILNET_MAGICDNS_SUFFIX: ${{ secrets.TAILNET_MAGICDNS_SUFFIX }}

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ emit and `@pulumi/pulumi` moved to a peer dependency.
 | `BLIT_HOSTNAME` / `MCP_HOSTNAME` / `MCP_AUTH_HOSTNAME` | Yes | Service hostnames |
 | `HCLOUD_TOKEN` | Yes | Hetzner API token. The cluster runs on the VPS it provisions, so this is not optional |
 | `SSH_PUBLIC_KEY` | No | Break-glass admin key, installed on the gateway and every edge (see below). Unset = nobody but Pulumi can SSH to them |
+| `UBUNTU_PRO_TOKEN` | No | Ubuntu Pro, for kernel livepatch on the gateway and every edge. Free for personal use on up to five machines. Unset = the reboot window is still set and only livepatch is skipped |
 | `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_CLIENT_SECRET` / `TS_TAILNET` | No | Manage the tailnet policy file as code (see below). Unset = policy stays hand-managed |
 
 **Tailscale**
@@ -250,6 +251,27 @@ Rotating the key is therefore a normal deploy. Unsetting the secret removes it.
 The key lands in `/etc/ssh/admin_authorized_keys`, selected by an
 `sshd_config.d` drop-in, never in the `authorized_keys` Pulumi authenticates
 with — a mistake in that file locks the deploy out of the box it is deploying to.
+
+
+### Automatic patching
+
+Cloud images install security updates on their own and then leave them there:
+`Automatic-Reboot` ships false, so a new kernel is downloaded and never booted.
+Every box gets a 04:00 reboot window so the patches it installs take effect.
+
+```bash
+gh secret set UBUNTU_PRO_TOKEN   # from https://ubuntu.com/pro/dashboard
+```
+
+Adds livepatch on top, which applies high and critical kernel CVE fixes to the
+*running* kernel — closing the interval between a fix landing and the next
+window, which is where local privilege escalation lives. The two are not
+substitutes: livepatch covers neither userspace nor fixes that restructure
+kernel data, and stops supporting a kernel that drifts too far behind, so the
+window is what keeps livepatch working. Free for personal use on five machines.
+
+Rotating the token is not enough on its own — an attached box is never offered a
+new one. Run `pro detach --assume-yes` on it first.
 
 ## Development
 

--- a/packages/hetzner/src/index.ts
+++ b/packages/hetzner/src/index.ts
@@ -3,6 +3,7 @@ export { createK3s } from "./k3s.ts";
 export { K3sConfSchema } from "./k3s.schemas.ts";
 export {
   createAdminSshAccess,
+  createAutomaticPatching,
   createNetworkTuning,
   inboundRule,
   resourcePrefix,

--- a/packages/hetzner/src/k3s.schemas.ts
+++ b/packages/hetzner/src/k3s.schemas.ts
@@ -11,7 +11,7 @@ import * as z from "zod";
  * has no policy engine, so every NetworkPolicy is inert under it
  * (see docs/architecture.md).
  *
- * Cilium's version has to match the cluster's: 1.19 supports k8s 1.33–1.36,
+ * Cilium's version has to match the cluster's: 1.20 supports k8s 1.33–1.36,
  * 1.18 supports 1.30–1.33. Moving `version` without checking that is how you
  * get a cluster with no working network.
  */
@@ -30,6 +30,6 @@ export const K3sConfSchema = z.object({
    * way — this never falls back to skipping TLS checks.
    */
   apiViaTailnet: z.boolean().default(false),
-  ciliumVersion: z.string().default("1.19.6"),
-  version: z.string().default("v1.36.2+k3s1"),
+  ciliumVersion: z.string().default("1.20.0"),
+  version: z.string().default("v1.36.3+k3s1"),
 });

--- a/packages/hetzner/src/k3s.ts
+++ b/packages/hetzner/src/k3s.ts
@@ -42,6 +42,10 @@ export function createK3s(
   k3s: z.infer<typeof K3sConfSchema>,
   apiHost: pulumi.Input<string>,
   name = "",
+  // What the cluster, context and user are called in the kubeconfig handed
+  // back. k3s calls all three `default`; this package does not know what the
+  // cluster is, so the caller says.
+  clusterName = "default",
 ) {
   const p = resourcePrefix(name);
 
@@ -130,13 +134,30 @@ cat /etc/rancher/k3s/k3s.yaml`,
   //
   // k3s writes `server: https://127.0.0.1:6443`, true on the box and useless
   // anywhere else, so it is rewritten to the name the cert already covers.
+  //
+  // It also names the cluster, context and user `default`, which collides with
+  // every other kubeconfig on the machine reading this — merging one in either
+  // clobbers an existing `default` or renames it by hand every time, and
+  // `--context default` says nothing about which cluster it reached. Renamed
+  // here rather than after the fact for the same reason the address is: the
+  // output should be usable as it comes out.
+  //
+  // Anchored to `: default` at end of line so it cannot match inside the
+  // base64 certificate data, where the string can occur by chance. The optional
+  // `-` matters: `users:` writes its entry as `- name: default` while `clusters:`
+  // indents `name:` under the item, so a pattern expecting only whitespace
+  // renames five of the six and leaves the user behind.
   const kubeconfig = pulumi
     .all([install.stdout, pulumi.output(apiHost)])
     .apply(([cfg, host]) =>
       pulumi.secret(
         cfg
           .slice(cfg.indexOf("apiVersion:"))
-          .replace("https://127.0.0.1:6443", `https://${host}:6443`),
+          .replace("https://127.0.0.1:6443", `https://${host}:6443`)
+          .replace(
+            /^(\s*-?\s*(?:name|cluster|user|current-context):\s*)default$/gm,
+            `$1${clusterName}`,
+          ),
       ),
     );
 

--- a/packages/hetzner/src/vps.ts
+++ b/packages/hetzner/src/vps.ts
@@ -1,6 +1,6 @@
 import * as command from "@pulumi/command";
 import type * as hcloud from "@pulumi/hcloud";
-import type * as pulumi from "@pulumi/pulumi";
+import * as pulumi from "@pulumi/pulumi";
 
 /** SSH connection to a provisioned Hetzner VPS. */
 export type SshConnection = {
@@ -96,6 +96,70 @@ ${reload}`,
       // Rotating the key has to delete first.
       deleteBeforeReplace: true,
     },
+  );
+}
+
+/**
+ * Makes security patches actually take effect, rather than merely arrive.
+ *
+ * Cloud images enable `unattended-upgrades` for the security pocket, so patches
+ * install on their own — and then sit there. `Automatic-Reboot` ships false, so
+ * a new kernel is downloaded, installed, and never booted. The gateway was found
+ * running 6.8.0-117 with 6.8.0-136 on disk and `/run/reboot-required` set, which
+ * is the default configuration working exactly as documented and achieving
+ * nothing. A window is the half that was missing.
+ *
+ * Livepatch is the other half, and they are not substitutes. A window still
+ * leaves the interval between a CVE landing and 04:00, which is where local
+ * privilege escalation lives; livepatch closes that to hours by patching the
+ * running kernel. It in turn does not cover userspace, or fixes that restructure
+ * kernel data, and it only supports a kernel for so long before demanding a
+ * reboot — so the window is also what keeps livepatch able to keep working.
+ *
+ * The token arrives as an environment variable rather than interpolated into
+ * the script: Pulumi persists resource inputs to state, and `pulumi.secret` on
+ * an input is what gets it encrypted there instead of stored in the clear.
+ */
+export function createAutomaticPatching(
+  name: string,
+  connection: SshConnection,
+  server: hcloud.Server,
+  proToken?: pulumi.Input<string>,
+) {
+  return new command.remote.Command(
+    `${name}-automatic-patching`,
+    {
+      connection,
+      environment: proToken ? { UBUNTU_PRO_TOKEN: proToken } : undefined,
+      create: `set -euo pipefail
+cat > /etc/apt/apt.conf.d/51unattended-upgrades-local << 'EOF'
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
+Unattended-Upgrade::Automatic-Reboot-Time "04:00";
+EOF
+# Written is not applied: apt merges apt.conf.d in lexical order, so assert the
+# value that actually resolves rather than the file that was just written.
+apt-config dump | grep -q 'Unattended-Upgrade::Automatic-Reboot "true"'
+
+if [ -n "\${UBUNTU_PRO_TOKEN:-}" ]; then
+  # Attaching twice is an error, so this is guarded rather than retried. The
+  # explicit enable is why attach does not auto-enable: livepatch is what this
+  # is for, and the rest of the entitlements should be a decision.
+  pro api u.pro.status.is_attached.v1 | grep -q '"is_attached": *true' \\
+    || pro attach "$UBUNTU_PRO_TOKEN" --no-auto-enable
+  pro enable livepatch --assume-yes || true
+  # Same reasoning as the sysctls: enable can report success on a kernel
+  # livepatch does not cover, and a security control believed to be on is worse
+  # than one known to be off.
+  pro status --format=json | python3 -c "
+import json, sys
+services = {s['name']: s['status'] for s in json.load(sys.stdin).get('services', [])}
+sys.exit(0 if services.get('livepatch') == 'enabled' else 1)
+"
+fi`,
+      triggers: [pulumi.output(proToken ?? ""), "patching-v1"],
+    },
+    { dependsOn: [server] },
   );
 }
 

--- a/packages/hetzner/src/vps.ts
+++ b/packages/hetzner/src/vps.ts
@@ -116,6 +116,12 @@ ${reload}`,
  * kernel data, and it only supports a kernel for so long before demanding a
  * reboot — so the window is also what keeps livepatch able to keep working.
  *
+ * Every box takes the same 04:00 window, which is deliberate while the fleet is
+ * a gateway and a home node: they serve different things, so one shared outage
+ * minute beats two staggered ones. It stops being right once edges exist —
+ * every VPN entry rebooting together is an outage rather than a blip, and the
+ * time wants to vary per box at that point.
+ *
  * The token arrives as an environment variable rather than interpolated into
  * the script: Pulumi persists resource inputs to state, and `pulumi.secret` on
  * an input is what gets it encrypted there instead of stored in the clear.
@@ -132,6 +138,16 @@ export function createAutomaticPatching(
       connection,
       environment: proToken ? { UBUNTU_PRO_TOKEN: proToken } : undefined,
       create: `set -euo pipefail
+# Same wait the k3s install opens with, and needed here for the same reason:
+# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
+# lock for minutes, and \`pro attach\` shells out to apt. This command depends
+# only on the server, so on a freshly created box it races both — and since
+# changing the image replaces the server, a fresh box is the normal case rather
+# than the first-run one. Under \`set -e\` losing that race is a failed deploy.
+cloud-init status --wait >/dev/null 2>&1 || true
+mkdir -p /etc/apt/apt.conf.d
+printf 'DPkg::Lock::Timeout "600";\\n' > /etc/apt/apt.conf.d/99-lock-timeout
+
 cat > /etc/apt/apt.conf.d/51unattended-upgrades-local << 'EOF'
 Unattended-Upgrade::Automatic-Reboot "true";
 Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
@@ -145,6 +161,11 @@ if [ -n "\${UBUNTU_PRO_TOKEN:-}" ]; then
   # Attaching twice is an error, so this is guarded rather than retried. The
   # explicit enable is why attach does not auto-enable: livepatch is what this
   # is for, and the rest of the entitlements should be a decision.
+  #
+  # The guard makes rotating the token a no-op: the box is already attached, so
+  # a new one is never presented. Rotation means \`pro detach --assume-yes\` on
+  # the box first, and is rare enough not to be worth detaching on every trigger
+  # change to support.
   pro api u.pro.status.is_attached.v1 | grep -q '"is_attached": *true' \\
     || pro attach "$UBUNTU_PRO_TOKEN" --no-auto-enable
   pro enable livepatch --assume-yes || true

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -145,10 +145,14 @@ config:
     serverType: cx33
     # The cluster lives here now. One `pulumi up` creates the box, installs k3s,
     # reads its kubeconfig and deploys into it — no ansible, no KUBE_* secrets.
-    # Cilium's version must match the k8s minor: 1.19 supports 1.33-1.36.
+    # Cilium's version must match the k8s minor: 1.20 is e2e tested against
+    # 1.33-1.36. Take the range from Cilium's own requirements doc for the
+    # branch rather than from memory — outside it you are relying on Kubernetes'
+    # backward compatibility rather than anything tested, and the failure is a
+    # cluster that comes up healthy and moves no packets.
     k3s:
-      version: v1.36.2+k3s1
-      ciliumVersion: 1.19.6
+      version: v1.36.3+k3s1
+      ciliumVersion: 1.20.0
     # xray shares :443; traffic that doesn't match a client falls back to
     # dest (local rathole https), so real visitors still get the site.
     #

--- a/packages/infra/src/conf.schemas.ts
+++ b/packages/infra/src/conf.schemas.ts
@@ -79,7 +79,7 @@ export const GatewayConfSchema = z.object({
    * slot it fills is still "the gateway".
    */
   name: z.string().default("sympathy"),
-  image: z.string().default("ubuntu-24.04"),
+  image: z.string().default("ubuntu-26.04"),
   k3s: K3sConfSchema.optional(),
   location: z.string().default("nbg1"),
   ratholeVersion: z.string().default("v0.5.0"),
@@ -107,7 +107,7 @@ export const EdgeConfSchema = z.object({
     sni: "www.bing.com",
     image: "docker.io/tobyxdd/hysteria:v2.10.0",
   }),
-  image: z.string().default("ubuntu-24.04"),
+  image: z.string().default("ubuntu-26.04"),
   location: z.string().default("hel1"),
   name: z.string(),
   reality: z

--- a/packages/infra/src/edge.ts
+++ b/packages/infra/src/edge.ts
@@ -1,5 +1,6 @@
 import {
   createAdminSshAccess,
+  createAutomaticPatching,
   createNetworkTuning,
   inboundRule,
 } from "@jaritanet/hetzner";
@@ -11,7 +12,7 @@ import {
   XrayConfSchema,
 } from "@jaritanet/vpn";
 import * as hcloud from "@pulumi/hcloud";
-import type * as pulumi from "@pulumi/pulumi";
+import * as pulumi from "@pulumi/pulumi";
 import * as tls from "@pulumi/tls";
 import type * as z from "zod";
 import type { EdgeConfSchema } from "./conf.schemas.ts";
@@ -36,6 +37,7 @@ export function createEdge(
   users: VpnUser[],
   authKey: pulumi.Output<string> | undefined,
   adminSshKey: string | undefined,
+  proToken: string | undefined,
 ) {
   const { name } = edge;
 
@@ -73,6 +75,13 @@ export function createEdge(
   };
 
   createNetworkTuning(name, connection, server);
+
+  createAutomaticPatching(
+    name,
+    connection,
+    server,
+    proToken ? pulumi.secret(proToken) : undefined,
+  );
 
   if (adminSshKey) {
     createAdminSshAccess(name, connection, server, adminSshKey);

--- a/packages/infra/src/env.schema.ts
+++ b/packages/infra/src/env.schema.ts
@@ -21,6 +21,12 @@ export const EnvSchema = z.object({
     )
     .optional(),
 
+  // Ubuntu Pro, for livepatch on the gateway and every edge. Free for personal
+  // use on up to five machines. Absent → the reboot window is still configured
+  // and only livepatch is skipped, because a box that boots its patches is the
+  // baseline and livepatch is the improvement on it.
+  UBUNTU_PRO_TOKEN: z.string().optional(),
+
   TS_AUTHKEY: z.string().optional(),
 
   // Tailnet policy-as-code. Absent, the policy stays hand-managed in the admin

--- a/packages/infra/src/gateway.ts
+++ b/packages/infra/src/gateway.ts
@@ -1,5 +1,6 @@
 import {
   createAdminSshAccess,
+  createAutomaticPatching,
   createK3s,
   createNetworkTuning,
   inboundRule,
@@ -44,11 +45,15 @@ export function createGateway(
   exits: { name: string; port: number }[] = [],
   {
     adminSshKey,
+    clusterName,
+    proToken,
     entryLabel,
     magicdnsSuffix = "",
     tailnetAuthKey,
   }: {
     adminSshKey?: string;
+    clusterName: string;
+    proToken?: string;
     entryLabel: string;
     magicdnsSuffix?: string;
     tailnetAuthKey?: string;
@@ -168,6 +173,13 @@ systemctl enable rathole
   };
 
   createNetworkTuning("gateway", connection, server);
+
+  createAutomaticPatching(
+    "gateway",
+    connection,
+    server,
+    proToken ? pulumi.secret(proToken) : undefined,
+  );
 
   if (adminSshKey) {
     createAdminSshAccess("gateway", connection, server, adminSshKey);
@@ -336,7 +348,7 @@ RATHOLE_EOF`,
       : server.ipv4Address;
 
   const k3s = gateway.k3s
-    ? createK3s(connection, server, gateway.k3s, apiHost)
+    ? createK3s(connection, server, gateway.k3s, apiHost, "", clusterName)
     : undefined;
 
   // Marks this node as one that serves VPN entries; the transport DaemonSets

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -90,6 +90,8 @@ export default async function () {
     // Exits surface on the gateway's rathole loopback (name + port).
     const gw = createGateway(gatewayConf, users, resolvedExits, {
       adminSshKey: env.SSH_PUBLIC_KEY,
+      clusterName: namespace,
+      proToken: env.UBUNTU_PRO_TOKEN,
       entryLabel: env.VPN_ENTRY_LABEL,
       magicdnsSuffix: env.TAILNET_MAGICDNS_SUFFIX,
       tailnetAuthKey: env.TS_AUTHKEY,
@@ -126,7 +128,13 @@ export default async function () {
       ? pulumi.secret(env.TS_AUTHKEY)
       : undefined;
     for (const edge of conf.edges) {
-      const e = createEdge(edge, users, edgeAuthKey, env.SSH_PUBLIC_KEY);
+      const e = createEdge(
+        edge,
+        users,
+        edgeAuthKey,
+        env.SSH_PUBLIC_KEY,
+        env.UBUNTU_PRO_TOKEN,
+      );
       const hostname = `${edge.name}.${edge.zone}`;
       const zone = conf.zones.find((z) => z.name === edge.zone);
       if (zone) {

--- a/scripts/make-seed-drive
+++ b/scripts/make-seed-drive
@@ -34,9 +34,16 @@
 # Nothing secret is stored in this repo. The SSH key comes from the running
 # agent, and the k3s join token is read from the cluster at build time.
 #
+# Reads TS_AUTHKEY, SEED_PASSWORD and SEED_PRO_TOKEN from the environment; mise
+# loads them from the gitignored .env (see mise.toml).
+#
 # Usage: scripts/make-seed-drive <device> <hostname> [--no-join]
 #   scripts/make-seed-drive /dev/disk4 lady
 set -euo pipefail
+
+# Paths are resolved from the repo root rather than the caller's directory, so
+# this works from anywhere — it shells out to a sibling script.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 DEVICE="${1:?usage: make-seed-drive <device> <hostname> [--no-join]}"
 HOSTNAME="${2:?usage: make-seed-drive <device> <hostname> [--no-join]}"
@@ -62,7 +69,7 @@ fi
 PUBKEY="$(ssh-add -L | grep -m1 '^ssh-' || true)"
 [[ -n "$PUBKEY" ]] || { echo "no key in the ssh agent — unlock it first" >&2; exit 1; }
 
-# A console password, from SEED_PASSWORD_FILE, hashed here so the plaintext
+# A console password, from SEED_PASSWORD in .env, hashed here so the plaintext
 # never reaches the drive. Without one the account is key-only *including at the
 # keyboard*, so a node whose network does not come up cannot be logged into at
 # all — the logs explaining why are on screen and unreachable, and reflashing
@@ -88,8 +95,8 @@ hash_password() {
 
 PASSWD_LINE=""
 LOCK_PASSWD=true
-if [[ -n "${SEED_PASSWORD_FILE:-}" ]]; then
-  PASSWD_LINE="    passwd: $(hash_password "$(< "$SEED_PASSWORD_FILE")")"
+if [[ -n "${SEED_PASSWORD:-}" ]]; then
+  PASSWD_LINE="    passwd: $(hash_password "$SEED_PASSWORD")"
   LOCK_PASSWD=false
 fi
 
@@ -154,11 +161,11 @@ YAML
   # picks up everything else. Attached here rather than afterwards because
   # `pro attach` over SSH is one more thing to remember on a box that is
   # supposed to arrive finished.
-  if [[ -n "${SEED_PRO_TOKEN_FILE:-}" ]]; then
+  if [[ -n "${SEED_PRO_TOKEN:-}" ]]; then
     cat <<YAML
 
 ubuntu_pro:
-  token: $(< "$SEED_PRO_TOKEN_FILE")
+  token: $SEED_PRO_TOKEN
   enable:
     - livepatch
 YAML
@@ -170,7 +177,7 @@ YAML
     VERSION="$(kubectl --context "$CONTEXT" get nodes \
       -l node-role.kubernetes.io/control-plane \
       -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')"
-    TOKEN="$(scripts/k3s-node-token "$CONTEXT")"
+    TOKEN="$("$ROOT/scripts/k3s-node-token" "$CONTEXT")"
     cat <<YAML
 
 # One ordered script rather than separate entries, because the steps depend on


### PR DESCRIPTION
Fixes #219, #221.

## Why a rebuild rather than an upgrade

The gateway runs 24.04 because `image` defaults there and nothing overrides it; a VPS is never rolled forward across releases, so it stays on whatever it booted. Kernel 7.0 belongs to 26.04, and HWE on 24.04 rolls through the interim releases' kernels rather than reaching it. So the ask is a new machine, not a reboot.

## Patches that arrive versus patches that apply

The gateway was found running `6.8.0-117-generic` with `6.8.0-136-generic` installed and unbooted, `libc6` likewise, and `/run/reboot-required` long since set. That is the documented default working exactly as specified and achieving nothing: `unattended-upgrades` covers the security pocket, `Automatic-Reboot` ships false, and nothing closes the loop. A kernel on disk that has never been booted is an unpatched kernel, on the box terminating xray and hysteria on a public `:443`.

`createAutomaticPatching` adds the window, and attaches Ubuntu Pro for livepatch where `UBUNTU_PRO_TOKEN` is set. The two are not substitutes and neither is sufficient:

- a window leaves the interval between a CVE landing and 04:00, which is where local privilege escalation lives
- livepatch closes that to hours, but covers neither userspace nor fixes that restructure kernel data, and stops supporting a kernel that drifts far enough behind — so the window is what keeps livepatch able to keep working

Absent token, the window is still configured and only livepatch is skipped: booting your patches is the baseline, livepatch is the improvement on it. 26.04 is on livepatch's supported-kernels list, so the enablement assertion is a real check rather than a trap.

Both assertions follow `createNetworkTuning`'s existing habit of checking what resolves rather than what was written — `apt-config dump` for the reboot setting, `pro status` for livepatch. A security control believed to be on is worse than one known to be off.

## Versions

| | from | to |
|---|---|---|
| image | `ubuntu-24.04` | `ubuntu-26.04` |
| k3s | `v1.36.2+k3s1` | `v1.36.3+k3s1` |
| Cilium | `1.19.6` | `1.20.0` |

Cilium 1.19 is e2e tested against Kubernetes 1.31–1.34; this cluster runs 1.36. The comment asserting "1.19 supports 1.33-1.36" was wrong and is corrected in both places it appeared — a comment claiming an untested pairing is fine is worse than no comment. 1.20 is tested against 1.33–1.36, so the new pair is inside the range. Taken knowingly that 1.20.0 is a `.0` barely a week old; `scripts/lima-node` exercises the agent join and datapath as a canary.

## Kubeconfig naming

k3s names the cluster, context and user all `default`, so `pulumi stack output kubeconfig` produced something that collided with every other kubeconfig on the machine and had to be renamed by hand on each import — and `--context default` says nothing about which cluster it reached. Now named after the project, for the same reason the server address is rewritten: the output should be usable as it comes out.

Included here rather than split out because the rebuild invalidates the local kubeconfig and forces a re-import, so this is the moment it is felt. Verified against the live cluster's actual output: all six occurrences renamed, certificate data untouched. The optional `-` in the pattern is load-bearing — `users:` writes `- name: default` while `clusters:` indents `name:` under the item, and a pattern expecting only whitespace renames five of six.

## Deploying this is disruptive, deliberately sequenced

Changing `image` replaces the server. In order:

1. **New IP, so every client profile rotates.** Automated, Telegram delivers, but every device must re-fetch.
2. **The cluster goes with the box** — the MCP gateway's Postgres, so Hydra's OAuth clients and consents; and Traefik's cert store, so every certificate re-issues via DNS-01. Let's Encrypt permits 5 duplicate certificates per week for an identical name set, which is a real ceiling if this needs retrying.
3. **The home node's seed drive is invalidated.** It hardcodes the API address and join token, both of which change. Regenerate with `scripts/make-seed-drive` *after* this lands and before flashing, or the node boots and fails to join with an error pointing nowhere near the cause.
4. `pulumi stack output kubeconfig --show-secrets > ~/.kube/jaritanet` afterwards — the CA is regenerated, so the existing one stops working, and `make-seed-drive` needs kubectl.

`UBUNTU_PRO_TOKEN` must exist as a repository secret before this deploys.

#220 should land after this, so it contributes the upgrade controller and compat guard without also performing an in-place CNI upgrade on a box being replaced anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSoVxv2DpGgAV6mEsu1TWH