### PR TITLE
223 fix(k3s): read the kubeconfig off the server, not off the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ imports `infra`, and the only sideways import is `@jaritanet/k8s`.
 
 **`@jaritanet/hetzner`** — the machine
 
-- **`k3s.ts`** — installs k3s over SSH and returns its kubeconfig as the same command's stdout, so config and cluster cannot drift apart
+- **`k3s.ts`** — installs k3s over SSH, and reads the kubeconfig back as a separate command keyed on the server rather than on the installer, so editing the install command does not churn the credentials the Kubernetes provider is built from
 - **`cilium.ts`** — the CNI, with `kubeProxyReplacement` (which is what makes `hostPort` work at all)
 - **`vps.ts`** — firewall rules and the sysctls the transports need (BBR, UDP buffers)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,6 +190,31 @@ which cgroup owns the socket before anything else.
 Edges keep the SSH path: they have no cluster, and one box per location running
 two daemons is not worth a control plane.
 
+## Why the kubeconfig is read separately from the install
+
+The Kubernetes provider is configured from the gateway's kubeconfig, and Pulumi
+replaces a provider whose configuration changed — along with every resource
+created through it. That is Cilium, every Service, IngressRoute, NetworkPolicy
+and PersistentVolume, including the CNI the cluster needs in order to come back.
+
+So the provider's configuration must not move for reasons that have nothing to
+do with the credentials. Taking the kubeconfig from the installer's stdout meant
+it did: the installer's output *was* the credential, so any edit to its command
+line regenerated it, and an ordinary flag change was indistinguishable from a
+cluster rebuild — visible only as a long list of ordinary-looking replacements
+in a preview nobody reads that closely.
+
+The kubeconfig is therefore its own `command.remote`, triggered on the server
+rather than on the installer. A new server is what mints new credentials: the
+installer preserves `/var/lib/rancher/k3s`, so the cluster CA survives any
+number of reinstalls on the same box. Rotating it some other way means bumping
+the tag in that command's triggers, and the cascade that follows is then the
+real thing rather than noise.
+
+Two changes still legitimately replace the provider, and both mean the
+credentials genuinely moved: replacing the server, and switching `apiHost`
+between the tailnet name and the public IP.
+
 ## Keeping k3s current on nodes nothing can reach
 
 The gateway's k3s is installed over SSH, so its version follows

