### PR TITLE
237 feat(vpn): egress exits on the node they present, over the tailnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,22 +102,27 @@ The VPN topology is three config lists in `packages/infra/Pulumi.main.yaml`.
 `:443/tcp`), Hysteria2 (`:443/udp`), and the tailnet relay. This is
 what clients connect *through*; `entry-select` picks the protocol.
 
-**`exits`** — where the gateway *egresses* your traffic (`exit-select`). An exit
-is an ss-rust server, and it exists to present somebody else's IP — a
-residential one, typically. How the gateway reaches one is being reworked: the
-tunnel it used was removed with the move onto a single co-located box.
+**`exits`** — where your traffic *egresses* (`exit-select`). An exit is an
+ss-rust server on the machine whose IP it presents — a residential one,
+typically. Entries reach it over the tailnet, so it works on a box behind NAT
+with nothing forwarded.
 
 ```yaml
 jaritanet:exits:
-  - name: lady        # picker tag `exit-lady`; the name is just a label
+  - name: lady
+    nodeLabel: jaritanet.radiosilence.dev/vpn-exit
+    server: 100.74.66.121
 ```
 
 - **`name`** is cosmetic — the picker tag (`exit-<name>`) and resource names.
-- **`port`** (the gateway loopback port) is derived from the name; set it only
-  to resolve a rare hash collision.
-
-Currently empty. `lady` can take the role once it joins — an exit only needs to
-be somewhere with an interesting address.
+- **`nodeLabel`** picks the machine that egresses. Apply it by hand
+  (`kubectl label node lady <label>=true`); nothing in the program can reach a
+  cloud-init-seeded node to do it, and a selector matching no node schedules
+  nothing while the cluster reports healthy.
+- **`server`** is that node's tailnet address — an address, not a name, because
+  it resolves at the entry end of a detour where MagicDNS does not exist.
+- **`port`** (the host port on the exit node) is derived from the name; set it
+  only to resolve a rare hash collision.
 
 **`edges`** — optional *additional* entry gateways (hy2 + REALITY), appearing in
 `entry-select`. Not needed with a single gateway; see

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ jaritanet:exits:
 - **`name`** is cosmetic — the picker tag (`exit-<name>`) and resource names.
 - **`nodeLabel`** picks the machine that egresses. Nothing in the program can
   reach a cloud-init-seeded node to apply it, so it is declared as the node
-  joins, via `SEED_NODE_LABELS` in `scripts/make-seed-drive`. A selector
-  matching no node schedules nothing while the cluster reports healthy.
+  joins, by `scripts/make-seed-drive` — which defaults to the labels the node
+  already carries, so a reflash keeps them. A selector matching no node
+  schedules nothing while the cluster reports healthy.
 - **`server`** is that node's tailnet address — an address, not a name, because
   it resolves at the entry end of a detour where MagicDNS does not exist. It is
   *pinned, not stable*: a re-registration moves it, and the exit then dials

--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ jaritanet:exits:
 ```
 
 - **`name`** is cosmetic — the picker tag (`exit-<name>`) and resource names.
-- **`nodeLabel`** picks the machine that egresses. Apply it by hand
-  (`kubectl label node lady <label>=true`); nothing in the program can reach a
-  cloud-init-seeded node to do it, and a selector matching no node schedules
-  nothing while the cluster reports healthy.
+- **`nodeLabel`** picks the machine that egresses. Nothing in the program can
+  reach a cloud-init-seeded node to apply it, so it is declared as the node
+  joins, via `SEED_NODE_LABELS` in `scripts/make-seed-drive`. A selector
+  matching no node schedules nothing while the cluster reports healthy.
 - **`server`** is that node's tailnet address — an address, not a name, because
-  it resolves at the entry end of a detour where MagicDNS does not exist.
+  it resolves at the entry end of a detour where MagicDNS does not exist. It is
+  *pinned, not stable*: a re-registration moves it, and the exit then dials
+  nobody, so update it from `kubectl get node <name> -o wide` if that happens.
 - **`port`** (the host port on the exit node) is derived from the name; set it
   only to resolve a rare hash collision.
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ jaritanet:exits:
 ```
 
 - **`name`** is cosmetic — the picker tag (`exit-<name>`) and resource names.
-- **`nodeLabel`** picks the machine that egresses. Nothing in the program can
-  reach a cloud-init-seeded node to apply it, so it is declared as the node
-  joins, by `scripts/make-seed-drive` — which defaults to the labels the node
-  already carries, so a reflash keeps them. A selector matching no node
-  schedules nothing while the cluster reports healthy.
+- **`node`** is the machine to put the exit on, and **`nodeLabel`** is the mark
+  it gets. Marking it is the whole deployment: the DaemonSet controller watches
+  Nodes, so the exit appears there in about a second and goes when the label
+  goes. Applied over the Kubernetes API rather than SSH — a cloud-init-seeded box
+  has no connection here but is a cluster member, which is the same reach k3s
+  upgrades use.
 - **`server`** is that node's tailnet address — an address, not a name, because
   it resolves at the entry end of a detour where MagicDNS does not exist. It is
   *pinned, not stable*: a re-registration moves it, and the exit then dials

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -577,12 +577,31 @@ than pinning to the primary: the two axes are genuinely independent, and the
 full entry × exit cross-product comes for free. (The predecessor pinned to the
 primary only because that was the one node terminating the reverse tunnel.)
 
+That membership is therefore load-bearing rather than optional. `createEdge`
+gates tailscale on `tailnet.authKey`, and an entry without a tailnet reaches no
+exit at all while the profile goes on offering every pair — so an `exits` list
+with no `authKey` fails the preview instead.
+
+**Composable across entries, but an edge cannot host an exit.** Adding a
+Helsinki edge tomorrow needs no change here and none to the exit: it joins
+`entry-select`, it is a tailnet member, and it reaches every exit. Hosting one is
+a different question. An exit is a `hostNetwork` DaemonSet, so it lands only on a
+**cluster node**, and edges are standalone Hetzner boxes with systemd transports
+that never join — `createEdge` does not call `createK3s`. The two sets are
+disjoint today, in both directions: an edge cannot host an exit, and a NATed home
+node can never be an entry, which is fundamental rather than a gap. Giving an
+edge an egress identity as well as an entry one needs either joining edges to the
+cluster or an `-systemd` exit variant beside the transports that already have
+one.
+
 `nodeLabel` decides which machine egresses — the same argument the VPN entry
 label makes. Nothing in this program can reach a cloud-init-seeded box to apply
-it, so it is declared as the node joins, by `SEED_NODE_LABELS` in
-`scripts/make-seed-drive`. Applying it by hand afterwards works and is drift: a
-reflash loses it, and the exit then schedules nowhere while the cluster reports
-itself healthy.
+it, so it is declared as the node joins, by `scripts/make-seed-drive`. That
+script defaults a node's labels to the `jaritanet.radiosilence.dev/*` ones it
+already carries, read from the cluster, so a reflash rebuilds the machine it was
+rather than a blank one; `SEED_NODE_LABELS` overrides, for a machine that has
+never joined. Applying a label by hand and stopping there is drift — the reflash
+loses it, the exit schedules nowhere, and the cluster reports itself healthy.
 
 `server` is **pinned, not stable**. A tailnet address survives reboots but not a
 re-registration — sympathy's moved from `100.69.78.57` to `100.78.67.16` in #238

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -578,8 +578,24 @@ full entry × exit cross-product comes for free. (The predecessor pinned to the
 primary only because that was the one node terminating the reverse tunnel.)
 
 `nodeLabel` decides which machine egresses — the same argument the VPN entry
-label makes — and like the file-server label it is applied by hand when the node
-joins, because nothing in this program can reach a cloud-init-seeded box.
+label makes. Nothing in this program can reach a cloud-init-seeded box to apply
+it, so it is declared as the node joins, by `SEED_NODE_LABELS` in
+`scripts/make-seed-drive`. Applying it by hand afterwards works and is drift: a
+reflash loses it, and the exit then schedules nowhere while the cluster reports
+itself healthy.
+
+`server` is **pinned, not stable**. A tailnet address survives reboots but not a
+re-registration — sympathy's moved from `100.69.78.57` to `100.78.67.16` in #238
+when its identity left the DaemonSet's Secret for systemd state — and the
+failure is quiet: the DaemonSet stays healthy, the profile stays valid, and the
+entry dials an address nobody answers on. Reading it from the Node's
+`InternalIP` would be self-correcting (a seeded agent joins with
+`--node-ip=$(tailscale ip -4)`, so it is already there) and is deliberately not
+done: it would make every preview depend on that Node object existing, putting
+the gateway's deploy behind a home box being in the cluster. On a rebuild — the
+gateway being restored, the home node not yet rejoined — that is the wrong
+failure. So it is written down, and re-read by hand if an exit ever
+re-registers.
 
 No kernel IP forwarding anywhere — ss-rust owns both ends of each flow
 (connection-level), so there's no return-path routing to misconfigure on a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -594,14 +594,25 @@ edge an egress identity as well as an entry one needs either joining edges to th
 cluster or an `-systemd` exit variant beside the transports that already have
 one.
 
