### PR TITLE
feat(scripts): optionally mount a media drive from the seed

### DIFF
--- a/scripts/make-seed-drive
+++ b/scripts/make-seed-drive
@@ -34,7 +34,8 @@
 # Nothing secret is stored in this repo. The SSH key comes from the running
 # agent, and the k3s join token is read from the cluster at build time.
 #
-# Reads TS_AUTHKEY, SEED_PASSWORD and SEED_PRO_TOKEN from the environment; mise
+# Reads TS_AUTHKEY, SEED_PASSWORD, SEED_PRO_TOKEN and the optional
+# SEED_MOUNT_LABEL/SEED_MOUNT_POINT from the environment; mise
 # loads them from the gitignored .env (see mise.toml).
 #
 # Usage: scripts/make-seed-drive <device> <hostname> [--no-join]
@@ -152,6 +153,24 @@ write_files:
       Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
       Unattended-Upgrade::Automatic-Reboot-Time "04:00";
 YAML
+
+  # A media drive, by label rather than device: USB enumeration order is not
+  # stable, and pointing a library at whatever came up first is its own bad day.
+  #
+  # `nofail` because a headless node that will not boot until a USB disk shows
+  # up is worse than one whose storage pods wait. That is safe here: the volumes
+  # are local PVs, and kubelet refuses to create a missing path rather than
+  # silently binding an empty one — so an absent drive leaves pods Pending
+  # instead of presenting an empty library to a scanner set to purge what it
+  # cannot see. Which is also why the mount point stays empty: the directories
+  # under it must come from the drive.
+  if [[ -n "${SEED_MOUNT_LABEL:-}" ]]; then
+    cat <<YAML
+
+mounts:
+  - [ "LABEL=$SEED_MOUNT_LABEL", "${SEED_MOUNT_POINT:-/mnt/kontent}", auto, "defaults,nofail,x-systemd.device-timeout=10", "0", "2" ]
+YAML
+  fi
 
   # Livepatch applies high and critical kernel CVE fixes to the *running*
   # kernel, which is the half of the problem a reboot window cannot solve: a


### PR DESCRIPTION
The home node's media lives on an external drive, and nothing mounted it once ansible went. `SEED_MOUNT_LABEL` (with an optional `SEED_MOUNT_POINT`, defaulting to `/mnt/kontent`) adds a cloud-init `mounts:` entry so a flashed node arrives with its storage attached.

By **label** rather than device path, since USB enumeration order is not stable. `auto` for the filesystem type rather than guessing.

## Why `nofail` is right here, and what makes it safe

A headless node that refuses to boot until a USB disk enumerates is a worse failure than one whose storage pods wait — you cannot see the console message, and the machine is simply gone.

That is only acceptable because of how the volumes are declared. They are **local PVs**, and kubelet will not create a missing path for one: it fails and the pod stays `Pending`. So an unmounted drive means no navidrome, rather than navidrome starting against an empty directory — which matters because it runs with `ND_SCANNER_PURGEMISSING: "always"` and would conclude the library had been deleted.

The protection depends on the mount point staying empty. Creating the media subdirectories on the root filesystem "to be tidy" would defeat it: the path would exist, kubelet would bind it, and the scanner would purge against an empty disk. Recorded in the script's comment for that reason.