### PR TITLE
fix(mariastew): use colon syntax for data-on so Datastar binds it

### DIFF
--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -314,4 +314,83 @@ mod tests {
             ("progress-info", "paused")
         );
     }
+
+    /// Datastar v1.0.2's generic `on` plugin splits the attribute suffix on
+    /// `:` to get the event name (`data-on:click`) — a dash (`data-on-click`)
+    /// resolves to a plugin named `on-click`, which does not exist, and the
+    /// attribute is dropped without an error. Every click handler on the page
+    /// silently did nothing until this was `:`. This test pins the syntax so
+    /// it cannot regress one attribute at a time.
+    #[test]
+    fn add_download_button_uses_colon_syntax_datastar_actually_matches() {
+        let page = Page {
+            roots: vec![],
+            rows: vec![],
+        }
+        .render()
+        .unwrap();
+        assert!(
+            page.contains(r#"data-on:click="document.getElementById('add-dialog').showModal()""#),
+            "add-dialog button markup: {page}"
+        );
+        assert!(
+            !page.contains("data-on-"),
+            "a dash-form data-on- attribute survived and will be silently ignored: {page}"
+        );
+    }
+
+    #[test]
+    fn add_dialog_opens_as_a_native_modal_over_the_open_state() {
+        let page = Page {
+            roots: vec![],
+            rows: vec![],
+        }
+        .render()
+        .unwrap();
+        assert!(
+            page.contains(r#"id="add-dialog""#) && page.contains("open:flex"),
+            "dialog is not styled to appear once the browser sets [open]: {page}"
+        );
+    }
+
+    #[test]
+    fn browse_and_download_row_actions_all_use_colon_syntax() {
+        let page = Downloads {
+            rows: vec![Row {
+                gid: "abc".into(),
+                name: "test.iso".into(),
+                percent: Some(50.0),
+                percent_display: Some("50".into()),
+                health: Health::Moving,
+                bar_class: "progress-success",
+                state: "moving",
+                down: "1.00 MiB/s".into(),
+                up: "0 B/s".into(),
+                size: "1.00 GiB".into(),
+                done: "512 MiB".into(),
+                connections: 1,
+                seeders: 1,
+                error: None,
+                finished: false,
+                paused: false,
+            }],
+        }
+        .render()
+        .unwrap();
+        assert!(page.contains(r#"data-on:click="@post('/downloads/abc/pause')""#));
+        assert!(!page.contains("data-on-"));
+
+        let browse = Browse {
+            parent: Some("/mnt/tv".into()),
+            path: "/mnt/tv/show".into(),
+            dirs: vec![DirView {
+                name: "season 1".into(),
+                path: "/mnt/tv/show/season 1".into(),
+            }],
+        }
+        .render()
+        .unwrap();
+        assert!(browse.contains("data-on:click"));
+        assert!(!browse.contains("data-on-"));
+    }
 }

--- a/apps/mariastew/templates/browse.html
+++ b/apps/mariastew/templates/browse.html
@@ -2,14 +2,14 @@
   <div class="flex items-center gap-2 text-sm">
     {% if let Some(p) = parent %}
     <button type="button" class="btn btn-xs btn-ghost"
-      data-on-click="@get('{{ crate::views::browse_href(p) }}')">↑ Up</button>
+      data-on:click="@get('{{ crate::views::browse_href(p) }}')">↑ Up</button>
     {% endif %}
     <span class="font-mono truncate opacity-70">{{ path }}</span>
   </div>
 
   <ul class="menu menu-sm bg-base-200 rounded-box">
     {% for d in dirs %}
-    <li><a data-on-click="@get('{{ crate::views::browse_href(d.path.as_str()) }}')">{{ d.name }}</a></li>
+    <li><a data-on:click="@get('{{ crate::views::browse_href(d.path.as_str()) }}')">{{ d.name }}</a></li>
     {% endfor %}
   </ul>
 
@@ -17,7 +17,7 @@
     <input type="hidden" name="parent" value="{{ path }}">
     <input name="name" placeholder="New folder name" class="input input-bordered input-sm flex-1">
     <button type="button" class="btn btn-sm"
-      data-on-click="@post('/mkdir', {contentType: 'form'})">Create</button>
+      data-on:click="@post('/mkdir', {contentType: 'form'})">Create</button>
   </div>
 
   <input type="hidden" name="dir" value="{{ path }}">

--- a/apps/mariastew/templates/downloads.html
+++ b/apps/mariastew/templates/downloads.html
@@ -26,17 +26,17 @@
       <div class="flex gap-2">
         {% if row.paused %}
         <button type="button" class="btn btn-xs"
-          data-on-click="@post('/downloads/{{ row.gid }}/resume')">Resume</button>
+          data-on:click="@post('/downloads/{{ row.gid }}/resume')">Resume</button>
         {% else %}
         <button type="button" class="btn btn-xs"
-          data-on-click="@post('/downloads/{{ row.gid }}/pause')">Pause</button>
+          data-on:click="@post('/downloads/{{ row.gid }}/pause')">Pause</button>
         {% endif %}
         {% if row.finished %}
         <button type="button" class="btn btn-xs btn-ghost"
-          data-on-click="@post('/downloads/{{ row.gid }}/remove')">Stop seeding</button>
+          data-on:click="@post('/downloads/{{ row.gid }}/remove')">Stop seeding</button>
         {% else %}
         <button type="button" class="btn btn-xs btn-error"
-          data-on-click="@post('/downloads/{{ row.gid }}/remove')">Delete download</button>
+          data-on:click="@post('/downloads/{{ row.gid }}/remove')">Delete download</button>
         {% endif %}
       </div>
     </div>

--- a/apps/mariastew/templates/page.html
+++ b/apps/mariastew/templates/page.html
@@ -12,7 +12,7 @@
 <header class="navbar bg-base-100 shadow-sm px-4">
   <h1 class="flex-1 text-lg font-semibold">mariastew</h1>
   <button type="button" class="btn btn-primary btn-sm"
-    data-on-click="document.getElementById('add-dialog').showModal()">Add download</button>
+    data-on:click="document.getElementById('add-dialog').showModal()">Add download</button>
 </header>
 
 <dialog id="add-dialog" class="open:flex flex-col gap-4 rounded-box bg-base-100 p-6 shadow-xl backdrop:bg-black/50 max-w-sm w-full">
@@ -21,7 +21,7 @@
     <input name="magnet" required placeholder="magnet:?xt=..." class="input input-bordered w-full">
     {{ self.picker()?|safe }}
     <button type="button" class="btn btn-primary"
-      data-on-click="@post('/add', {contentType: 'form'})">Add</button>
+      data-on:click="@post('/add', {contentType: 'form'})">Add</button>
   </form>
   <form method="dialog">
     <button class="btn btn-ghost btn-sm">Cancel</button>


### PR DESCRIPTION
Nothing on the page responded to a tap. Every button was inert — add, pause, resume, remove, the directory picker and mkdir.

## Cause

Datastar v1.0 takes its attribute key after a **colon**: `data-on:click`. The templates were written with `data-on-click`, which is the pre-1.0 form. Datastar reads everything after `data-`, fails to resolve `on-click` to a plugin, and silently ignores the attribute — no console error, no visual difference, just an element that does nothing.

Confirmed against the vendored bundle and by code search in `starfederation/datastar` at `v1.0.2`: `data-on-click` appears **0** times, `data-on:click` appears in the repo's own usage.

All nine instances used the wrong form, which is why the whole page was dead rather than one control.

`data-init="@get('/stream')"` was unaffected — it takes no key, so there is no colon to omit, which is why live progress worked while nothing could be clicked.

## Verification

`cargo test` covers the rendered markup now, so a regression to the hyphen form fails the build rather than shipping a page where nothing responds. 66 tests pass; clippy clean; `mise run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs7qxMHbC1WyagqYLDMxHQ