### PR TITLE
fix(hetzner): re-run box configuration when the server is replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Rotating the key is therefore a normal deploy. Unsetting the secret removes it.
 The key lands in `/etc/ssh/admin_authorized_keys`, selected by an
 `sshd_config.d` drop-in, never in the `authorized_keys` Pulumi authenticates
 with — a mistake in that file locks the deploy out of the box it is deploying to.
+Replacing a box reinstalls it: the resource is triggered by the server's id as
+well as the key, so a rebuild cannot leave the new box without a way in.
 
 
 ### Automatic patching

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -586,7 +586,7 @@ for is **k3s failing to come up**: no API server, no kubectl, no privileged pod.
 The mechanism for adding a key is the broken thing at that moment, which is why
 the key is installed on every deploy rather than when it is wanted.
 
-Three decisions hold it up:
+Four decisions hold it up:
 
 **It arrives over SSH, not through `sshKeys` or `userData`.** Hetzner applies
 both only at creation, so changing either forces a replacement — a new IP, a new
@@ -599,7 +599,18 @@ goes in `/etc/ssh/admin_authorized_keys`, selected by an `sshd_config.d` drop-in
 that lists root's own file first. A mistake in the shared file locks the deploy
 out of the box it is deploying to, with no way back in. `sshd -t` runs before
 anything is reloaded and the drop-in is removed if it rejects, so a bad config
-fails the Pulumi resource rather than the daemon.
+fails the Pulumi resource rather than the daemon. `sshd -T` then asserts that the
+daemon actually resolves the file: sshd takes the first `AuthorizedKeysFile` it
+obtains, so a directive ahead of the include would leave a drop-in that reads as
+installed and selects nothing.
+
+**It is triggered by the server's id, not only by the key.** `dependsOn` orders
+the command after the box; it does not re-run it when the box is replaced.
+Triggered by the key alone the resource keeps its recorded success across a
+rebuild, so the new box comes up with no admin key and the stack reports no
+drift — nothing asks to be fixed. That is how the 26.04 rebuild produced a
+gateway whose break-glass access had never been installed, and why
+`createNetworkTuning` and `createAutomaticPatching` take the same trigger.
 
 **Absent secret means no resource**, matching how `TS_AUTHKEY` gates the tailnet
 relay. Removing the secret deletes the key from the boxes on the next deploy.

