### PR TITLE
239 feat(tailnet): bring the live policy under version control

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,22 +316,49 @@ gateway. The gateway is a tailnet member so it can relay `100.x` over the
 tunnel, so whatever it may reach, a bug in Xray or Hysteria may also reach —
 grants contain that class of bug regardless of which layer above them is wrong.
 
+Since #238 the tailnet also carries **pod traffic between nodes** — Cilium
+addresses both nodes by tailnet IP because the home node is behind NAT. So the
+policy is not a convenience path beside the cluster, it is the cluster's
+dataplane, and that constraint is invisible from the admin console. It is the
+sharper half of the argument for the policy living next to the code: a grant
+that fails to permit the node pair does not degrade access, it **partitions the
+cluster** — pods keep reporting healthy while traffic goes nowhere.
+
 Managing it here is opt-in and cannot clobber an existing policy: the provider
 refuses to modify a policy file it has not imported. Bringing it under Pulumi:
 
 1. **Create the OAuth client.** Admin console → *Settings* → *OAuth clients* →
-   *Generate OAuth client*. Tick **`policy_file`** with **write** access (read
-   alone lets Pulumi import but not apply). Nothing else is needed. The secret
-   is shown once — copy it there and then. Free on the Personal plan.
-2. **Set the secrets.** `gh secret set TS_OAUTH_CLIENT_ID`,
-   `gh secret set TS_OAUTH_CLIENT_SECRET`, and `gh secret set TS_TAILNET` —
-   the tailnet name is the one in the admin console's top-left switcher
-   (e.g. `example.com` or `tail1234.ts.net`), not the org display name.
+   *Generate OAuth client*. Tick **Policy File** with **write** access (read
+   alone lets Pulumi import but not apply). No tags — those are only required
+   for scopes that mint devices or keys. The secret is shown once, so copy it
+   there and then. Free on the Personal plan.
+2. **Put it in stack config**, not GitHub secrets — the deploy reads nothing
+   from the environment:
+
+   ```sh
+   pulumi config set --path tailnet.oauth.clientId     <client-id>
+   pulumi config set --path tailnet.oauth.clientSecret <secret> --secret
+   ```
+
+   Leave `tailnet.name` unset for now. `main.ts` constructs the resource only
+   when both are present, so the credential sits inert until the policy file is
+   ready to import — which is what keeps steps 2 and 3 from having to land in
+   the same breath.
 3. Copy the tailnet's **current** policy into
    `packages/infra/tailnet-policy.hujson`, replacing the placeholder. Bring what
-   exists under version control before changing anything.
-4. Import it so Pulumi adopts the existing policy rather than replacing it:
-   `pulumi import tailscale:index/acl:Acl tailnet-policy acl`
+   exists under version control before changing anything. Then set the tailnet
+   name — the one in the admin console's top-left switcher (e.g. `example.com`
+   or `tail1234.ts.net`), not the org display name:
+   `pulumi config set --path tailnet.name <tailnet>`
+4. Import it so Pulumi adopts the existing policy rather than replacing it. Add
+   `import: "acl"` to the resource's options in `tailnet-policy.ts`, run
+   `pulumi up`, then remove the line. Pulumi refuses the import if the file and
+   the live policy differ, so a mistranscribed policy fails loudly instead of
+   overwriting the real one — which is also the cheapest way to diff them.
+
+   The bare CLI form (`pulumi import tailscale:index/acl:Acl tailnet-policy
+   acl`) needs `--provider`, since the resource is built with an explicit
+   provider and the default one holds no credentials.
 5. Only now start tightening. This is where the value is, and it has its own
    order — the gateway currently joins as `tag:server`, shared with every other
    server, so no grant can single it out:
@@ -339,15 +366,26 @@ refuses to modify a policy file it has not imported. Bringing it under Pulumi:
    1. Uncomment `tag:gateway` in `tagOwners` and deploy. **A node cannot
       advertise a tag the policy does not define**, so this must land first or
       the gateway drops off the tailnet on its next `tailscale up`.