-`nodeLabel` decides which machine egresses — the same argument the VPN entry
-label makes. Nothing in this program can reach a cloud-init-seeded box to apply
-it, so it is declared as the node joins, by `scripts/make-seed-drive`. That
-script defaults a node's labels to the `jaritanet.radiosilence.dev/*` ones it
-already carries, read from the cluster, so a reflash rebuilds the machine it was
-rather than a blank one; `SEED_NODE_LABELS` overrides, for a machine that has
-never joined. Applying a label by hand and stopping there is drift — the reflash
-loses it, the exit schedules nowhere, and the cluster reports itself healthy.
+**The label is the deployment.** `nodeLabel` decides which machine egresses, and
+the DaemonSet controller watches Nodes — so marking one schedules the exit onto
+it and unmarking it tears the pod down, with no `pulumi up` in between. Measured
+on this cluster: `desiredNumberScheduled` went 0 → 1 **1.09s** after the label
+landed, and 1 → 0 **0.36s** after it was removed.
+
+That makes the label the single piece of state an exit depends on, and the only
+one whose absence nothing reports — an unlabelled node is zero pods on a cluster
+that looks perfectly healthy. So `node` names the machine and this program
+applies the label itself, as a `NodePatch` over the Kubernetes API rather than
+SSH: a box seeded from cloud-init has no connection here, but it is a cluster
+member, which is the same reach that carries k3s upgrades to it. `patchForce` is
+what makes that reconcile rather than merely assert — an apply carrying the same
+value co-owns the field without complaint, and it is the diverged state, where
+someone has changed the label by hand, that conflicts with `kubectl label`'s
+field manager and needs forcing back.
+
+Hand-labelling still works, and is how you move an exit for an afternoon. It is
+no longer what holds one in place.
 
 `server` is **pinned, not stable**. A tailnet address survives reboots but not a
 re-registration — sympathy's moved from `100.69.78.57` to `100.78.67.16` in #238

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,8 @@ all workloads in it. The box itself runs k3s and sshd and nothing else.
 ## The whole system, end to end
 
 The gateway is the **hub**. A client picks how it *enters* (`entry-select`) and
-where it *egresses* (`exit-select`). Everything transits the gateway.
+where it *egresses* (`exit-select`). Everything transits an entry; an exit is a
+second hop past it, over the tailnet.
 
 ```mermaid
 flowchart TD
@@ -355,8 +356,9 @@ intervention.
 
 One combined profile carries both transports and DNS handling, behind the two
 selectors: **`entry-select`** (how you reach the gateway) and **`exit-select`**
-(where the gateway egresses you). The client runs **no WireGuard**; the tailnet
-hop happens on the gateway (see below).
+(where you egress). They compose freely — every exit detours through
+`entry-select`, so any entry reaches any exit. The client runs **no WireGuard**;
+the tailnet hop happens on the gateway (see below).
 
 ```mermaid
 flowchart TD
@@ -370,7 +372,7 @@ flowchart TD
     TN -->|yes| ENTRY["entry-select<br/>gateway → tailscale relay"]
     TN -->|no| EXIT["exit-select"]
     EXIT --> ED["exit-direct → entry-select<br/>(egress at the gateway)"]
-    EXIT --> EN["exit-&lt;name&gt;<br/>(egress at an exit box)"]
+    EXIT --> EN["exit-&lt;name&gt;<br/>(ss to 100.x, detour entry-select)"]
 ```
 
 Two route rules do the work: `100.x` → `entry-select` (tailnet egresses at the
@@ -541,42 +543,65 @@ from the ISP, and neither is worth it for an exit whose entire purpose is
 presenting a residential **IPv4** address. Accepted deliberately — if something
 you rely on breaks only through the exit, suspect this first.
 
-An exit is an **ss-rust** server, as a k8s Deployment (`modules/exit.ts`) today,
-or a cloud-init VPS later. Add one via the `exits` config list:
+An exit is an **ss-rust** server, as a `hostNetwork` DaemonSet
+(`packages/vpn/src/exit.ts`) pinned to the machine whose address it presents.
+Add one via the `exits` config list:
 
 ```yaml
 jaritanet:exits:
   - name: lady
-    port: 9000
+    nodeLabel: jaritanet.radiosilence.dev/vpn-exit
+    server: 100.74.66.121
 ```
-
-Each exit's ss-rust port is expected on the **primary gateway's loopback**
-(`127.0.0.1:<port>`) — the same pattern as the Reality decoy `dest` — and the
-client's ss outbound detours through the primary so the inner address resolves
-at that end. What surfaces the port there is the open question: the reverse
-tunnel that used to do it went with the move onto a single co-located box.
 
 ```mermaid
 flowchart LR
