### PR TITLE
chore: retire oldboy

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ choices and the `:443` multiplexing.
 ### The gateway is not optional any more
 
 `HCLOUD_TOKEN` and `gateway.k3s` are both required: the cluster runs on the VPS
-the token provisions, so there is no cluster without it. The older direct mode —
-DNS pointed at a home box serving Traefik on hostPort 443 — went with oldboy.
+the token provisions, so there is no cluster without it.
 
 | | |
 |---|---|
@@ -117,9 +116,8 @@ jaritanet:exits:
 - **`port`** (the gateway loopback port) is derived from the name; set it only
   to resolve a rare hash collision.
 
-Currently empty. The exit that existed egressed oldboy's residential IP, and
-that machine is retired; `lady` can take the role when it arrives, since an
-exit only needs to be somewhere with an interesting address.
+Currently empty. `lady` can take the role once it joins — an exit only needs to
+be somewhere with an interesting address.
 
 **`edges`** — optional *additional* entry gateways (hy2 + REALITY), appearing in
 `entry-select`. Not needed with a single gateway; see

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -204,9 +204,8 @@ config:
   # just ss-rust + rathole; the gateway reaches it over the rathole tunnel.
   # `name` is all you set (drives the picker tag exit-<name> + resource names);
   # the loopback port is auto-derived from the name.
-  # Exits were ss-rust in the home cluster, reached over rathole. oldboy is
-  # retired, so there are none until a second node exists — at which point an
-  # exit is just a pod on it, with no tunnel involved.
+  # None until a second node exists, at which point an exit is just a pod on it
+  # with no tunnel involved.
   jaritanet:exits: []
   jaritanet:services:
     navidrome:
@@ -257,20 +256,20 @@ config:
           key: kubernetes.io/hostname
           operator: In
           values:
-            - oldboy
+            - lady
         persistence:
           - name: music
             storage: 2Ti
             hostPath: /mnt/kontent/music
             mountPath: /music
             readOnly: true
-            nodeAffinityHostname: oldboy
+            nodeAffinityHostname: lady
           - name: data
             storage: 20Gi
             hostPath: /home/navidrome/data
             mountPath: /data
             readOnly: false
-            nodeAffinityHostname: oldboy
+            nodeAffinityHostname: lady
     files:
       hostname: ''
       args:
@@ -303,14 +302,14 @@ config:
           key: kubernetes.io/hostname
           operator: In
           values:
-            - oldboy
+            - lady
         persistence:
           - name: files
             storage: 20Mi
             hostPath: /srv/files
             mountPath: /srv/files
             readOnly: true
-            nodeAffinityHostname: oldboy
+            nodeAffinityHostname: lady
     blit:
       hostname: ''
       args:

--- a/packages/infra/src/deploy.ts
+++ b/packages/infra/src/deploy.ts
@@ -30,13 +30,10 @@ const COMMENT_LIMIT = 60_000;
 const CONFIG_FROM_ENV = {
   "jaritanet:cloudflare.accountId": "CLOUDFLARE_ACCOUNT_ID",
   "jaritanet:traefik.acmeEmail": "ACME_EMAIL",
-  // navidrome and files lived on oldboy, which is retired. Their config stays
-  // in Pulumi.main.yaml with a blank hostname — which main.ts skips — so it is
-  // ready for `lady` without being deployed onto a node that cannot host it:
-  // both pin volumes to `nodeAffinityHostname: oldboy`, so scheduling them
-  // anywhere else leaves a pod Pending until the deploy times out.
-  //
-  // Commented rather than deleted: uncomment when the disk has a machine again.
+  // navidrome and files keep their config with a blank hostname, which main.ts
+  // skips. Their volumes pin to `lady`, the machine physically holding the
+  // disk, so deploying them before it joins leaves a pod Pending until the
+  // deploy times out. Uncomment when the disk has a machine again.
   "jaritanet:services.blit.hostname": "BLIT_HOSTNAME",
   "jaritanet:mcpGateway.hostname": "MCP_HOSTNAME",
   "jaritanet:mcpGateway.authHostname": "MCP_AUTH_HOSTNAME",

--- a/packages/infra/tailnet-policy.hujson
+++ b/packages/infra/tailnet-policy.hujson
@@ -16,7 +16,7 @@
 // The catch worth understanding before tightening: the gateway is a *relay*, so
 // whatever it cannot reach, you cannot reach over the VPN either. The right
 // question is not "how locked down can this be" but "what do I actually use the
-// tunnel to reach" — likely oldboy on a handful of ports.
+// tunnel to reach" — likely the home node on a handful of ports.
 {
 	"tagOwners": {
 		// The gateway wants its own tag. It currently joins as tag:server, which

--- a/packages/k8s/src/service.test.ts
+++ b/packages/k8s/src/service.test.ts
@@ -260,7 +260,7 @@ describe("service template", () => {
               hostPath: "/mnt/music",
               mountPath: "/music",
               readOnly: true,
-              nodeAffinityHostname: "oldboy",
+              nodeAffinityHostname: "lady",
             },
             {
               name: "data",
@@ -268,7 +268,7 @@ describe("service template", () => {
               hostPath: "/home/nd/data",
               mountPath: "/data",
               readOnly: false,
-              nodeAffinityHostname: "oldboy",
+              nodeAffinityHostname: "lady",
             },
           ],
           ...over,

--- a/packages/vpn/src/singbox.schema.test.ts
+++ b/packages/vpn/src/singbox.schema.test.ts
@@ -50,7 +50,7 @@ const node = {
 };
 const edge = { ...node, name: "helsinki", server: "5.6.7.8" };
 const exits = [
-  { name: "oldboy", port: 9000, method: "aes-128-gcm", password: "ss-psk" },
+  { name: "home", port: 9000, method: "aes-128-gcm", password: "ss-psk" },
 ];
 
 describe("delivered profiles are valid sing-box configs", () => {

--- a/scripts/check-profiles.ts
+++ b/scripts/check-profiles.ts
@@ -55,7 +55,7 @@ const node = {
 };
 const edge = { ...node, name: "helsinki", server: "5.6.7.8" };
 const exits = [
-  { name: "oldboy", port: 9000, method: "aes-128-gcm", password: "ss-psk" },
+  { name: "home", port: 9000, method: "aes-128-gcm", password: "ss-psk" },
 ];
 
 const profiles = [


### PR DESCRIPTION
`navidrome` and `files` pinned their volumes to `nodeAffinityHostname: oldboy`, a machine that no longer exists. They stay disabled behind a blank hostname, but the pin decides where they can ever schedule, so it should name the box that will actually hold the disk.

## Why a hostname and not the `file-node` label

The DaemonSets beside them — samba, syncthing — select on `jaritanet.radiosilence.dev/file-node`, and `conf.schemas.ts` argues for that: which machine serves files is a property of the machine, not a hostname written down in config.

That reasoning does not extend to these. A local PV is bound to a physical disk inside one specific machine, so `kubernetes.io/hostname` states a fact about where the bytes are — move the drive and the pin should move with it. The label answers the different question of which node *should* serve files, which is a scheduling preference. Both are correct for what they describe.

## Also removed

Every other mention was history rather than reasoning: the direct mode that predates the VPS, an exit that egressed a residential IP, a policy comment, and two test fixtures named after the box.

88 tests pass, types clean, no reference to `oldboy` remains in the tree.