--- a/packages/hetzner/src/k3s.test.ts
+++ b/packages/hetzner/src/k3s.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { renderKubeconfig } from "./k3s.ts";
+
+// Shape and ordering as k3s writes it, with the base64 truncated. The `default`
+// on the `client-certificate-data` line is the accident the anchors exist for.
+const RAW = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tCmRlZmF1bHQK
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    client-certificate-data: ZGVmYXVsdAo=default
+    client-key-data: a2V5Cg==
+`;
+
+describe("renderKubeconfig", () => {
+  const rendered = renderKubeconfig(RAW, "gateway.example.ts.net", "jaritanet");
+
+  it("points the server at the name the certificate covers", () => {
+    expect(rendered).toContain("server: https://gateway.example.ts.net:6443");
+    expect(rendered).not.toContain("127.0.0.1");
+  });
+
+  it("renames all six of cluster, context and user", () => {
+    expect(rendered.match(/jaritanet$/gm)).toHaveLength(6);
+    expect(rendered).not.toMatch(/^\s*-?\s*(name|cluster|user):\s*default$/m);
+    expect(rendered).toContain("current-context: jaritanet");
+  });
+
+  it("leaves certificate data alone", () => {
+    expect(rendered).toContain("certificate-authority-data: LS0tCmRlZmF1bHQK");
+    expect(rendered).toContain("client-certificate-data: ZGVmYXVsdAo=default");
+  });
+});

--- a/packages/hetzner/src/k3s.ts
+++ b/packages/hetzner/src/k3s.ts
@@ -49,12 +49,6 @@ export function createK3s(
 ) {
   const p = resourcePrefix(name);
 
-  // k3s reads this at startup, which is why the address lands here rather than
-  // in the installer's flags: re-running the installer regenerates the
-  // kubeconfig below, and a changed kubeconfig replaces the Kubernetes provider
-  // and with it every resource in the cluster — a full teardown to change one
-  // flag.
-  //
   // `node-ip` is the box's tailnet address. Cilium tunnels pod traffic to
   // whatever a node reports as its InternalIP, and the home node is behind NAT
   // with no forwarded ports, so its tailnet address is the only one that can be
@@ -148,63 +142,87 @@ mkdir -p /opt/cni/bin
 for plugin in /var/lib/rancher/k3s/data/cni/*; do
   ln -sfn "$plugin" "/opt/cni/bin/$(basename "$plugin")"
 done
-# The installer returns before the API is up; everything downstream reads the
-# kubeconfig, so wait for it to actually serve rather than racing it.
+# The installer returns before the API is up, and everything downstream talks
+# to it, so wait for it to actually serve rather than racing it.
 for i in $(seq 1 60); do
   k3s kubectl get --raw /readyz >/dev/null 2>&1 && break
   sleep 5
 done
-k3s kubectl get --raw /readyz >/dev/null
-# Printed last so it is this command's stdout: the config and the cluster it
-# describes then come from the same execution.
-cat /etc/rancher/k3s/k3s.yaml`,
-      // The resolv-conf tag is part of the trigger because changing the
-      // command text alone does not re-run a remote command.
+k3s kubectl get --raw /readyz >/dev/null`,
       triggers: [k3s.version, pulumi.output(apiHost), "resolv-conf-v1"],
     },
     {
       dependsOn: [server, nodeConfig],
-      // This command's stdout ends with the kubeconfig, which carries a
-      // cluster-admin client certificate and key. Pulumi persists every
+      // Whatever the vendor script prints while running as root. Pulumi
+      // persists every resource output to state and none of it is worth
+      // storing in the clear.
+      additionalSecretOutputs: ["stdout"],
+    },
+  );
+
+  // A read of its own, triggered on the machine rather than on the installer's
+  // command line. Pulumi replaces a provider whose configuration changed, and
+  // every resource created through it goes with it — Cilium, Services,
+  // IngressRoutes, PersistentVolumes. Taking the kubeconfig from the
+  // installer's stdout put every edit to the install command on that path,
+  // however unrelated, so an ordinary flag change was indistinguishable from a
+  // cluster rebuild and only visible to someone reading the preview closely.
+  //
+  // The server is the trigger because a new server is what mints new
+  // credentials: the installer preserves /var/lib/rancher/k3s, so the cluster
+  // CA survives any number of reinstalls on the same box. Anything that rotates
+  // it out of band — an uninstall, `k3s certificate rotate-ca` — is a bump of
+  // the tag, and the cascade that follows is then the real thing.
+  const read = new command.remote.Command(
+    `${p}k3s-kubeconfig`,
+    {
+      connection,
+      create: "cat /etc/rancher/k3s/k3s.yaml",
+      triggers: [server.id, "kubeconfig-v1"],
+    },
+    {
+      dependsOn: [server, install],
+      // Cluster-admin client certificate and key. Pulumi persists every
       // resource output to state, so without this it is stored in the clear.
       additionalSecretOutputs: ["stdout"],
     },
   );
 
-  // The kubeconfig is the install command's own stdout, not a separate read.
-  // As two resources they could disagree: reinstalling k3s regenerates its CA,
-  // but a read whose trigger had not changed kept serving the old one — which
-  // presents as "x509: certificate signed by unknown authority" against a
-  // cluster that is up and reachable. One execution cannot drift from itself.
-  //
-  // k3s writes `server: https://127.0.0.1:6443`, true on the box and useless
-  // anywhere else, so it is rewritten to the name the cert already covers.
-  //
-  // It also names the cluster, context and user `default`, which collides with
-  // every other kubeconfig on the machine reading this — merging one in either
-  // clobbers an existing `default` or renames it by hand every time, and
-  // `--context default` says nothing about which cluster it reached. Renamed
-  // here rather than after the fact for the same reason the address is: the
-  // output should be usable as it comes out.
-  //
-  // Anchored to `: default` at end of line so it cannot match inside the
-  // base64 certificate data, where the string can occur by chance. The optional
-  // `-` matters: `users:` writes its entry as `- name: default` while `clusters:`
-  // indents `name:` under the item, so a pattern expecting only whitespace
-  // renames five of the six and leaves the user behind.
   const kubeconfig = pulumi
-    .all([install.stdout, pulumi.output(apiHost)])
+    .all([read.stdout, pulumi.output(apiHost)])
     .apply(([cfg, host]) =>
-      pulumi.secret(
-        cfg
-          .slice(cfg.indexOf("apiVersion:"))
-          .replace("https://127.0.0.1:6443", `https://${host}:6443`)
-          .replace(
-            /^(\s*-?\s*(?:name|cluster|user|current-context):\s*)default$/gm,
-            `$1${clusterName}`,
-          ),
-      ),
+      pulumi.secret(renderKubeconfig(cfg, host, clusterName)),
     );
 
   return { install, kubeconfig };