--- a/packages/hetzner/src/vps.ts
+++ b/packages/hetzner/src/vps.ts
@@ -30,6 +30,25 @@ export const inboundRule = (
 });
 
 /**
+ * Triggers for a command that configures a server, alongside whatever else it
+ * depends on.
+ *
+ * `dependsOn` only orders; it does not make a replaced server re-run anything.
+ * A command triggered solely by its own config keeps its recorded success when
+ * the box underneath it is rebuilt, so the new box comes up unconfigured while
+ * the stack reports no drift — the worst shape a failure can take, because
+ * nothing asks to be fixed. The 26.04 rebuild landed exactly there: patching
+ * re-ran only because its token happened to change in the same update, and the
+ * admin key and the network sysctls were never installed at all. A server's id
+ * changes on replacement, so including it ties the command to the box it
+ * actually configured.
+ */
+const serverTriggers = (
+  server: hcloud.Server,
+  ...rest: pulumi.Input<unknown>[]
+) => [server.id, ...rest];
+
+/**
  * Break-glass SSH access for a human, over SSH so the box is never rebuilt.
  *
  * Everything routine is reachable with kubectl alone — host files, host
@@ -83,10 +102,25 @@ if ! sshd -t; then
   echo "sshd rejected the admin drop-in; rolled back" >&2
   exit 1
 fi
+# Written is not applied: sshd takes the first AuthorizedKeysFile it obtains, so
+# an uncommented directive ahead of the Include wins and leaves a drop-in that
+# reads as installed while selecting nothing. Assert what the daemon resolves,
+# the same reasoning createNetworkTuning and createAutomaticPatching follow.
+# Read into a variable rather than piping to \`grep -q\`, whose early exit would
+# fail the pipeline under pipefail on the very path that succeeded.
+resolved=$(sshd -T | grep -i '^authorizedkeysfile ' || true)
+case "$resolved" in
+  *${keyFile}*) ;;
+  *)
+    rm -f ${dropIn}
+    echo "sshd resolved '$resolved'; ${keyFile} did not take effect, rolled back" >&2
+    exit 1
+    ;;
+esac
 ${reload}`,
       delete: `rm -f ${dropIn} ${keyFile}
 ${reload}`,
-      triggers: [publicKey, "admin-ssh-v1"],
+      triggers: serverTriggers(server, publicKey, "admin-ssh-v2"),
     },
     {
       dependsOn: [server],
@@ -182,7 +216,11 @@ services = {s['name']: s['status'] for s in json.load(sys.stdin).get('services',
 sys.exit(0 if services.get('livepatch') == 'enabled' else 1)
 "
 fi`),
-      triggers: [pulumi.output(proToken ?? ""), "patching-v1"],
+      triggers: serverTriggers(
+        server,
+        pulumi.output(proToken ?? ""),
+        "patching-v1",
+      ),
     },
     { dependsOn: [server] },
   );
@@ -224,7 +262,7 @@ sysctl --system
 # rather than trusting that sysctl.d was read in the order we assumed.
 test "$(sysctl -n net.core.rmem_max)" = 16777216
 test "$(sysctl -n net.core.wmem_max)" = 16777216`,
-      triggers: ["bbr-fq-udp-buffers-v2"],
+      triggers: serverTriggers(server, "bbr-fq-udp-buffers-v2"),
     },
     { dependsOn: [server] },
   );


### PR DESCRIPTION
Closes #224.

The ticket's premise was that 26.04 changed how the `sshd_config.d` drop-in
resolves. It didn't. The drop-in mechanism works on 26.04 exactly as designed —
the resource simply never ran on the rebuilt box.

## What was actually wrong

`dependsOn` orders a `command.remote.Command` after the server; it does not
re-run it when that server is replaced. `createAdminSshAccess` and
`createNetworkTuning` are triggered only by their own config, so both kept their
recorded success across the 26.04 rebuild and never executed on the new box.
State was clean, so nothing reported drift. `createAutomaticPatching` survived
by accident — its Pro token changed in the same update, which is why the ticket
found patching and livepatch healthy while SSH was broken.

Found on the live gateway:

| | expected | actual |
|---|---|---|
| `/etc/ssh/admin_authorized_keys` | present | absent |
| `/etc/ssh/sshd_config.d/60-jaritanet-admin.conf` | present | absent |
| `net.core.rmem_max` | 16777216 | 4194304 (stock) |
| `tcp_congestion_control` | bbr | cubic |

So break-glass SSH was absent, and Hysteria2 has been running without BBR and
without the UDP buffers that make it fast.

## The fix

Each of the three commands now includes the server's id in its triggers, via a
`serverTriggers` helper that carries the reasoning. A replaced server has a new
id, so the command replaces and re-runs against the box it is meant to configure.

`createAdminSshAccess` additionally asserts with `sshd -T` that the daemon
resolves the key file, rather than that the file was written — the same
"written is not applied" check `createNetworkTuning` and `createAutomaticPatching`
already make. This covers the ticket's first hypothesis directly: sshd takes the
first `AuthorizedKeysFile` it obtains, so a directive ahead of the include would
leave a drop-in that reads as installed and selects nothing.

## How to confirm it works

The mechanism was verified end-to-end on the rebuilt gateway (26.04,
OpenSSH 10.2p1) through a privileged debug pod, since SSH is the broken thing:
a throwaway keypair was generated on the box, installed through the exact create
script in this diff, and used to authenticate.

```
sshd -t: OK
authorizedkeysfile .ssh/authorized_keys /etc/ssh/admin_authorized_keys
AUTH_OK as root on sympathy
```

Both the drop-in and the throwaway key were removed afterwards; the box is back
to stock and `sshd -T` resolves `.ssh/authorized_keys .ssh/authorized_keys2`
again. Nothing was left installed — the real key arrives on the next deploy.

For the record, 26.04's `sshd_config` still `Include`s `sshd_config.d` as its
first directive and sets no `AuthorizedKeysFile` of its own, and both
`ssh.socket` and `ssh.service` are active so the conditional reload fires. All
three of the ticket's hypotheses are ruled out.

## Reviewing the diff

The preview will show all three commands replacing. That is the point — it is
what finally installs the admin key and the sysctls on the current gateway. The
`delete` for the admin key runs against the box it is already on, not a dead one.

## Scope

The `-systemd` transport installers (`hysteria-systemd`, `xray-systemd`,
`tailscale-systemd`) have the same bug class for edge boxes, but they take an
opaque `dependsOn` rather than a server, so fixing them means a signature change
across `edge.ts` and `gateway.ts`. Filed as #226 rather than widening this
diff.