### PR TITLE
fix(ci): scope container release notes to the container

### DIFF
--- a/.github/workflows/build-files-container.yml
+++ b/.github/workflows/build-files-container.yml
@@ -72,6 +72,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Notes are scoped with git log, which needs history and tags.
+          fetch-depth: 0
 
       - name: Create the release, and its tag
         env:
@@ -79,7 +82,14 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
+          # --generate-notes diffs against the previous tag in the repo, which
+          # knows nothing about tag prefixes: the first release of a container
+          # credits it with every PR ever, and later ones pick up whichever
+          # container tagged last. Scope to this container's own history instead.
+          prev=$(git tag --list 'files-v*' --sort=-version:refname | head -1)
+          range=${prev:+$prev..}HEAD
+          notes=$(git log --no-merges --pretty='- %s' "$range" -- containers/files)
           gh release create "files-v$VERSION" \
             --title "files v$VERSION" \
             --target "$GITHUB_SHA" \
-            --generate-notes
+            --notes "${notes:-- No changes recorded for this container.}"

--- a/.github/workflows/build-serve-from-env-container.yml
+++ b/.github/workflows/build-serve-from-env-container.yml
@@ -80,6 +80,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Notes are scoped with git log, which needs history and tags.
+          fetch-depth: 0
 
       - name: Create the release, and its tag
         env:
@@ -87,7 +90,14 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
+          # --generate-notes diffs against the previous tag in the repo, which
+          # knows nothing about tag prefixes: the first release of a container
+          # credits it with every PR ever, and later ones pick up whichever
+          # container tagged last. Scope to this container's own history instead.
+          prev=$(git tag --list 'serve-from-env-v*' --sort=-version:refname | head -1)
+          range=${prev:+$prev..}HEAD
+          notes=$(git log --no-merges --pretty='- %s' "$range" -- containers/serve-from-env)
           gh release create "serve-from-env-v$VERSION" \
             --title "serve-from-env v$VERSION" \
             --target "$GITHUB_SHA" \
-            --generate-notes
+            --notes "${notes:-- No changes recorded for this container.}"


### PR DESCRIPTION
`serve-from-env v0.1.0` — a 2.8MB static file server — is credited with **115 PRs**, including the entire VPN stack, the Cilium migration, and both the "replace rathole with frp" change and its revert.

`--generate-notes` diffs against the previous tag in the repository and has no concept of `tagPrefix`. The first release of a container has no predecessor of its own prefix, so GitHub walks back to the beginning of history. Worse, the two prefixes interleave chronologically — `files-v1.0.0` was tagged a minute before `serve-from-env-v0.1.0` — so subsequent releases would diff against whichever container tagged last and describe someone else's changes.

Notes now come from `git log` between this container's own previous tag and HEAD, pathspecced to its directory, so a release describes what was released. Empty ranges get an explicit line rather than blank notes. The release job's checkout gains `fetch-depth: 0`, since scoping needs history and tags.

Same fix in both container workflows rather than factored out: two call sites, and the pathspec and tag glob differ in each.