-   2. Mint a new auth key that is authorised for `tag:gateway` (admin console →
-      *Keys* → *Generate auth key* → set the tag) and replace `tailnet.authKey`. The
-      existing key can only assign the tags it was created with, so reusing it
-      cannot work.
-   3. Set `gateway.tailnet.tag` to `tag:gateway` and deploy. The node
-      re-registers with the new tag.
-   4. Write grants naming what the tunnel is actually used to reach.
+   2. Generate a **second OAuth client**, `auth_keys` scope, tagged
+      `tag:gateway`, and replace `tailnet.authKey` with its secret. A client can
+      only mint keys for the tags it was created with, so reusing the existing
+      one cannot work. Not a raw auth key from *Keys* → *Generate auth key*:
+      those cap at 90 days, and the expiry drops the gateway off the tailnet —
+      see [Secrets](#secrets).
+   3. Extend whatever grants currently reach the node via `tag:server` to cover
+      `tag:gateway` **before** setting `gateway.tailnet.tag`. The node
+      re-registers under the new tag on deploy, and stops matching the old one
+      the moment it does — including the grant carrying pod traffic.
+   4. Write grants naming what the tunnel is actually used to reach, and a
+      top-level `tests` block asserting it. The provider validates `tests`
+      against the policy before it applies anything, so an assertion that
+      `sympathy` still reaches `lady` on the cluster ports turns a partition
+      into a failed `pulumi up`. Without it nothing checks the dataplane until
+      pods start timing out.
 
-Step 5.4 is the trap: the gateway is a *relay*, so whatever it cannot reach,
-**you** cannot reach over the VPN either. The question is not how locked down it
-can be, but what you actually use the tailnet for. Getting it wrong locks you out of your own mesh, and a bad policy is
-recoverable only from the admin console, which is no fun from a train.
+Step 5.4 is the trap, in two directions. The gateway is a *relay*, so whatever
+it cannot reach, **you** cannot reach over the VPN either — the question is not
+how locked down it can be, but what you actually use the tailnet for. And the
+node pair carries pod traffic, so a grant that omits it takes out the cluster
+rather than your convenience. Both are recoverable only from the admin console,
+which is no fun from a train.

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -457,5 +457,9 @@ config:
     authKey:
       secure: AAABAFdTxr5vrl04OjZGpzGrBywrhs6it+Dk/4ehhFth1gje1gho8PoXoYSt77fAQuWcfStdTtnP3yv7nVxNCqQOJMw9kL7pEJY08cPWAsWEr//mfbnSC/2Ap4IMsAw=
     magicdnsSuffix: zonkey-jazz.ts.net
+    oauth:
+      clientId: kwGpaNTK9Y11CNTRL
+      clientSecret:
+        secure: AAABAGhrgFsFYiXNK3QDi18u9DbNtR/bd39xzOW+IkgvlQZHDoGnpD8325akS306yfV4DsZKTVoUnRCIEhTJfgaDM0KSuzgFABAKTxC5MpHPA6t6c2wzSkjhKI3YWfg=
   jaritanet:vpnUsers:
     secure: AAABACurdilg/HdFEY83oVFyPGyDRfbtDKWALsVqW/yTckjv6qBDJqEc

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -461,5 +461,6 @@ config:
       clientId: kwGpaNTK9Y11CNTRL
       clientSecret:
         secure: AAABAGhrgFsFYiXNK3QDi18u9DbNtR/bd39xzOW+IkgvlQZHDoGnpD8325akS306yfV4DsZKTVoUnRCIEhTJfgaDM0KSuzgFABAKTxC5MpHPA6t6c2wzSkjhKI3YWfg=
+    name: zonkey-jazz.ts.net
   jaritanet:vpnUsers:
     secure: AAABACurdilg/HdFEY83oVFyPGyDRfbtDKWALsVqW/yTckjv6qBDJqEc

--- a/packages/infra/src/tailnet-policy.ts
+++ b/packages/infra/src/tailnet-policy.ts
@@ -14,6 +14,12 @@ import type * as pulumi from "@pulumi/pulumi";
  * grant limiting what the gateway can talk to would have contained it without
  * anyone noticing the bug.
  *
+ * It cuts the other way too, which the containment argument alone misses: since
+ * #238 Cilium addresses both nodes by tailnet IP, so this policy carries pod
+ * traffic between them. A grant that omits the node pair does not degrade
+ * access, it partitions the cluster — and that constraint is invisible from the
+ * admin console, which is the sharper reason for the policy to live here.
+ *
  * The policy is a file rather than a JS object because HuJSON keeps comments,
  * and a policy whose reasoning is stripped out is a policy nobody dares edit.
  *

--- a/packages/infra/tailnet-policy.hujson
+++ b/packages/infra/tailnet-policy.hujson
@@ -17,6 +17,13 @@
 // whatever it cannot reach, you cannot reach over the VPN either. The right
 // question is not "how locked down can this be" but "what do I actually use the
 // tunnel to reach" — likely the home node on a handful of ports.
+//
+// The second catch is worse, because it does not look like an access problem.
+// Since #238 Cilium addresses both nodes by tailnet IP, so node-to-node pod
+// traffic rides this policy. A grant that omits the pair partitions the cluster
+// while every pod still reports healthy. Assert the pair in a top-level `tests`
+// block — the provider validates it before applying, so that failure arrives as
+// a failed `pulumi up` rather than as services timing out.
 {
 	"tagOwners": {
 		// The gateway wants its own tag. It currently joins as tag:server, which

--- a/packages/infra/tailnet-policy.hujson
+++ b/packages/infra/tailnet-policy.hujson
@@ -1,45 +1,90 @@
-// Tailnet policy file (HuJSON — comments are preserved when applied).
-//
-// NOT YET LIVE. This is a starting point, not the current policy. The Pulumi
-// resource refuses to touch a policy it has not imported, so nothing here
-// applies until someone runs the import in the README. Before that import,
-// replace everything below with the tailnet's *current* policy — the point is
-// to bring what exists under version control first and tighten afterwards, not
-// to swap a working policy for a guess.
-//
-// Why this is worth doing: the gateway is a tailnet member so it can relay
-// 100.x over the VPN tunnel. Anything it can reach, a bug in Xray or Hysteria
-// can also reach — see #162, where guest rules that looked like they blocked
-// the tailnet did not. Grants here are what contains that class of bug, and
-// they hold regardless of which layer above them is wrong.
-//
-// The catch worth understanding before tightening: the gateway is a *relay*, so
-// whatever it cannot reach, you cannot reach over the VPN either. The right
-// question is not "how locked down can this be" but "what do I actually use the
-// tunnel to reach" — likely the home node on a handful of ports.
-//
-// The second catch is worse, because it does not look like an access problem.
-// Since #238 Cilium addresses both nodes by tailnet IP, so node-to-node pod
-// traffic rides this policy. A grant that omits the pair partitions the cluster
-// while every pod still reports healthy. Assert the pair in a top-level `tests`
-// block — the provider validates it before applying, so that failure arrives as
-// a failed `pulumi up` rather than as services timing out.
+// Example/default ACLs for unrestricted connections.
 {
-	"tagOwners": {
-		// The gateway wants its own tag. It currently joins as tag:server, which
-		// it shares with every other server, so no grant can distinguish it.
-		// Give it one here first — a node cannot advertise a tag the policy does
-		// not define — then set gateway.tailnet.tag to match.
-		// "tag:gateway": ["autogroup:admin"],
-	},
+	// Declare static groups of users. Use autogroups for all users or users with a specific role.
+	// "groups": {
+	//  	"group:example": ["alice@example.com", "bob@example.com"],
+	// },
 
-	"grants": [
-		// Placeholder mirroring Tailscale's default: everything reaches
-		// everything. Replace with the imported policy, then narrow.
+	// Define the tags which can be applied to devices and by which users.
+	// "tagOwners": {
+	//  	"tag:example": ["autogroup:admin"],
+	// },
+
+	// Define access control lists for users, groups, autogroups, tags,
+	// Tailscale IP addresses, and subnet ranges.
+	"acls": [
+		// Allow all connections.
+		// Comment this section out if you want to define specific restrictions.
+		{"action": "accept", "src": ["*"], "dst": ["*:*"]},
+
+		// Allow users in "group:example" to access "tag:example", but only from
+		// devices that are running macOS and have enabled Tailscale client auto-updating.
+		// {"action": "accept", "src": ["group:example"], "dst": ["tag:example:*"], "srcPosture":["posture:autoUpdateMac"]},
+	],
+
+	// Define postures that will be applied to all rules without any specific
+	// srcPosture definition.
+	// "defaultSrcPosture": [
+	//      "posture:anyMac",
+	// ],
+
+	// Define device posture rules requiring devices to meet
+	// certain criteria to access parts of your system.
+	// "postures": {
+	//      // Require devices running macOS, a stable Tailscale
+	//      // version and auto update enabled for Tailscale.
+	// 	"posture:autoUpdateMac": [
+	// 	    "node:os == 'macos'",
+	// 	    "node:tsReleaseTrack == 'stable'",
+	// 	    "node:tsAutoUpdate",
+	// 	],
+	//      // Require devices running macOS and a stable
+	//      // Tailscale version.
+	// 	"posture:anyMac": [
+	// 	    "node:os == 'macos'",
+	// 	    "node:tsReleaseTrack == 'stable'",
+	// 	],
+	// },
+
+	// Define users and devices that can use Tailscale SSH.
+	"ssh": [
+		// Allow all users to SSH into their own devices in check mode.
+		// Comment this section out if you want to define specific restrictions.
 		{
-			"src": ["*"],
-			"dst": ["*"],
-			"ip":  ["*"],
+			"action": "check",
+			"src":    ["autogroup:member"],
+			"dst":    ["autogroup:self"],
+			"users":  ["autogroup:nonroot", "root"],
 		},
 	],
+	"nodeAttrs": [
+		{"target": ["100.120.110.113"], "attr": ["mullvad"]},
+		{"target": ["100.81.66.75"], "attr": ["mullvad"]},
+		{"target": ["100.69.92.89"], "attr": ["mullvad"]},
+		{"target": ["100.125.129.11"], "attr": ["mullvad"]},
+		{
+			// Funnel policy, which lets tailnet members control Funnel
+			// for their own devices.
+			// Learn more at https://tailscale.com/kb/1223/tailscale-funnel/
+			"target": ["autogroup:member"],
+			"attr":   ["funnel"],
+		},
+		{"target": ["100.124.42.33"], "attr": ["mullvad"]},
+		{"target": ["100.90.106.88"], "attr": ["mullvad"]},
+		{"target": ["100.86.209.52"], "attr": ["mullvad"]},
+	],
+
+	// Test access rules every time they're saved.
+	// "tests": [
+	//  	{
+	//  		"src": "alice@example.com",
+	//  		"accept": ["tag:example"],
+	//  		"deny": ["100.101.102.103:443"],
+	//  	},
+	// ],
+	// "{
+	"tagOwners": {
+		"tag:server": ["jc@blit.cc"],
+		"tag:ci":     ["jc@blit.cc"],
+	},
 }


### PR DESCRIPTION
Closes #239.

The tailnet policy is now managed by Pulumi. **It is already imported** — the
adoption was done locally before this PR went up, because it had to be.

## Why the import had to precede the merge

Merging deploys. With `tailnet.name` and `tailnet.oauth` in config, `main.ts:176`
constructs the `Acl`, and a resource that Pulumi has not imported cannot be
created while `overwriteExistingContent` is false — the provider refuses. Merging
first would have turned main red until someone imported by hand, which CI cannot
do. So the order was import, then merge; that refusal is the safety property
working, not an obstacle.

Done and verified:

- `pulumi up --target` on the Acl alone — `+ 1 created` (the provider),
  `= 1 imported`, 145 unchanged. Targeted so the unrelated pending
  `singbox-notify` update stayed put rather than Telegramming every VPN user.
- The live policy hashes `8e862870…` before and after. **No rule changed.**
- Preview with the import option removed shows the Acl absent from the plan.
  What is left is the same `singbox-notify` diff that predates this branch.

## What is actually under version control

Tailscale's stock default, fetched from the API and committed byte-exact:
`tagOwners` for `tag:server` and `tag:ci`, the `mullvad`/`funnel` `nodeAttrs`,
`check`-mode SSH, and one `accept src:* dst:*:*`.

So — plainly — **the containment argument in #239 does not hold yet.** The
gateway can reach everything on the tailnet today. This PR buys version control
and a reviewable diff, not security. The allow-all is also why node-to-node pod
traffic currently works.

Byte-exact was a requirement rather than a preference: the provider compares the
entire HuJSON string, comments included, so the placeholder's explanatory header
could not survive the import. Annotating the policy is an ordinary edit now that
it is managed. Its reasoning lives in `tailnet-policy.ts` and the README
meanwhile.

## The docs were not followable

Fixing them was most of the work, and two steps were harmful on the path they
described:

- Credentials were routed to GitHub secrets, which the deploy no longer reads.
- The import command resolved the default provider, which holds no credentials.
- Minting a raw auth key for `tag:gateway` reintroduces the 90-day expiry the
  OAuth client exists to avoid; the expiry drops the gateway off the tailnet.
- Switching `gateway.tailnet.tag` before extending grants moves the node out of
  `tag:server` the moment it re-registers.

Post-#238 the last two take out pod traffic rather than merely access — Cilium
addresses both nodes by tailnet IP, so this policy is the cluster's dataplane. A
grant omitting the node pair partitions the cluster while pods report healthy.
That direction appeared in none of the existing comments and is invisible from
the admin console, which is the sharper argument for the policy living here.

The mitigation is native: a top-level `tests` block is validated by the provider
*before* every create and update, so an assertion that `sympathy` reaches `lady`
turns a partitioning grant into a failed `pulumi up`. Step 5.4 now says so.

## Verifying

`mise run check` is green (128 tests, clean typecheck). The substance is prose
and a policy file — read them. The claims about no-diff and unchanged rules are
the preview and hash output above, reproducible with `pulumi preview`.

## Follow-ups, deliberately not here

Tightening grants and the `tag:gateway` switch, per #239: version control first,
tightening as its own act with its own reasoning. Six of the seven `mullvad`
`nodeAttrs` target IPs matching no current node — stale pins worth a look, but
not something a verbatim import gets to change.