-    DEV["device"] -->|"detour: primary (hy2/reality)"| GW["primary gateway"]
-    GW -->|"127.0.0.1:<port>"| SS["ss-rust exit (k8s)"]
-    SS -->|"pod egress, CNI SNAT → node IP"| INET(("Internet"))
+    DEV["device"] -->|"detour: entry-select (hy2/reality)"| GW["entry — gateway or edge"]
+    GW -->|"tailnet — 100.x:&lt;port&gt;"| SS["ss-rust exit (hostNetwork, on lady)"]
+    SS -->|"host stack, src = LAN → residential IP"| INET(("Internet"))
 ```
 
-The client's `exit-<name>` outbound is Shadowsocks to `127.0.0.1:<port>`,
-detouring through the **primary** gateway. In a detour chain the inner address
-resolves at the gateway end, so `127.0.0.1:<port>` means "this exit's loopback
-on the primary." Exits pin to the primary because it is the only node where
-those loopbacks exist — edges (also in `entry-select`) serve hy2/reality only,
-so routing an exit through an edge would dial a dead loopback. `entry-select`
-still governs *direct* egress across all gateways; exits transit the primary.
+**`hostNetwork` is the mechanism, not a shortcut.** In the node's own namespace
+the host stack picks the source address by routing, so no CNI masquerade sits in
+the path and lady egresses her residential IPv4 (verified: default route
+`via 192.168.50.1 dev eno1`, egress `168.199.77.151`). It is also what puts
+`tailscale0` in the pod's namespace, so the port an entry dials is the node's
+tailnet address rather than a ClusterIP the overlay would have to carry.
+
+**The tailnet is the transport.** lady is behind NAT with nothing forwarded,
+deliberately; every path to her is one she opened outbound. Her k3s node IP is
+already her tailnet address, so this reuses a path that carries the cluster's
+own node-to-node traffic. Every gateway and edge is a tailnet member, which is
+why the client's `exit-<name>` outbound detours through **`entry-select`** rather
+than pinning to the primary: the two axes are genuinely independent, and the
+full entry × exit cross-product comes for free. (The predecessor pinned to the
+primary only because that was the one node terminating the reverse tunnel.)
+
+`nodeLabel` decides which machine egresses — the same argument the VPN entry
+label makes — and like the file-server label it is applied by hand when the node
+joins, because nothing in this program can reach a cloud-init-seeded box.
 
 No kernel IP forwarding anywhere — ss-rust owns both ends of each flow
 (connection-level), so there's no return-path routing to misconfigure on a
-remote box. The exit pod egresses normally and the CNI SNATs to the node IP. Topology is a pure function of the config lists,
-expanded at `pulumi up`. (Making exits reachable via *any* gateway — the full
-entry × exit cross-product — needs every gateway to surface the exit loopbacks;
-deferred. When more than one does, `port` must be identical across them.)
+remote box. That is also what makes an offline exit legible: `exit-select` is a
+manual selector, so a human is the failover, and a dial that is refused or times
+out at a named address is far easier to read than a handshake that succeeds and
+then silently swallows packets. Topology is a pure function of the config lists,
+expanded at `pulumi up`.
+
+**Why not the alternatives.** A Tailscale exit node (`--advertise-exit-node`) is
+a whole-device default-route override, so the gateway selecting it would send
+*everything* out of the house — the exact failure `--accept-routes=false` exists
+to prevent — and there is no per-flow selection, which is what an exit axis is.
+Cilium's egress gateway is the k8s-native answer and leaves the pod alone, but
+wants cluster-wide `bpf.masquerade`, resolves its egress IP once (a DHCP renewal
+on the home LAN leaves it dropping), and black-holes traffic behind a successful
+handshake when the gateway node is down. A hand-rolled WireGuard peer is a worse
+tailnet: no DERP fallback, no NAT traversal, and its config lives on lady's disk
+where Pulumi cannot reach it.
+
+Throughput does not discriminate between any of these — a residential upstream
+caps every one of them long before its own overhead does.
 
 ## Multi-user access (admin / guest)
 
@@ -615,6 +640,8 @@ their profile JSON; the restrictions still hold because they live at the gateway
   entry, killing the entry kills everything downstream.
 - **Exits** — gated by the ss-rust PSK, which is simply omitted from guest
   profiles, so a guest has no exit outbound to select even if they edit the JSON.
+  They now sit at tailnet addresses too, so the guest tailnet blackhole below
+  denies them a second time, on a rule that was already there.
 - **Everything that isn't the public internet** — an Xray routing rule blackholes
   guest flows to the tailnet, loopback and RFC1918. Enumerating what a guest may
   *not* touch is the losing side of the argument, so the rule denies every

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -225,15 +225,6 @@ config:
       image: docker.io/klutchell/unbound:v1.25.2
     hcloudToken:
       secure: AAABAOgRAPNoCi9RMimIgP3fLzyirP3UdoMx34L1D5tApjmkfrEF60Ys9++KOGJz+0jKxMI5PgGC1LXqk1AiRgZS3psE7g/YHhKkWxMGiCoHVW83ro5MjAtbrAhSyl8+
-  # Egress exit nodes — ss-rust in the cluster, reached via the
-  # tunnel, egressing the home residential IP. Selectable in the client as
-  # exit-<name>; exits transit the primary gateway.
-  # Egress exit nodes — where the gateway forwards your traffic out. Each is
-  # just ss-rust; how the gateway reaches it is being reworked.
-  # `name` is all you set (drives the picker tag exit-<name> + resource names);
-  # the loopback port is auto-derived from the name.
-  # None until a second node exists, at which point an exit is just a pod on it
-  # with no tunnel involved.
   # What lady serves off the media drive. Shares are anonymous — `map to guest`
   # turns unknown users into `guestAccount`, which must own the files or every
   # read fails — and reachable only from the tailnet and the LAN, never the
@@ -265,7 +256,20 @@ config:
       folders:
         - name: music
           hostPath: /mnt/kontent/music
-  jaritanet:exits: []
+  # Egress exit nodes — ss-rust on the machine whose IP you want to leave from,
+  # selectable in the client as exit-<name>. lady is the only one worth having:
+  # her address is a consumer ISP's, which no Hetzner range can be.
+  #
+  # `server` is her tailnet address — how an entry reaches a box behind NAT with
+  # no forwarded port — and is stable per node. `nodeLabel` must already be on
+  # the node: nothing here can reach a cloud-init-seeded box to apply it, so it
+  # goes on by hand when the node joins:
+  #   kubectl label node lady jaritanet.radiosilence.dev/vpn-exit=true
+  # The port is derived from the name; only set `port` to break a hash clash.
+  jaritanet:exits:
+    - name: lady
+      nodeLabel: jaritanet.radiosilence.dev/vpn-exit
+      server: 100.74.66.121
   jaritanet:services:
     navidrome:
       hostname:

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -265,14 +265,16 @@ config:
   # the exit then dials nobody, with everything still reporting healthy, so it
   # is re-read from `kubectl get node lady -o wide` when that happens.
   #
-  # `nodeLabel` must already be on the node. Nothing here can reach a
-  # cloud-init-seeded box to apply it, so it is declared as she joins, by
-  # scripts/make-seed-drive — which carries over whatever she already has, so a
-  # reflash does not quietly return her without it.
+  # `node` is the machine this program marks with `nodeLabel`, over the API
+  # rather than SSH. Marking it is the whole deployment: the DaemonSet controller
+  # watches Nodes, so the exit appears there within a second and vanishes if the
+  # label goes. Hand-labelling still works and is how you move an exit for an
+  # afternoon — it is no longer what holds it in place.
   #
   # The port is derived from the name; only set `port` to break a hash clash.
   jaritanet:exits:
     - name: lady
+      node: lady
       nodeLabel: jaritanet.radiosilence.dev/vpn-exit
       server: 100.74.66.121
   jaritanet:services:

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -261,10 +261,14 @@ config:
   # her address is a consumer ISP's, which no Hetzner range can be.
   #
   # `server` is her tailnet address — how an entry reaches a box behind NAT with
-  # no forwarded port — and is stable per node. `nodeLabel` must already be on
-  # the node: nothing here can reach a cloud-init-seeded box to apply it, so it
-  # goes on by hand when the node joins:
-  #   kubectl label node lady jaritanet.radiosilence.dev/vpn-exit=true
+  # no forwarded port. Pinned rather than stable: a re-registration moves it and
+  # the exit then dials nobody, with everything still reporting healthy, so it
+  # is re-read from `kubectl get node lady -o wide` when that happens.
+  #
+  # `nodeLabel` must already be on the node. Nothing here can reach a
+  # cloud-init-seeded box to apply it, so it is declared as she joins, by
+  # SEED_NODE_LABELS in scripts/make-seed-drive.
+  #
   # The port is derived from the name; only set `port` to break a hash clash.
   jaritanet:exits:
     - name: lady

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -267,7 +267,8 @@ config:
   #
   # `nodeLabel` must already be on the node. Nothing here can reach a
   # cloud-init-seeded box to apply it, so it is declared as she joins, by
-  # SEED_NODE_LABELS in scripts/make-seed-drive.
+  # scripts/make-seed-drive — which carries over whatever she already has, so a
+  # reflash does not quietly return her without it.
   #
   # The port is derived from the name; only set `port` to break a hash clash.
   jaritanet:exits:

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -56,8 +56,7 @@ export default async function () {
   let hysteria: SingboxNode["hysteria"] | undefined;
 
   // sing-box nodes for the edges. The primary is prepended once its transports
-  // are known — buildProfile detours exits through nodes[0], so the order is
-  // load-bearing.
+  // are known, so it leads the picker.
   const edgeNodes: SingboxNode[] = [];
 
   // The VPN roster. No `vpnUsers` → a single implicit owner-admin, so the
@@ -66,19 +65,22 @@ export default async function () {
   const users: VpnUser[] =
     vpnUsers.length > 0 ? vpnUsers : [{ name: "owner", role: "admin" }];
 
-  // Resolve each exit's loopback port once (derived from the name unless set),
-  // so the identical port is used at the ss server and the client outbound.
-  // Assert uniqueness — a clash means the user
-  // should set an explicit `port` on one of the exits.
+  // Resolve each exit's host port once (derived from the name unless set), so
+  // the identical port is used at the ss server and the client outbound.
+  // Uniqueness is asserted per node, not globally: the port is bound on the
+  // exit's own host, so two exits only clash when they share a machine.
   const resolvedExits = conf.exits.map((e) => ({
     image: e.image,
     method: e.method,
     name: e.name,
+    nodeLabel: e.nodeLabel,
     port: e.port ?? deriveExitPort(e.name),
+    server: e.server,
   }));
-  if (new Set(resolvedExits.map((e) => e.port)).size !== resolvedExits.length) {
+  const exitBinds = resolvedExits.map((e) => `${e.nodeLabel}:${e.port}`);
+  if (new Set(exitBinds).size !== exitBinds.length) {
     throw new Error(
-      "exit loopback port collision — set an explicit `port` on the clashing exit",
+      "two exits share a node and a port — set an explicit `port` on the clashing exit",
     );
   }
 
@@ -246,8 +248,8 @@ export default async function () {
   );
   const nsName = ns.metadata.name;
 
-  // Egress exit nodes: ss-rust in-cluster, bound to the gateway's loopback.
-  // Clients reach them by detouring through the primary, which is that host.
+  // Egress exit nodes: ss-rust pinned by node label, hostNetwork, dialled at
+  // that node's tailnet address by whichever entry the client picked.
   const exits = resolvedExits.map((e) => createExit(provider, nsName, e));
 
   // --- Ingress: Traefik. The cluster runs on the gateway, so xray relays
@@ -402,8 +404,7 @@ export default async function () {
   //
   // The primary is a node too: clients connect by IP, and its REALITY decoy is
   // its own reverse-proxied site (unlike edges, which use an external one). It
-  // leads the list because buildProfile detours exits through nodes[0], the
-  // host whose loopback the exits are bound to.
+  // leads the list so it heads the entry picker.
   const nodes: SingboxNode[] = [
     ...(gatewayIp && reality && hysteria
       ? [{ name: "primary", server: gatewayIp, hysteria, reality }]

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -73,11 +73,12 @@ export default async function () {
     image: e.image,
     method: e.method,
     name: e.name,
+    node: e.node,
     nodeLabel: e.nodeLabel,
     port: e.port ?? deriveExitPort(e.name),
     server: e.server,
   }));
-  const exitBinds = resolvedExits.map((e) => `${e.nodeLabel}:${e.port}`);
+  const exitBinds = resolvedExits.map((e) => `${e.node}:${e.port}`);
   if (new Set(exitBinds).size !== exitBinds.length) {
     throw new Error(
       "two exits share a node and a port — set an explicit `port` on the clashing exit",

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -83,6 +83,15 @@ export default async function () {
       "two exits share a node and a port — set an explicit `port` on the clashing exit",
     );
   }
+  // Exits are reached over the tailnet, and every entry's membership is gated on
+  // this key (see createEdge). Without it the profile still offers every
+  // entry × exit pair and not one of them can connect, so this is a red preview
+  // rather than an exit axis that is present and dead.
+  if (resolvedExits.length && !conf.tailnet.authKey) {
+    throw new Error(
+      "exits need `tailnet.authKey`: an entry with no tailnet cannot reach one",
+    );
+  }
 
   if (conf.gateway?.hcloudToken) {
     gatewayConf = conf.gateway ?? GatewayConfSchema.parse({});

--- a/packages/vpn/src/exit.schemas.ts
+++ b/packages/vpn/src/exit.schemas.ts
@@ -2,26 +2,30 @@ import * as z from "zod";
 
 /**
  * A selectable egress exit node: an ss-rust server whose IP the traffic leaves
- * from. Substrate-agnostic (k8s now; a cloud-init VPS later).
+ * from. The whole point is the address it presents, so an exit is pinned to a
+ * machine and dialled at that machine's own address.
  *
- * The client's ss outbound dials `127.0.0.1:<port>` and detours through the
- * primary gateway. A detour resolves the inner address at the far end, so the
- * port has to exist on the primary's loopback — which is why `port` is fixed
- * per exit rather than allocated, and why exits pin to the primary rather than
- * following whichever entry `entry-select` picks for direct traffic.
+ * `nodeLabel` decides which machine egresses, the same argument the VPN entry
+ * label and the file-server label make. Nothing here can apply it: a node
+ * seeded from cloud-init has no connection in this program, so the label goes
+ * on by hand when the node joins.
  *
- * What binds that loopback port is currently unresolved: the reverse tunnel
- * that did it was removed when the cluster moved onto the gateway itself.
+ * `server` is where an entry dials the exit — its tailnet address, since every
+ * gateway and edge is a tailnet member and the home node has no inbound port.
+ * An address rather than a name because it resolves at the *entry* end of a
+ * detour, where MagicDNS does not exist: the client's resolvers are all
+ * tunnelled and the gateway's unbound knows nothing of the tailnet.
  *
- * `name` is the only field you normally set — it drives the picker tag
- * (`exit-<name>`) and the resource names. `port` is the gateway loopback port
- * (pure plumbing); leave it unset and it's derived deterministically from the
- * name at deploy time. Only set it to resolve a rare name-hash collision.
+ * `name` drives the picker tag (`exit-<name>`) and the resource names. `port`
+ * is the host port on the exit node (pure plumbing); leave it unset and it is
+ * derived deterministically from the name at deploy time. Only set it to
+ * resolve a rare name-hash collision.
  */
 export const ExitConfSchema = z.object({
   image: z.string().default("ghcr.io/shadowsocks/ssserver-rust:v1.24.0"),
   method: z.string().default("aes-256-gcm"),
   name: z.string(),
+  nodeLabel: z.string(),
   port: z.number().optional(),
-  substrate: z.enum(["k8s"]).default("k8s"),
+  server: z.ipv4(),
 });

--- a/packages/vpn/src/exit.schemas.ts
+++ b/packages/vpn/src/exit.schemas.ts
@@ -11,11 +11,23 @@ import { LabelKey, Port } from "@jaritanet/k8s";
  * seeded from cloud-init has no connection in this program — so it is declared
  * as the node joins, by `SEED_NODE_LABELS` in `scripts/make-seed-drive`.
  *
- * `server` is where an entry dials the exit — its tailnet address, since every
- * gateway and edge is a tailnet member and the home node has no inbound port.
- * An address rather than a name because it resolves at the *entry* end of a
- * detour, where MagicDNS does not exist: the client's resolvers are all
- * tunnelled and the gateway's unbound knows nothing of the tailnet.
+ * `server` is where an entry dials the exit — its tailnet address, since the
+ * home node has no inbound port. An address rather than a name because it
+ * resolves at the *entry* end of a detour, where MagicDNS does not exist: the
+ * client's resolvers are all tunnelled and the gateway's unbound knows nothing
+ * of the tailnet.
+ *
+ * That makes a tailnet a hard requirement of the exit axis, not a nicety: an
+ * entry's membership is gated on `tailnet.authKey`, and an entry without one
+ * reaches no exit at all while the profile goes on offering every pair. Asserted
+ * in main rather than left to be discovered.
+ *
+ * An exit can only run on a **cluster node**, since it is a DaemonSet. Edges are
+ * standalone boxes with systemd transports and never join, so the machines that
+ * can be an entry and the machines that can host an exit are disjoint sets today
+ * — in both directions, as a NATed home node can never be an entry. Giving an
+ * edge an exit needs either cluster membership or a `-systemd` exit beside the
+ * other transports.
  *
  * It is **pinned, not stable**. A tailnet address survives reboots but not a
  * re-registration: sympathy's moved from `100.69.78.57` to `100.78.67.16` when

--- a/packages/vpn/src/exit.schemas.ts
+++ b/packages/vpn/src/exit.schemas.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { Port } from "@jaritanet/k8s";
+import { LabelKey, Port } from "@jaritanet/k8s";
 
 /**
  * A selectable egress exit node: an ss-rust server whose IP the traffic leaves
@@ -7,15 +7,31 @@ import { Port } from "@jaritanet/k8s";
  * machine and dialled at that machine's own address.
  *
  * `nodeLabel` decides which machine egresses, the same argument the VPN entry
- * label and the file-server label make. Nothing here can apply it: a node
- * seeded from cloud-init has no connection in this program, so the label goes
- * on by hand when the node joins.
+ * label and the file-server label make. Nothing here can apply it — a node
+ * seeded from cloud-init has no connection in this program — so it is declared
+ * as the node joins, by `SEED_NODE_LABELS` in `scripts/make-seed-drive`.
  *
  * `server` is where an entry dials the exit — its tailnet address, since every
  * gateway and edge is a tailnet member and the home node has no inbound port.
  * An address rather than a name because it resolves at the *entry* end of a
  * detour, where MagicDNS does not exist: the client's resolvers are all
  * tunnelled and the gateway's unbound knows nothing of the tailnet.
+ *
+ * It is **pinned, not stable**. A tailnet address survives reboots but not a
+ * re-registration: sympathy's moved from `100.69.78.57` to `100.78.67.16` when
+ * its identity left the DaemonSet's Secret for systemd state. Re-auth, node
+ * deletion or state loss on an exit node does the same, and the failure is
+ * quiet — the DaemonSet stays healthy and the profile stays valid while the
+ * entry dials an address nobody answers on. So it is updated by hand, from
+ * `kubectl get node <name> -o wide`, whenever that happens.
+ *
+ * Reading it from the Node's `InternalIP` would be self-correcting (a seeded
+ * agent joins with `--node-ip=$(tailscale ip -4)`, so the value is already
+ * there) and was deliberately not done: it makes every preview depend on that
+ * Node object existing, which puts the *gateway's* deploy behind a home box
+ * being in the cluster. On a cluster rebuild, where the gateway is the thing
+ * being restored and the home node has not rejoined yet, that is the wrong
+ * failure.
  *
  * `name` drives the picker tag (`exit-<name>`) and the resource names. `port`
  * is the host port on the exit node (pure plumbing); leave it unset and it is
@@ -26,7 +42,7 @@ export const ExitConfSchema = z.object({
   image: z.string().default("ghcr.io/shadowsocks/ssserver-rust:v1.24.0"),
   method: z.string().default("aes-256-gcm"),
   name: z.string(),
-  nodeLabel: z.string(),
+  nodeLabel: LabelKey,
   port: Port.optional(),
   server: z.ipv4(),
 });

--- a/packages/vpn/src/exit.schemas.ts
+++ b/packages/vpn/src/exit.schemas.ts
@@ -7,9 +7,18 @@ import { LabelKey, Port } from "@jaritanet/k8s";
  * machine and dialled at that machine's own address.
  *
  * `nodeLabel` decides which machine egresses, the same argument the VPN entry
- * label and the file-server label make. Nothing here can apply it — a node
- * seeded from cloud-init has no connection in this program — so it is declared
- * as the node joins, by `SEED_NODE_LABELS` in `scripts/make-seed-drive`.
+ * label and the file-server label make — and it is the whole mechanism, not
+ * bookkeeping. The DaemonSet controller watches Nodes, so marking one schedules
+ * the exit onto it in about a second and unmarking it tears the pod down; k8s
+ * does the rest and nothing here has to.
+ *
+ * That also makes the label the single piece of state the exit depends on, and
+ * the only one whose absence nothing reports: an unlabelled node means zero pods
+ * on a cluster that looks perfectly healthy. So `node` names the machine to put
+ * it on and this program applies it, over the Kubernetes API rather than SSH —
+ * reach comes from cluster membership, the same property that carries k3s
+ * upgrades to a box Pulumi never created. Hand-labelling is then a way to move
+ * an exit for an afternoon, not the thing holding it in place.
  *
  * `server` is where an entry dials the exit — its tailnet address, since the
  * home node has no inbound port. An address rather than a name because it
@@ -54,6 +63,7 @@ export const ExitConfSchema = z.object({
   image: z.string().default("ghcr.io/shadowsocks/ssserver-rust:v1.24.0"),
   method: z.string().default("aes-256-gcm"),
   name: z.string(),
+  node: z.string(),
   nodeLabel: LabelKey,
   port: Port.optional(),
   server: z.ipv4(),

--- a/packages/vpn/src/exit.ts
+++ b/packages/vpn/src/exit.ts
@@ -6,6 +6,7 @@ import { cpuRequests, sha256hex } from "@jaritanet/k8s";
 /** An exit with its host port resolved (see deriveExitPort). */
 export type ResolvedExit = {
   name: string;
+  node: string;
   nodeLabel: string;
   port: number;
   method: string;
@@ -57,6 +58,36 @@ export function createExit(
   exit: ResolvedExit,
 ) {
   const name = `exit-${exit.name}`;
+
+  // The label is the switch. The DaemonSet controller watches Nodes, so this
+  // patch is what schedules the exit — a labelled node grows the pod in about a
+  // second, and removing the label tears it down just as fast. Declaring it here
+  // rather than leaving it to a human is the difference between "the exit is on
+  // lady" being a fact about the config and a fact about someone's memory: an
+  // unlabelled node schedules zero pods and reports itself perfectly healthy.
+  //
+  // Over the Kubernetes API, not SSH — a node seeded from cloud-init has no
+  // connection in this program, but it is a cluster member, which is the same
+  // reach k3s upgrades use to get to it.
+  //
+  // patchForce is what makes this reconcile rather than merely assert. A
+  // server-side apply carrying the same value co-owns the field happily, so the
+  // steady state needs nothing; it is the *diverged* state that conflicts, and
+  // `kubectl label` holds the field as a different manager. Without the force,
+  // the one case this exists for — someone changed the label by hand — fails the
+  // deploy with a field-manager conflict instead of putting it back.
+  const label = new k8s.core.v1.NodePatch(
+    `${name}-node`,
+    {
+      metadata: {
+        annotations: { "pulumi.com/patchForce": "true" },
+        labels: { [exit.nodeLabel]: "true" },
+        name: exit.node,
+      },
+    },
+    { provider },
+  );
+
   const password = new random.RandomPassword(`${name}-ss`, {
     length: 32,
     special: false,
@@ -141,7 +172,11 @@ export function createExit(
         },
       },
     },
-    { dependsOn: [secret], provider },
+    // On the label as well as the config: Pulumi awaits DaemonSet readiness, and
+    // a DaemonSet whose selector matches no node is "ready" with zero pods. Get
+    // that order wrong and the first deploy reports success having scheduled
+    // nothing, with the label landing a moment later.
+    { dependsOn: [label, secret], provider },
   );
 
   return {

--- a/packages/vpn/src/exit.ts
+++ b/packages/vpn/src/exit.ts
@@ -106,6 +106,15 @@ export function createExit(
             // The node's resolver, not the cluster's: ss-rust resolves the
             // destination names its clients send it, and those should be
             // answered where the traffic egresses, not in Germany.
+            //
+            // This only resolves anything *because* of hostNetwork above, and
+            // the two cannot be separated. A seeded agent sets no
+            // `--resolv-conf`, so `Default` hands the pod the host's
+            // /etc/resolv.conf — `nameserver 127.0.0.53`, the systemd-resolved
+            // stub — which answers only where that address is a real listener,
+            // i.e. the host's namespace. Drop hostNetwork and it becomes the
+            // pod's own loopback with nothing behind it, which is the SERVFAIL
+            // trap k3s.ts already documents for coredns.
             dnsPolicy: "Default",
             automountServiceAccountToken: false,
             nodeSelector: { [exit.nodeLabel]: "true" },

--- a/packages/vpn/src/exit.ts
+++ b/packages/vpn/src/exit.ts
@@ -1,18 +1,22 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
-import { sha256hex } from "@jaritanet/k8s";
+import { cpuRequests, sha256hex } from "@jaritanet/k8s";
 
-/** An exit with its loopback port resolved (see deriveExitPort). */
+/** An exit with its host port resolved (see deriveExitPort). */
 export type ResolvedExit = {
   name: string;
+  nodeLabel: string;
   port: number;
   method: string;
   image: string;
+  server: string;
 };
 
+const LIMITS = { cpu: "500m", memory: "128Mi" };
+
 /**
- * Deterministic loopback port from the exit name (djb2 → 20000–29999), so you
+ * Deterministic host port from the exit name (djb2 → 20000–29999), so you
  * never hand-pick plumbing. Stable per name and order-independent; a config
  * `port` override wins, and main asserts the resolved set is collision-free.
  */
@@ -23,12 +27,25 @@ export function deriveExitPort(name: string): number {
 }
 
 /**
- * A k8s egress exit: ss-rust in the cluster. It NATs out via the pod's normal
- * egress, which the CNI SNATs to the node IP — so the exit presents whichever
- * node it runs on. No `hostNetwork`, no kernel forwarding: ss-rust owns both
- * ends of each flow.
+ * A k8s egress exit: ss-rust on the node whose address the traffic should
+ * leave from, reached over the tailnet by whichever entry the client picked.
  *
- * How the gateway reaches it is unresolved — see exit.schemas.ts.
+ * `hostNetwork` is the mechanism, not a shortcut. In the node's own namespace
+ * the host stack picks the source address by routing, so nothing masquerades
+ * the flow and a home node egresses its residential ISP address — the one
+ * thing a datacentre range can never be. It is also what puts `tailscale0` in
+ * the pod's namespace, so the port an entry dials is the node's tailnet
+ * address rather than a ClusterIP the overlay would have to carry.
+ *
+ * A DaemonSet for the reason samba and the transports are: the host port is
+ * exclusive, so two replicas can never share a node and `maxSurge: 0` follows
+ * — the old pod must be gone before the replacement can bind.
+ *
+ * No kernel forwarding and no return-path routing on a remote box: ss-rust
+ * owns both ends of every flow. An offline node is a dial that fails at a
+ * named address, which is what a manually-selected exit needs — `exit-select`
+ * has a human for failover, and a connection that establishes and then
+ * swallows packets is the failure they read worst.
  *
  * The ss password is a single Pulumi secret consumed here (server Secret) and
  * by the client outbound (see singbox) — one source, no drift. Returns the
@@ -68,13 +85,16 @@ export function createExit(
     { provider },
   );
 
-  new k8s.apps.v1.Deployment(
+  new k8s.apps.v1.DaemonSet(
     name,
     {
       metadata: { name, namespace },
       spec: {
-        replicas: 1,
         selector: { matchLabels: { app: name } },
+        updateStrategy: {
+          type: "RollingUpdate",
+          rollingUpdate: { maxUnavailable: 1, maxSurge: 0 },
+        },
         template: {
           // Roll the pod when the ss config (password/method/port) changes.
           metadata: {
@@ -82,6 +102,13 @@ export function createExit(
             labels: { app: name },
           },
           spec: {
+            hostNetwork: true,
+            // The node's resolver, not the cluster's: ss-rust resolves the
+            // destination names its clients send it, and those should be
+            // answered where the traffic egresses, not in Germany.
+            dnsPolicy: "Default",
+            automountServiceAccountToken: false,
+            nodeSelector: { [exit.nodeLabel]: "true" },
             containers: [
               {
                 name: "ssserver",
@@ -95,7 +122,8 @@ export function createExit(
                   },
                 ],
                 resources: {
-                  limits: { cpu: "500m", memory: "128Mi" },
+                  limits: LIMITS,
+                  ...cpuRequests(LIMITS.cpu),
                 },
               },
             ],
@@ -107,28 +135,11 @@ export function createExit(
     { dependsOn: [secret], provider },
   );
 
-  const service = new k8s.core.v1.Service(
-    name,
-    {
-      metadata: { name, namespace },
-      spec: {
-        selector: { app: name },
-        ports: [
-          { name: "ss-tcp", port: exit.port, protocol: "TCP" },
-          { name: "ss-udp", port: exit.port, protocol: "UDP" },
-        ],
-      },
-    },
-    { provider },
-  );
-
-  const host = pulumi.interpolate`${service.metadata.name}.${namespace}.svc.cluster.local`;
-
   return {
-    host,
     method: exit.method,
     name: exit.name,
     password: password.result,
     port: exit.port,
+    server: exit.server,
   };
 }

--- a/packages/vpn/src/singbox.schema.test.ts
+++ b/packages/vpn/src/singbox.schema.test.ts
@@ -50,7 +50,13 @@ const node = {
 };
 const edge = { ...node, name: "helsinki", server: "5.6.7.8" };
 const exits = [
-  { name: "home", port: 9000, method: "aes-128-gcm", password: "ss-psk" },
+  {
+    name: "home",
+    port: 9000,
+    method: "aes-128-gcm",
+    password: "ss-psk",
+    server: "100.74.66.121",
+  },
 ];
 
 describe("delivered profiles are valid sing-box configs", () => {

--- a/packages/vpn/src/singbox.test.ts
+++ b/packages/vpn/src/singbox.test.ts
@@ -19,7 +19,13 @@ const node = {
   },
 };
 const exits = [
-  { name: "home", port: 9000, method: "aes-128-gcm", password: "ss-psk" },
+  {
+    name: "home",
+    port: 9000,
+    method: "aes-128-gcm",
+    password: "ss-psk",
+    server: "100.74.66.121",
+  },
 ];
 
 const tags = (p: ReturnType<typeof buildProfile>) =>
@@ -74,6 +80,30 @@ describe("buildProfile roles", () => {
     // No outbound anywhere carries the ss PSK for a guest.
     const json = JSON.stringify(p);
     expect(json).not.toContain("ss-psk");
+  });
+});
+
+describe("buildProfile exit axis", () => {
+  const admin = { name: "jc", role: "admin" } as const;
+  const edge = { ...node, name: "edge1", server: "5.6.7.8" };
+  const exitOut = (nodes: (typeof node)[]) =>
+    (
+      buildProfile(admin, nodes, "ts.net", exits).outbounds as {
+        tag: string;
+        server?: string;
+        detour?: string;
+      }[]
+    ).find((o) => o.tag === "exit-home");
+
+  it("dials the exit node's own address, not a loopback on the entry", () => {
+    expect(exitOut([node])?.server).toBe("100.74.66.121");
+  });
+
+  // The two axes are independent: the exit is reached over the tailnet, which
+  // every entry is a member of, so an exit must not pin to nodes[0].
+  it("detours through entry-select whatever the entry count", () => {
+    expect(exitOut([node])?.detour).toBe("entry-select");
+    expect(exitOut([node, edge])?.detour).toBe("entry-select");
   });
 });
 

--- a/packages/vpn/src/singbox.ts
+++ b/packages/vpn/src/singbox.ts
@@ -53,6 +53,7 @@ export type Exit = {
   port: number;
   method: string;
   password: pulumi.Input<string>;
+  server: pulumi.Input<string>;
 };
 
 type ResolvedExit = {
@@ -60,6 +61,7 @@ type ResolvedExit = {
   port: number;
   method: string;
   password: string;
+  server: string;
 };
 
 // Innermost tun MTU for the whole chain. Sized so a packet survives the worst
@@ -157,10 +159,10 @@ const selector = (tag: string, outbounds: string[], def: string) => ({
  *     entry gateway). Route `final` points here; tailnet + DNS stay on
  *     `entry-select` so they egress at the gateway, never via an exit.
  *
- * Each exit outbound targets `127.0.0.1:<port>` and detours through the
- * **primary** gateway — the inner address resolves at the primary end, hitting
- * that exit's loopback bind. Exits therefore always
- * transit the primary, regardless of the `entry-select` pick for direct egress.
+ * Each exit outbound targets the exit node's own (tailnet) address and detours
+ * through `entry-select`, so the inner address resolves at whichever entry the
+ * client is using. Every entry is a tailnet member, so the two axes are
+ * independent: any entry composes with any exit.
  *
  * Per-user + role-aware: reality outbounds use the user's own UUID; admins also
  * get hy2 (their per-node password) and the exit axis; guests are
@@ -230,24 +232,19 @@ export function buildProfile(
   // The exit axis only exists when there are exits — otherwise routing points
   // straight at entry-select (direct egress, no extra groups).
   if (effExits.length) {
-    // Exits pin to the PRIMARY gateway (nodes[0]) — the only node running
-    // the exits, so the only one exposing their loopbacks. Edges (also in
-    // entry-select) run hy2/reality only; detouring an exit through an edge
-    // would dial 127.0.0.1:<port> where nothing listens.
-    const primaryEntry = nodes.length === 1 ? "auto" : `auto-${nodes[0].name}`;
-
-    // Each exit: a Shadowsocks outbound dialled through the primary. The
-    // 127.0.0.1:<port> resolves at the primary → its loopback bind → the
-    // exit's ss-rust → egress at the exit's own IP.
+    // Each exit: a Shadowsocks outbound dialled through whichever entry
+    // `entry-select` picked. The exit's tailnet address resolves at that end,
+    // and every gateway and edge is a tailnet member — so the axes are
+    // genuinely independent and any entry can reach any exit.
     for (const e of effExits) {
       outbounds.push({
         type: "shadowsocks",
         tag: `exit-${e.name}`,
-        server: "127.0.0.1",
+        server: e.server,
         server_port: e.port,
         method: e.method,
         password: e.password,
-        detour: primaryEntry,
+        detour: "entry-select",
       });
     }
 

--- a/packages/vpn/src/xray-systemd.ts
+++ b/packages/vpn/src/xray-systemd.ts
@@ -16,7 +16,8 @@ import { GUEST_DENY_CIDRS } from "./xray.ts";
  * x25519 private key stays in /usr/local/etc/xray, and one REALITY UUID is
  * minted per user (`email: <name>`) so a user is revoked by dropping them from
  * the clients list. Guests (reality-only) are blackholed server-side to the
- * tailnet CIDR and the exit loopbacks — a hard block, not a profile omission.
+ * tailnet CIDR — which is where the exits live too — and every other address
+ * that is not the internet. A hard block, not a profile omission.
  *
  * `user`-scoped routing only resolves once the inbound sniffs the flow, so the
  * inbound enables sniffing with `routeOnly` (route on the sniffed destination

--- a/packages/vpn/src/xray.ts
+++ b/packages/vpn/src/xray.ts
@@ -8,15 +8,17 @@ import { sha256hex } from "@jaritanet/k8s";
 import { realityKeypair } from "./reality.ts";
 
 // A guest may address the public internet and nothing else. Narrower rules were
-// a mistake: the exit loopbacks were blocked only on their own port range
-// (20000-29999, see deriveExitPort in exit.ts), which left 0.0.0.0 — a synonym
-// for localhost on Linux — reachable, and said nothing about the rest of the
-// gateway's own stack. Enumerating what a guest may not touch is the losing
-// side of that argument, so this is every address that isn't the internet.
+// a mistake: exits were blocked only on their own port range (20000-29999, see
+// deriveExitPort in exit.ts), which left 0.0.0.0 — a synonym for localhost on
+// Linux — reachable, and said nothing about the rest of the gateway's own
+// stack. Enumerating what a guest may not touch is the losing side of that
+// argument, so this is every address that isn't the internet. Exits now live at
+// tailnet addresses, so the first entry denies them as a consequence rather
+// than as a rule of its own.
 export const GUEST_DENY_CIDRS = [
-  "100.64.0.0/10", // tailnet
+  "100.64.0.0/10", // tailnet, incl. every exit
   "fd7a:115c:a1e0::/48",
-  "127.0.0.0/8", // the gateway itself, incl. the exit loopbacks
+  "127.0.0.0/8", // the gateway itself
   "0.0.0.0/8",
   "::1/128",
   "10.0.0.0/8",

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -284,21 +284,7 @@
                 ]
               },
               "nodeLabel": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "secure": {
-                        "type": "string"
-                      }
-                    },
-                    "required": ["secure"],
-                    "additionalProperties": false
-                  }
-                ]
+                "$ref": "#/$defs/__schema5"
               },
               "port": {
                 "$ref": "#/$defs/__schema2"
@@ -501,16 +487,16 @@
               "type": "object",
               "properties": {
                 "apiViaTailnet": {
-                  "$ref": "#/$defs/__schema5"
-                },
-                "ciliumVersion": {
                   "$ref": "#/$defs/__schema6"
                 },
-                "upgradeControllerVersion": {
+                "ciliumVersion": {
                   "$ref": "#/$defs/__schema7"
                 },
-                "version": {
+                "upgradeControllerVersion": {
                   "$ref": "#/$defs/__schema8"
+                },
+                "version": {
+                  "$ref": "#/$defs/__schema9"
                 }
               }
             },
@@ -647,7 +633,7 @@
                   "minItems": 1,
                   "type": "array",
                   "items": {
-                    "$ref": "#/$defs/__schema9"
+                    "$ref": "#/$defs/__schema10"
                   }
                 },
                 "version": {
@@ -678,7 +664,7 @@
           "properties": {
             "nodeLabel": {
               "default": "jaritanet.radiosilence.dev/file-node",
-              "$ref": "#/$defs/__schema10"
+              "$ref": "#/$defs/__schema5"
             },
             "samba": {
               "type": "object",
@@ -1742,7 +1728,7 @@
           ]
         },
         "jaritanet:vpnEntryLabel": {
-          "$ref": "#/$defs/__schema10"
+          "$ref": "#/$defs/__schema5"
         },
         "jaritanet:vpnUsers": {
           "anyOf": [
@@ -1939,10 +1925,28 @@
       ]
     },
     "__schema5": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?\\.)*[a-z0-9]([-a-z0-9]*[a-z0-9])?\\/[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "secure": {
+              "type": "string"
+            }
+          },
+          "required": ["secure"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "__schema6": {
       "default": false,
       "type": "boolean"
     },
-    "__schema6": {
+    "__schema7": {
       "default": "1.20.0",
       "anyOf": [
         {
@@ -1960,7 +1964,7 @@
         }
       ]
     },
-    "__schema7": {
+    "__schema8": {
       "default": "v0.20.1",
       "anyOf": [
         {
@@ -1978,25 +1982,8 @@
         }
       ]
     },
-    "__schema8": {
-      "default": "v1.36.3+k3s1",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "secure": {
-              "type": "string"
-            }
-          },
-          "required": ["secure"],
-          "additionalProperties": false
-        }
-      ]
-    },
     "__schema9": {
+      "default": "v1.36.3+k3s1",
       "anyOf": [
         {
           "type": "string"
@@ -2016,8 +2003,7 @@
     "__schema10": {
       "anyOf": [
         {
-          "type": "string",
-          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?\\.)*[a-z0-9]([-a-z0-9]*[a-z0-9])?\\/[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$"
+          "type": "string"
         },
         {
           "type": "object",

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -96,16 +96,19 @@
               "name": {
                 "type": "string"
               },
+              "nodeLabel": {
+                "type": "string"
+              },
               "port": {
                 "type": "number"
               },
-              "substrate": {
-                "default": "k8s",
+              "server": {
                 "type": "string",
-                "enum": ["k8s"]
+                "format": "ipv4",
+                "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$"
               }
             },
-            "required": ["name"]
+            "required": ["name", "nodeLabel", "server"]
           }
         },
         "jaritanet:gateway": {

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -283,6 +283,23 @@
                   }
                 ]
               },
+              "node": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "secure": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["secure"],
+                    "additionalProperties": false
+                  }
+                ]
+              },
               "nodeLabel": {
                 "$ref": "#/$defs/__schema5"
               },
@@ -309,7 +326,7 @@
                 ]
               }
             },
-            "required": ["name", "nodeLabel", "server"]
+            "required": ["name", "node", "nodeLabel", "server"]
           }
         },
         "jaritanet:fastmail": {

--- a/scripts/make-seed-drive
+++ b/scripts/make-seed-drive
@@ -42,9 +42,10 @@
 #
 # Node labels are applied as the agent joins, and each one selects a workload in
 # `Pulumi.main.yaml` — lady's `file-node` puts samba/syncthing/navidrome on the
-# disks, her `vpn-exit` puts the ss-rust egress exit on the residential link.
-# A label that goes missing is silent: the DaemonSet selecting it schedules
-# nowhere and the cluster reports itself perfectly healthy.
+# disks. A label that goes missing is silent: the DaemonSet selecting it
+# schedules nowhere and the cluster reports itself perfectly healthy. (The exit
+# label is the exception, and no longer needs to be here: the stack applies that
+# one itself over the API. See `createExit`.)
 #
 # They default to the `jaritanet.radiosilence.dev/*` labels the node already
 # carries, read from the cluster, so a reflash rebuilds the machine it was

--- a/scripts/make-seed-drive
+++ b/scripts/make-seed-drive
@@ -35,8 +35,23 @@
 # agent, and the k3s join token is read from the cluster at build time.
 #
 # Reads SEED_TS_AUTHKEY, SEED_PASSWORD, SEED_PRO_TOKEN and the optional
-# SEED_MOUNT_DEV/SEED_MOUNT_POINT from the environment; mise
+# SEED_MOUNT_DEV/SEED_MOUNT_POINT/SEED_NODE_LABELS from the environment; mise
 # loads them from the gitignored .env (see mise.toml).
+#
+# ## What a node declares about itself
+#
+# SEED_NODE_LABELS is a space-separated `key=value` list, applied as the agent
+# joins. Every one of them selects a workload in `Pulumi.main.yaml`, so a label
+# missing here is a DaemonSet that schedules nowhere while the cluster reports
+# itself healthy — and the same label applied by hand afterwards is drift that
+# a reflash silently loses. What lady is:
+#
+#   SEED_NODE_LABELS='jaritanet.radiosilence.dev/file-node=true \
+#                     jaritanet.radiosilence.dev/vpn-exit=true'
+#
+# file-node puts samba/syncthing/navidrome on the disks; vpn-exit puts the
+# ss-rust egress exit on the residential link, which is the whole point of it
+# running there rather than anywhere cheaper.
 #
 # Usage: scripts/make-seed-drive <device> <hostname> [--no-join]
 #   scripts/make-seed-drive /dev/disk4 lady
@@ -286,8 +301,11 @@ YAML
 #
 # The k3s version is pinned to the server's rather than left to \`latest\`, so a
 # release landing between now and first boot cannot put the agent ahead of the
-# control plane. No VPN entry label and no taint: which machine serves a VPN
-# entry is a property of that machine, and this one is a workload node.
+# control plane. No VPN *entry* label and no taint: which machine serves an
+# entry is a property of that machine, and this one is a workload node. A VPN
+# *exit* is the opposite and does belong here (see SEED_NODE_LABELS) — an entry
+# is fungible, any box with a public address will do, while an exit exists
+# solely to present this machine's own.
 runcmd:
   # systemd-fsck preens by default and drops to an emergency shell for anything
   # it will not fix unsupervised — on a headless box that is a machine sat

--- a/scripts/make-seed-drive
+++ b/scripts/make-seed-drive
@@ -40,18 +40,16 @@
 #
 # ## What a node declares about itself
 #
-# SEED_NODE_LABELS is a space-separated `key=value` list, applied as the agent
-# joins. Every one of them selects a workload in `Pulumi.main.yaml`, so a label
-# missing here is a DaemonSet that schedules nowhere while the cluster reports
-# itself healthy — and the same label applied by hand afterwards is drift that
-# a reflash silently loses. What lady is:
+# Node labels are applied as the agent joins, and each one selects a workload in
+# `Pulumi.main.yaml` — lady's `file-node` puts samba/syncthing/navidrome on the
+# disks, her `vpn-exit` puts the ss-rust egress exit on the residential link.
+# A label that goes missing is silent: the DaemonSet selecting it schedules
+# nowhere and the cluster reports itself perfectly healthy.
 #
-#   SEED_NODE_LABELS='jaritanet.radiosilence.dev/file-node=true \
-#                     jaritanet.radiosilence.dev/vpn-exit=true'
-#
-# file-node puts samba/syncthing/navidrome on the disks; vpn-exit puts the
-# ss-rust egress exit on the residential link, which is the whole point of it
-# running there rather than anywhere cheaper.
+# They default to the `jaritanet.radiosilence.dev/*` labels the node already
+# carries, read from the cluster, so a reflash rebuilds the machine it was
+# rather than a blank one. SEED_NODE_LABELS (space-separated `key=value`)
+# overrides that, and is how a machine that has never joined gets any.
 #
 # Usage: scripts/make-seed-drive <device> <hostname> [--no-join]
 #   scripts/make-seed-drive /dev/disk4 lady
@@ -282,8 +280,27 @@ YAML
     # What this machine is, declared as it joins rather than applied by a human
     # afterwards — which is the same argument the config makes for selecting on
     # a label rather than a hostname, carried one step further.
+    #
+    # Defaulted from the labels the node currently carries, because a reflash is
+    # normally a rebuild of a machine that already exists and the truth is on it.
+    # Writing them down here instead would be a second copy to keep in step, and
+    # an env var is worse still: it lives in a gitignored file, so the labels
+    # survive exactly as long as one shell does. Losing them is silent — the
+    # DaemonSets that select them schedule nowhere and the cluster reports
+    # itself healthy.
+    #
+    # Only our own prefix: kubernetes.io/* and the upgrade controller's plan
+    # hashes are the cluster's to set, and re-declaring them at join is at best
+    # noise and at worst a stale hash. SEED_NODE_LABELS overrides, which is how
+    # a machine that has never joined gets any.
+    NODE_LABELS="${SEED_NODE_LABELS:-$(
+      kubectl --context "$CONTEXT" get node "$HOSTNAME" -o go-template='
+        {{range $k, $v := .metadata.labels}}{{$k}}={{$v}}{{"\n"}}{{end}}' \
+        2>/dev/null | grep '^jaritanet\.radiosilence\.dev/' | tr '\n' ' '
+    )}"
+    echo "node labels: ${NODE_LABELS:-(none — set SEED_NODE_LABELS if it needs any)}" >&2
     LABEL_ARGS=""
-    for label in ${SEED_NODE_LABELS:-}; do
+    for label in $NODE_LABELS; do
       LABEL_ARGS="$LABEL_ARGS --node-label $label"
     done
     cat <<YAML


### PR DESCRIPTION
Exits used to be surfaced on the gateway's loopback by rathole. That tunnel went
when the cluster moved onto the gateway, so `exit-select` has had no transport
under it since. This puts the ss-rust listener on the machine that egresses and
reaches it over the tailnet.

## Mechanism

```mermaid
flowchart LR
  subgraph dev["device — sing-box"]
    direction TB
    TUN["tun · 198.18.0.1/30 · mtu 1280"]
    XS{{"exit-select"}}
    SSC["exit-lady<br/>shadowsocks → 100.74.66.121:23855<br/><b>detour: entry-select</b>"]
    ES{{"entry-select"}}
    TUN --> XS
    XS -->|"exit-direct"| ES
    XS -->|"exit-lady"| SSC
    SSC -->|"dial via"| ES
  end

  subgraph sym["sympathy — Hetzner VPS, public"]
    direction TB
    ENT["xray :443/tcp<br/>hysteria2 :443,3478,4500/udp<br/>hostNetwork"]
    TS0["tailscale0"]
    ENT --> TS0
  end

  subgraph lady["lady — home, behind NAT, no forwarded port"]
    direction TB
    SSS["ss-rust :23855<br/>DaemonSet · hostNetwork"]
    ENO["eno1 · 192.168.50.138"]
    SSS --> ENO
  end

  ES -->|"REALITY / hy2"| ENT
  ENT -->|"exit-direct: egress here"| HZ(("Hetzner IP"))
  TS0 -->|"tailnet · 100.x · ~15ms"| SSS
  ENO --> RES(("168.199.77.151<br/>residential"))
```

The `exit-lady` outbound names `100.74.66.121:23855` but carries `detour:
entry-select`, so that address is **resolved and dialled at the entry**, not on
the device. sing-box wraps the Shadowsocks stream inside whichever REALITY or hy2
tunnel `entry-select` settled on; the entry unwraps it and opens a TCP/UDP
connection out `tailscale0`. ss-rust on lady terminates it and originates the
onward flow itself.

Three consequences fall out of that:

- **The exit is `hostNetwork`, so the host stack picks the source address by
  routing.** No CNI masquerade is in the path, so the flow leaves `eno1` as
  `168.199.77.151` rather than as whatever the overlay would SNAT it to. The
  ambiguity the issue raised — is the node IP the `100.x` or the LAN address? —
  does not arise, because the pod is in the host's namespace.
- **The detour is `entry-select`, not `auto-<primary>`.** Exits pinned to the
  primary only because it was the one node terminating rathole. Every gateway and
  edge is a tailnet member, so any entry composes with any exit — the entry ×
  exit cross-product `exit.schemas.ts` deferred.
- **ss-rust owns both ends of every flow.** No kernel forwarding, no return-path
  routing on a remote box, and an offline lady is a dial that fails at a named
  address rather than a handshake that succeeds and then swallows packets.
  `exit-select` is a manual selector, so a human is the failover and legible
  failure is worth more than elegance.

`dnsPolicy: Default` is coupled to `hostNetwork` and the two cannot be separated:
`Default` hands the pod the host's resolv.conf, whose `127.0.0.53` stub answers
only where it is a real listener. Drop `hostNetwork` and it becomes the pod's own
loopback with nothing behind it — the SERVFAIL trap `k3s.ts` documents for
coredns. Destination names therefore resolve at lady, which is also where they
should be answered.

## Config

```yaml
jaritanet:exits:
  - name: lady
    node: lady
    nodeLabel: jaritanet.radiosilence.dev/vpn-exit
    server: 100.74.66.121
```

`port` is omitted and derived from the name (`deriveExitPort("lady")` → `23855`);
set it only to break a hash collision.

**The label is the deployment.** The DaemonSet controller watches Nodes, so
marking one schedules the exit onto it and unmarking it tears the pod down, with
no `pulumi up` in between — measured on this cluster at **1.09s** to schedule and
**0.36s** to remove. That makes the label the single piece of state an exit
depends on, and the only one whose absence nothing reports, so `node` names the
machine and the stack applies the label itself as a `NodePatch` — over the
Kubernetes API rather than SSH, since a cloud-init-seeded box has no connection
here but is a cluster member. `patchForce` makes it reconcile rather than merely
assert: a same-value apply co-owns the field happily, and it is the diverged
state (someone relabelled by hand) that conflicts with `kubectl label`'s field
manager. Both halves verified against the live node.

`server` is **pinned, not stable**. A tailnet address survives reboots but not a
re-registration: sympathy's moved `100.69.78.57` → `100.78.67.16` in #238 when
its identity left the DaemonSet's Secret for systemd state. Reading the Node's
`InternalIP` would be self-correcting and is deliberately not done — it makes
every preview depend on that Node object existing, putting the gateway's deploy
behind a home box being in the cluster, which is exactly wrong during a rebuild.
`Node.get` also needs a node *name*, so it would mean two config fields
identifying one machine.

## What the client gets

`buildProfile` for an admin, exit axis only:

```json
{ "type": "shadowsocks", "tag": "exit-lady",
  "server": "100.74.66.121", "server_port": 23855,
  "method": "aes-256-gcm", "password": "<ss-psk>",
  "detour": "entry-select" }

{ "type": "selector", "tag": "exit-direct",
  "outbounds": ["entry-select"], "default": "entry-select" }

{ "type": "selector", "tag": "exit-select",
  "outbounds": ["exit-direct", "exit-lady"], "default": "exit-direct" }
```

`route.final` → `exit-select`. Guests get none of it: no ss PSK in their profile,
and the exit now sits inside the `100.64.0.0/10` block `GUEST_DENY_CIDRS` already
enforced at the entry, so the server-side denial is a consequence rather than a
new rule.

## What `pulumi up` would create

```
+ kubernetes:core/v1:NodePatch exit-lady-node    labels lady with the exit label
+ random:index:RandomPassword  exit-lady-ss      length 32, special false
+ kubernetes:core/v1:Secret    exit-lady-config  config.json (ss password in cleartext)
+ kubernetes:apps/v1:DaemonSet exit-lady
```

The DaemonSet depends on the patch: Pulumi awaits DaemonSet readiness, and one
whose selector matches no node is ready with zero pods — the wrong order reports
a successful deploy that scheduled nothing.

```
+ kubernetes:apps/v1:DaemonSet: (create)  exit-lady
    spec.template.spec:
      hostNetwork                 : true
      dnsPolicy                   : "Default"
      automountServiceAccountToken: false
      nodeSelector                : { jaritanet.radiosilence.dev/vpn-exit: "true" }
      containers[0]:
        image    : "ghcr.io/shadowsocks/ssserver-rust:v1.24.0"
        command  : ["ssserver", "-c", "/etc/shadowsocks/config.json"]
        resources: limits { cpu 500m, memory 128Mi }, requests { cpu 50m }
    spec.updateStrategy.rollingUpdate: { maxUnavailable: 1, maxSurge: 0 }
```

`maxSurge: 0` because the host port is exclusive — the old pod must be gone
before the replacement can bind. Plus the profile round: `singbox-profiles`
Secret + Deployment replace on the new content, and `singbox-notify` re-fires
because the profile hash changed.

Totals: **4 to create, 1 to update, 3 to replace, 136 unchanged.** Nothing is
destroyed — the previous `exits` list was empty, so there is no old
Deployment/Service to remove.

Two diffs in the preview are **not from this change**: `tailscale-up` shows
`~create` because its script interpolates the tailnet auth key and the configured
one differs from state, and `singbox-notify`'s `create` differs only by the
absolute path of the worktree it was previewed from.

## Verification

Both open questions in the issue were settled on the live cluster before any code
was written, from a `hostNetwork` pod on lady:

| | |
|---|---|
| Route | `1.1.1.1 via 192.168.50.1 dev eno1 src 192.168.50.138` |
| Egress v4 | `168.199.77.151` — residential |
| Egress v6 | none, as `docs/architecture.md` already documents as accepted |
| Tailnet, sympathy → `100.74.66.121` | 3/3, ~15ms |

- `mise run check` — 125 tests, typecheck, lint, format.
- `mise run check:profiles` — all 4 profile shapes accepted by the real sing-box
  binary (v1.14.0-alpha.47). A published schema cannot answer "will the devices
  take this"; this can.
- New `buildProfile exit axis` tests assert the outbound dials the node address
  and detours `entry-select` at both one and several entries — the regression
  that would otherwise silently reintroduce primary pinning.
- `bash -n scripts/make-seed-drive`.

## Rejected alternatives

Recorded in `docs/architecture.md` with the reasoning, in short:

| | Why not |
|---|---|
| Tailscale exit node | `--exit-node` is a whole-device default-route override — the gateway would send *everything* out of the house, taking the relay and every hosted service with it. No per-flow selection, which is what an exit axis is. |
| Cilium egress gateway | Needs cluster-wide `bpf.masquerade`; resolves its egress IP once, so a DHCP renewal leaves it dropping; black-holes behind a *successful* handshake when the gateway node is down. |
| Hand-rolled WireGuard | A worse tailnet — no DERP fallback, no NAT traversal, and its config lives on lady's disk where Pulumi cannot reach it. |

Throughput discriminates between none of them: a residential upstream caps every
option long before its own overhead does.

## Composability

Any entry reaches any exit — that is what the `entry-select` detour bought, and
adding a Helsinki edge tomorrow needs no change here and none to the exit.
Hosting is the other question: an exit is a `hostNetwork` DaemonSet so it lands
only on a **cluster node**, and edges are standalone Hetzner boxes with systemd
transports that never join (`createEdge` does not call `createK3s`). So the two
sets are disjoint today, in both directions — an edge cannot host an exit, and a
NATed home node can never be an entry, which is fundamental rather than a gap.
Stated in `docs/architecture.md` and the schema docstring.

That also makes tailnet membership load-bearing rather than optional: an entry's
membership is gated on `tailnet.authKey`, and without one the profile would go on
offering every entry × exit pair while none could connect. `main.ts` throws
instead, in the same shape as the exit-port collision check.

## Before merging

Nothing. The stack applies the exit label itself, so there is no manual step and
nothing for a reflash to lose. `scripts/make-seed-drive` still carries a node's
other labels through a reflash (`file-node` is applied at join and is not
Pulumi's), defaulting to the `jaritanet.radiosilence.dev/*` ones the node already
has.

Closes #237