+}
+
+/**
+ * Makes k3s's own kubeconfig usable off the box it came from.
+ *
+ * k3s writes `server: https://127.0.0.1:6443`, true there and useless anywhere
+ * else, so it is rewritten to the name the certificate already covers.
+ *
+ * It also names the cluster, context and user `default`, which collides with
+ * every other kubeconfig on the machine reading this — merging one in either
+ * clobbers an existing `default` or renames it by hand every time, and
+ * `--context default` says nothing about which cluster it reached.
+ *
+ * The rename is anchored to `: default` at end of line so it cannot match
+ * inside the base64 certificate data, where the string can occur by chance. The
+ * optional `-` matters: `users:` writes its entry as `- name: default` while
+ * `clusters:` indents `name:` under the item, so a pattern expecting only
+ * whitespace renames five of the six and leaves the user behind.
+ */
+export function renderKubeconfig(
+  raw: string,
+  apiHost: string,
+  clusterName: string,
+) {
+  return raw
+    .replace("https://127.0.0.1:6443", `https://${apiHost}:6443`)
+    .replace(
+      /^(\s*-?\s*(?:name|cluster|user|current-context):\s*)default$/gm,
+      `$1${clusterName}`,
+    );
 }

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -195,7 +195,12 @@ export default async function () {
   // --- Kubernetes provider ---
   // The cluster runs on the gateway itself, and the same `pulumi up` that
   // creates the server produces this kubeconfig — no secret round-trip, and
-  // nothing for a human to rotate. See modules/k3s.ts.
+  // nothing for a human to rotate.
+  //
+  // A changed kubeconfig replaces this provider and every resource created
+  // through it, so what the value is allowed to depend on is load-bearing:
+  // @jaritanet/hetzner reads it off the box keyed on the server, not on the
+  // installer that happens to run alongside it.
   if (!gatewayK3s) {
     throw new Error("gateway.k3s is required: it provides the cluster");
   }


### PR DESCRIPTION
Closes #223.

## What it does

The Kubernetes provider is configured from the gateway's kubeconfig. Pulumi replaces a provider whose configuration changed, and every resource created through it goes with it — Cilium, every Service, IngressRoute, NetworkPolicy and PersistentVolume. Deriving the kubeconfig from the k3s installer's stdout meant the installer's *command line* was on that path: adding `--node-ip` regenerated the credential and the preview wanted to rebuild the cluster.

The kubeconfig is now its own `command.remote` (`k3s-kubeconfig`, a plain `cat /etc/rancher/k3s/k3s.yaml`), triggered on `server.id` rather than on anything about the installer. The installer keeps the readiness wait and no longer prints the config.

## Load-bearing decisions

- **`server.id` is the trigger** because a new server is what mints new credentials. The k3s installer preserves `/var/lib/rancher/k3s`, so the cluster CA survives any number of reinstalls on the same box. This is the answer to the objection the old code documented ("a read whose trigger had not changed kept serving the old CA") — that drift needs the data dir to go away, which needs a new box.
- **`"kubeconfig-v1"` in the triggers** is the lever for a rotation that happens some other way (`k3s certificate rotate-ca`, a manual uninstall). Bumping it re-reads, and the cascade that follows is then the real thing.
- **`additionalSecretOutputs` stays on the installer** even though its stdout no longer carries the config: state still holds the pre-split value, and dropping the option would write it back in the clear.
- **Two changes still legitimately replace the provider** and both mean the credentials genuinely moved: replacing the server, and switching `apiHost` between the tailnet name and the public IP. That is inherent — the endpoint is *in* the kubeconfig.
- The host rewrite and the `default` → cluster-name rename came out into `renderKubeconfig`, which is now unit tested — including the anchoring that previously renamed five of six entries. The `slice(indexOf("apiVersion:"))` went with the installer preamble it existed for; it would have returned the last character on a miss.

## How this landed

The transition needed the read to exist in state before the provider's input
switched to it, or the provider's `kubeconfig` is unknown at plan time and the
preview cannot tell a credential change from a no-op.

**A targeted update cannot carry a provider change.** `pulumi up --target
'**k3s-kubeconfig**'` against the merged code fails: the new read makes the
provider diff, and every resource outside the target set — cilium first — then
has no registered provider (`has not been registered yet, this is due to a
change of providers mixed with --target`).

What worked was to stage the read while the provider still pointed at the old
value. Locally, and never committed, `kubeconfig` was derived from
`install.stdout` again (with the `slice(indexOf("apiVersion:"))` the stored
value carries), which reproduces exactly what state already held. The read is
then unconsumed, so the targeted apply creates it and nothing else:

```
pulumi up --target '**k3s-kubeconfig**'   # + k3s-kubeconfig, no provider row
git checkout packages/hetzner/src/k3s.ts  # drop the local edit
pulumi preview
```

That preview came back with the provider absent from the plan entirely — 2
updates, 143 unchanged. The value computed from `read.stdout` is byte-identical
to what the installer's stdout produced, which is the property the whole change
rests on, now demonstrated rather than asserted.

The same staging applies to any future change that moves the provider's
configuration for a reason other than the credentials.
## Verify

- `mise run check` — lint, format, typecheck, 128 tests including the three new ones in `packages/hetzner/src/k3s.test.ts`
- The real check is the preview after the targeted apply: a clean plan means the provider's configuration no longer moves for reasons unrelated to the credentials
