### PR TITLE
fix(gateway): tailscale below the cluster, so pod traffic can cross the tailnet

### DIFF
--- a/packages/hetzner/src/k3s.ts
+++ b/packages/hetzner/src/k3s.ts
@@ -43,8 +43,56 @@ export function createK3s(
   // back. k3s calls all three `default`; this package does not know what the
   // cluster is, so the caller says.
   clusterName = "default",
+  // Ordering only: the node's address comes from tailscaled, so it must be up
+  // and authenticated before k3s starts.
+  dependsOn: pulumi.Resource[] = [],
 ) {
   const p = resourcePrefix(name);
+
+  // k3s reads this at startup, which is why the address lands here rather than
+  // in the installer's flags: re-running the installer regenerates the
+  // kubeconfig below, and a changed kubeconfig replaces the Kubernetes provider
+  // and with it every resource in the cluster — a full teardown to change one
+  // flag.
+  //
+  // `node-ip` is the box's tailnet address. Cilium tunnels pod traffic to
+  // whatever a node reports as its InternalIP, and the home node is behind NAT
+  // with no forwarded ports, so its tailnet address is the only one that can be
+  // reached at all. Both ends must agree or the encapsulated packets are
+  // addressed somewhere they cannot land.
+  //
+  // Read on the box rather than passed in: this program never learns the
+  // address, and reading it here means a node that re-registers with a new one
+  // corrects itself on the next deploy instead of silently disagreeing.
+  //
+  // The public address stays in `tls-san` so the API is still reachable there
+  // for CI and for a human whose tailnet is the thing that broke.
+  const nodeConfig = new command.remote.Command(
+    `${p}k3s-node-config`,
+    {
+      connection,
+      create: pulumi.interpolate`set -euo pipefail
+NODE_IP="$(tailscale ip -4 2>/dev/null | head -1)"
+if [ -z "$NODE_IP" ]; then
+  echo "tailscale reports no IPv4 address — cannot set node-ip" >&2
+  exit 1
+fi
+mkdir -p /etc/rancher/k3s
+cat > /etc/rancher/k3s/config.yaml << EOF
+node-ip: "$NODE_IP"
+tls-san:
+  - "${apiHost}"
+  - "${server.ipv4Address}"
+EOF
+# Only meaningful where k3s is already running; on a fresh box the installer
+# below reads the file at first start and this is a no-op.
+if systemctl is-active --quiet k3s; then
+  systemctl restart k3s
+fi`,
+      triggers: [pulumi.output(apiHost), server.ipv4Address, "node-ip-v1"],
+    },
+    { dependsOn: [server, ...dependsOn] },
+  );
 
   const install = new command.remote.Command(
     `${p}k3s-install`,
@@ -115,7 +163,7 @@ cat /etc/rancher/k3s/k3s.yaml`,
       triggers: [k3s.version, pulumi.output(apiHost), "resolv-conf-v1"],
     },
     {
-      dependsOn: [server],
+      dependsOn: [server, nodeConfig],
       // This command's stdout ends with the kubeconfig, which carries a
       // cluster-admin client certificate and key. Pulumi persists every
       // resource output to state, so without this it is stored in the clear.

--- a/packages/infra/src/gateway.ts
+++ b/packages/infra/src/gateway.ts
@@ -222,8 +222,13 @@ systemctl restart unbound`,
 
   // Tailnet relay: only when configured and an auth key is present, so
   // enabling `tailnet` in config before the secret is set is a safe no-op.
+  // Not gated on `sshTransports` like the other units: this is not a transport
+  // the cluster serves but the substrate it stands on. Cilium addresses nodes
+  // by their tailnet IP because the home node has no other reachable address,
+  // so tailscaled has to exist before k3s installs — which rules out running it
+  // as a pod in the cluster it is a precondition for.
   const tailscale =
-    gateway.tailnet && tailnetAuthKey && sshTransports
+    gateway.tailnet && tailnetAuthKey
       ? createTailscaleSystemd(
           connection,
           gateway.tailnet,
@@ -241,7 +246,15 @@ systemctl restart unbound`,
       : server.ipv4Address;
 
   const k3s = gateway.k3s
-    ? createK3s(connection, server, gateway.k3s, apiHost, "", clusterName)
+    ? createK3s(
+        connection,
+        server,
+        gateway.k3s,
+        apiHost,
+        "",
+        clusterName,
+        tailscale ? [tailscale] : [],
+      )
     : undefined;
 
   // Marks this node as one that serves VPN entries; the transport DaemonSets

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -16,7 +16,6 @@ import {
   createExit,
   createHysteria,
   createProfileServer,
-  createTailscale,
   createUnbound,
   createXray,
   deriveExitPort,
@@ -263,6 +262,9 @@ export default async function () {
   createRedirectMiddleware(provider, nsName, traefikRelease);
 
   // --- The gateway's own transports, in the cluster on the box they front ---
+  // Tailscale is not among them: pod networking is addressed by tailnet IP, so
+  // it has to exist before the cluster does — see createGateway.
+  //
   // All hostNetwork, so xray owns the host's :443 and relays anything that is
   // not a VPN client to 127.0.0.1:8443 — Traefik's hostPort, just above. That
   // loopback only means the host's when the pod shares its netns, which is also
@@ -279,17 +281,6 @@ export default async function () {
       conf.vpnEntryLabel,
       transportDeps,
     );
-
-    if (gatewayConf.tailnet && conf.tailnet.authKey) {
-      createTailscale(
-        provider,
-        nsName,
-        gatewayConf.tailnet,
-        pulumi.secret(conf.tailnet.authKey),
-        conf.vpnEntryLabel,
-        transportDeps,
-      );
-    }
 
     if (gatewayConf.xray) {
       const t = createXray(


### PR DESCRIPTION
Cross-node pod traffic was a blackhole. `music` and `files` returned gateway timeouts because Traefik runs on `sympathy` while both pods run on `lady`, and nothing could cross. Port-forward and SMB worked throughout — they bypass pod networking, which is what disguised it.

## Why

Cilium tunnels pod traffic (VXLAN, UDP 8472) to whatever a node reports as its `InternalIP`:

- `lady` → `100.74.66.121` (tailnet)
- `sympathy` → `46.224.208.89` (public)

The Hetzner firewall admits `22/80/443/6443` and the Hysteria UDP ports — not 8472. So every packet from the home node was addressed somewhere it could not land. `cilium status` reported `Cluster health: 1/2 reachable` from both sides.

A CNI does not solve this. Cilium provides a flat pod network *given* that nodes can reach each other on their node IP; reachability across NAT is a substrate assumption it inherits, not one it provides. Cilium's own WireGuard encryption does not help either — `lady` has no forwarded ports, so `sympathy` can never initiate to her. Tailscale is the only thing that reaches her at all, so pod traffic must ride it, which means both nodes addressed by tailnet IP.

Opening 8472 was the alternative and is rejected: it exposes an unauthenticated encapsulation endpoint to the internet, and restricting it by source fails on a dynamic residential IP.

## What changed

**tailscaled moves out of the cluster.** It is a precondition for the cluster network, not a transport the cluster serves, so it cannot be a pod in the cluster that depends on it. It becomes a systemd unit installed over SSH — the path the edges already use. Deliberately the only thing moving back out.

**The node address lands in `/etc/rancher/k3s/config.yaml`, not the installer's flags.** This matters more than it looks: re-running the installer regenerates the kubeconfig it returns, and a changed kubeconfig replaces the Kubernetes provider — and with it *every* resource in the cluster, including Cilium's Helm release, every Service, NetworkPolicy and PersistentVolume. A full teardown to change one flag. Via the config file the preview is 2 creates and 6 deletes.

`node-ip` is read on the box (`tailscale ip -4`) rather than passed in: this program never learns the address, and reading it there means a node that re-registers with a different one corrects itself on the next deploy instead of silently disagreeing.

**The public address stays in `tls-san`.** `--node-ip` only sets the node's InternalIP; the API server still binds `0.0.0.0:6443`. The kubeconfig continues to point at `https://46.224.208.89:6443`, so CI and admin access are unchanged.

## Verifying

`pulumi preview`: 2 creates (`tailscale-up`, `k3s-node-config`), 6 deletes (the DaemonSet, its RBAC, and its two Secrets), **138 unchanged** — confirming no provider replacement.

After applying, `sympathy`'s node `InternalIP` should be its tailnet address and `cilium status` should report `2/2 reachable`; `music` and `files` should then answer over ingress rather than only via port-forward.

## Applying

k3s restarts, so the API blips. One manual pre-step is required and cannot be expressed in the graph: the outgoing DaemonSet is `hostNetwork`, so it and the incoming systemd unit would fight over the host's `tailscale0` and tun device, and Pulumi cannot order a Kubernetes deletion against an SSH command. Delete the DaemonSet first, then deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSoVxv2DpGgAV6mEsu1TWH