### PR TITLE
229 fix(updater): warn on an upstream that lags its own image

### DIFF
--- a/.github/tracked-versions.yml
+++ b/.github/tracked-versions.yml
@@ -103,8 +103,9 @@
 # The image repo and the release repo are different projects here: klutchell
 # builds the container and cuts no GitHub releases, so it was unreadable and
 # failed the whole run. Upstream tags "release-1.25.2", which normalises to the
-# tag the image actually carries. If the build ever lags upstream the image
-# check catches it — that is what the check is for.
+# tag the image actually carries. The build lags upstream routinely, which the
+# image check reports and holds the pin for — a warning, not a failure, since
+# waiting is the only correct response to it.
 - app: Unbound
   repo: NLnetLabs/unbound
   path: [config, "jaritanet:gateway", unbound, image]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ Daily check for new releases of the components listed in `.github/tracked-versio
 
 The workflow only supplies tokens; the work is `packages/infra/src/update-apps.ts`, with the decisions it makes — tag normalisation, image reference parsing, and whether an entry moved — isolated in `versions.ts` where they are unit tested. A release tag is never trusted on its own: the registry is asked whether the image actually published, including for entries already up to date, so a pin that stopped resolving is reported rather than waiting for the next pod restart to find it.
 
+A missing image fails the run only when it is the *pinned* one — that is a live deployment referencing something that no longer exists. A newer release whose image has not published yet warns and leaves the entry alone: several upstreams build their container separately from the release it tracks, so lag is their normal operation and there is nothing here to act on. Failing on it left the workflow permanently red, which costs the alarm rather than fixing anything.
+
 Rewrites go through the YAML document API and mutate the existing scalar, so a bump changes exactly one line and leaves comments and quoting alone.
 
 ### Ansible Deployment (`run-playbook.yml`)

--- a/packages/infra/src/update-apps.ts
+++ b/packages/infra/src/update-apps.ts
@@ -228,6 +228,10 @@ for (const entry of entries) {
     failed.push(entry.app);
     continue;
   }
+  if (decision.kind === "lagging") {
+    warn(`${entry.app} — ${decision.reason}`);
+    continue;
+  }
   if (decision.kind === "up-to-date") {
     log(`${entry.app} — up to date (${decision.current})`);
     continue;
@@ -262,6 +266,9 @@ if (titles.length === 0) {
 }
 
 if (failed.length > 0) {
-  process.stdout.write(`::error::could not check: ${failed.join(" ")}\n`);
+  // Only entries something here can act on reach this: a release that cannot be
+  // read, a path the config moved out from under, a pin that no longer resolves.
+  // An upstream whose image has not published yet warns and is not counted.
+  process.stdout.write(`::error::needs attention: ${failed.join(" ")}\n`);
   process.exitCode = 1;
 }

--- a/packages/infra/src/versions.test.ts
+++ b/packages/infra/src/versions.test.ts
@@ -136,7 +136,7 @@ describe("decide", () => {
     });
   });
 
-  it("stays put when the release exists but its image does not", () => {
+  it("stays put, without failing the run, when the release exists but its image does not", () => {
     const decision = decide({
       ...base,
       current: "1.2.2",
@@ -144,9 +144,9 @@ describe("decide", () => {
       exists: false,
     });
     expect(decision).toEqual({
-      kind: "problem",
+      kind: "lagging",
       reason:
-        "released v1.2.3 but o/r:1.2.3 is not in the registry; staying on 1.2.2",
+        "released v1.2.3 but o/r:1.2.3 is not in the registry yet; staying on 1.2.2",
     });
   });
 
@@ -157,6 +157,22 @@ describe("decide", () => {
       kind: "problem",
       reason: "pinned to o/r:1.2.3, which is not in the registry",
     });
+  });
+
+  it("separates the two missing images: only the pinned one is a problem", () => {
+    const lagging = decide({
+      ...base,
+      current: "1.2.2",
+      ref: "o/r:1.2.3",
+      exists: false,
+    });
+    const broken = decide({
+      ...base,
+      current: "1.2.3",
+      ref: "o/r:1.2.3",
+      exists: false,
+    });
+    expect([lagging.kind, broken.kind]).toEqual(["lagging", "problem"]);
   });
 
   it("is up to date when the value already matches", () => {

--- a/packages/infra/src/versions.ts
+++ b/packages/infra/src/versions.ts
@@ -44,6 +44,9 @@ export const STRINGIFY_OPTIONS = {
 export type Decision =
   | { kind: "up-to-date"; current: string }
   | { kind: "update"; from: string; to: string }
+  // Upstream has moved and its image has not caught up. Reported, not failed —
+  // see `decide`.
+  | { kind: "lagging"; reason: string }
   | { kind: "problem"; reason: string };
 
 /**
@@ -104,6 +107,19 @@ export function verifyRef(entry: Tracked, version: string) {
  * that stopped resolving — a release deleted, or one whose image never
  * published in the first place — is reported rather than sitting quietly until
  * the next pod restart finds it.
+ *
+ * A missing image means two different things depending on which one is missing,
+ * and only one of them is ours. A **pinned** ref that has gone is a live
+ * deployment referencing something that no longer exists, and needs a human. A
+ * **newer** release whose image has not published yet is an upstream mid-flight:
+ * klutchell builds unbound's container separately from the release it tracks,
+ * and tailscale's ghcr tags trail its GitHub tags by days. Nothing here is
+ * wrong, nothing here can act, and the entry simply stays where it is.
+ *
+ * That distinction is the difference between an alarm and noise. Treating both
+ * as failures left this workflow red for a week over two upstreams behaving
+ * exactly as they always have, which is the state where nobody reads it any
+ * more and the pin that genuinely broke goes out with the tide.
  */
 export function decide({
   tag,
@@ -127,13 +143,15 @@ export function decide({
     };
   }
   if (ref && !exists) {
-    return {
-      kind: "problem",
-      reason:
-        current === next
-          ? `pinned to ${ref}, which is not in the registry`
-          : `released ${tag} but ${ref} is not in the registry; staying on ${current}`,
-    };
+    return current === next
+      ? {
+          kind: "problem",
+          reason: `pinned to ${ref}, which is not in the registry`,
+        }
+      : {
+          kind: "lagging",
+          reason: `released ${tag} but ${ref} is not in the registry yet; staying on ${current}`,
+        };
   }
   if (current === next) return { kind: "up-to-date", current };
   return { kind: "update", from: current, to: next };


### PR DESCRIPTION
Closes #229.

`update-apps` has been red every run since 2026-08-02. Nothing is broken.

## What was wrong

Any missing image was a failure. Two different things go missing:

| missing | means | can we act? |
| --- | --- | --- |
| the **pinned** ref | a live deployment references something that no longer exists | yes — needs a human |
| a **newer** release's ref | upstream cut a tag, its image hasn't published | no — wait |

The second is routine for two entries. klutchell builds unbound's container separately from the NLnetLabs release it tracks; tailscale's ghcr tags trail its GitHub tags by days. The updater already did the right thing in both cases — held the pin, printed a `::warning::` — and then exited 1 regardless.

A check that is always failing isn't a check. The cost isn't the red X, it's that the pin which genuinely stops resolving now goes out with the tide.

## What changed

`decide` splits the two: a new `lagging` decision for an unpublished upstream image, `problem` reserved for the pinned ref. `update-apps` warns on `lagging` without counting it, so the run exits 0. Fatal now means something in this repo can act on it — a release that can't be read, a path the config moved out from under, a pin that no longer resolves.

The GitHub error summary changes from `could not check:` to `needs attention:`, which is what the remaining cases actually are.

## How to confirm

`./packages/infra/src/update-apps.ts --dry-run` against today's upstreams:

```
Hysteria2 — up to date (docker.io/tobyxdd/hysteria:v2.12.0)
::warning::Tailscale — released v1.102.2 but ghcr.io/tailscale/tailscale:v1.102.2 is not in the registry yet; staying on ghcr.io/tailscale/tailscale:v1.98.10
::warning::Unbound — released release-1.26.0 but docker.io/klutchell/unbound:v1.26.0 is not in the registry yet; staying on docker.io/klutchell/unbound:v1.25.2
nothing to update
exit=0
```

Both upstreams still visible, neither fails the run. `versions.test.ts` covers the split directly — same missing ref, `lagging` when a newer release, `problem` when it's the pin.

## Not in scope

Nothing escalates a lag that goes on too long. That needs state across runs, and neither of these two has ever failed to catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XecdNH5x5KB74RLpxvPTou