### PR TITLE
feat(mariastew): docker compose for local development

### DIFF
--- a/apps/mariastew/.gitignore
+++ b/apps/mariastew/.gitignore
@@ -1,0 +1,4 @@
+# docker-compose's bind mount for local aria2 downloads — real content, not
+# fixtures, so only the directory itself is tracked.
+dev-data/downloads/*
+!dev-data/downloads/.gitkeep

--- a/apps/mariastew/Dockerfile.dev
+++ b/apps/mariastew/Dockerfile.dev
@@ -1,0 +1,40 @@
+# Dev-only image for docker-compose. A debug build, deliberately: /auth/dev-login
+# (src/auth/routes.rs) is gated on #[cfg(debug_assertions)], which `cargo build
+# --release` — what the production Dockerfile runs — never sets. Kept as a
+# separate file rather than a build arg on the real Dockerfile so a mistake here
+# can never change what CI ships.
+FROM rust:1.97-alpine AS build
+
+RUN apk add --no-cache musl-dev
+WORKDIR /src
+
+# Same dependency-caching trick as the production Dockerfile: compile once
+# against a stub main so only a source change invalidates the layer below.
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
+    cargo build --locked && \
+    rm -rf src
+
+COPY src ./src
+COPY templates ./templates
+COPY assets ./assets
+# Cargo would otherwise reuse the stub's artefact — same crate, and the only
+# newer input is a path it has already built.
+RUN touch src/main.rs && cargo build --locked
+
+# alpine, not scratch, for the same reason as the production image: compose
+# runs this image as both containers (see docker-compose.yml), so it has to
+# carry aria2c, and reqwest's rustls-platform-verifier needs the system trust
+# store even for the Rust binary alone.
+FROM alpine:3.24
+
+RUN apk add --no-cache aria2 ca-certificates
+
+COPY --from=build /src/target/debug/mariastew /mariastew
+
+EXPOSE 8080
+ENV BIND_ADDR=0.0.0.0:8080
+
+USER 1000:1000
+
+ENTRYPOINT ["/mariastew"]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -183,6 +183,45 @@ empty download list and a banner saying so — rather than a 500; `/add`,
 asking aria2 to do something. Point `ARIA2_RPC_URL` at a real instance to see
 downloads move.
 
+### docker compose, if you want aria2 too
+
+`docker compose up --build` (or `mise run mariastew:dev` from the repo root)
+brings up the full flow — mariastew and a real aria2c — with one command:
+
+```sh
+cd apps/mariastew
+docker compose up --build
+```
+
+Then visit `http://localhost:8080/auth/dev-login`. Downloads land in
+`apps/mariastew/dev-data/downloads/` on the host, bind-mounted into both
+containers at `/downloads`, and `ROOTS` is preset to point at it. `docker
+compose down` stops and removes both containers and the network; the
+downloads directory is yours and is left alone.
+
+This mirrors "One image, run twice" above rather than inventing a second
+image: `docker-compose.yml` builds one image and runs it as both services,
+overriding the aria2 container's entrypoint to run `aria2c` with the same
+`--enable-rpc --rpc-listen-all=false --rpc-listen-port=6800` the production
+pod uses. Because that flag binds the RPC port to loopback only, the aria2
+service joins mariastew's network namespace
+(`network_mode: "service:mariastew"`) instead of talking to it over a
+compose bridge network — the same shared-netns relationship the pod gives
+the two containers for free.
+
+The image is built from `Dockerfile.dev`, not the production `Dockerfile`:
+same two-stage layout and dependency-caching trick, but a debug build, so
+`/auth/dev-login` is actually compiled in. The production Dockerfile is
+untouched and still `--release` — nothing here can affect what CI ships.
+
+**Iteration loop:** `docker compose up --build` again after a source change.
+The dependency-caching trick means only the final `cargo build` layer
+reruns — a few seconds for a small change to `src/`, not a from-scratch
+compile. A template change needs the same rebuild, for the reason above
+("compiled into the binary by Askama") — there is no hot reload for
+templates or the stylesheet; run `mise run css` first if a template edit
+touched a class, then rebuild the image.
+
 ## Rebuilding the stylesheet
 
 The stylesheet is generated with Tailwind + DaisyUI but the *output*

--- a/apps/mariastew/docker-compose.yml
+++ b/apps/mariastew/docker-compose.yml
@@ -1,0 +1,55 @@
+# One-command local dev loop: `docker compose up --build`, then
+# http://localhost:8080/auth/dev-login. See README's "Local development" for
+# what dev-login does and does not need, and Dockerfile.dev for why this
+# builds a debug binary rather than reusing the production Dockerfile.
+services:
+  # Owns the shared network namespace and the published port, mirroring the
+  # pod: one image, two containers, aria2's RPC reachable only from
+  # 127.0.0.1 inside it. aria2 below joins this network rather than getting
+  # its own, so `ARIA2_RPC_URL`'s 127.0.0.1 is the same loopback for both.
+  mariastew:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    image: mariastew-dev
+    ports:
+      - "8080:8080"
+    environment:
+      ROOTS: "downloads:/downloads"
+      PUBLIC_URL: "http://localhost:8080"
+      ARIA2_RPC_URL: "http://127.0.0.1:6800/jsonrpc"
+      # Never actually reached: /auth/dev-login mints a session without
+      # touching Hydra. Config::from_env still requires all three to be set.
+      OIDC_ISSUER: "https://dev.invalid"
+      OIDC_CLIENT_ID: "dev"
+      OIDC_CLIENT_SECRET: "dev"
+      RUST_LOG: "info,mariastew=debug"
+    volumes:
+      - ./dev-data/downloads:/downloads
+
+  # Same image, run as aria2c instead of mariastew — see "One image, run
+  # twice" in the README. `--rpc-listen-all=false` binds the RPC port to
+  # loopback only, which is why this has to share mariastew's network
+  # namespace rather than talk to it over a compose bridge network.
+  aria2:
+    image: mariastew-dev
+    depends_on:
+      - mariastew
+    network_mode: "service:mariastew"
+    entrypoint:
+      - /usr/bin/aria2c
+      - --enable-rpc
+      - --rpc-listen-all=false
+      - --rpc-listen-port=6800
+      - --dir=/downloads
+      - --continue=true
+      - --check-integrity=true
+      # Nothing is preallocated, so a file the filter rejected never touches
+      # disk — see "Why files land straight in the library" in the README.
+      - --file-allocation=none
+      - --seed-ratio=0.0
+      - --enable-dht=true
+      - --bt-enable-lpd=true
+      - --enable-peer-exchange=true
+    volumes:
+      - ./dev-data/downloads:/downloads

--- a/mise.toml
+++ b/mise.toml
@@ -66,6 +66,11 @@ run = "./node_modules/.bin/tailwindcss -i styles/app.css -o assets/app.css --min
 description = "Validate every profile shape against the real sing-box binary (needs docker)"
 run = "./scripts/check-profiles.ts"
 
+[tasks."mariastew:dev"]
+description = "Run mariastew + aria2 locally against a debug build (needs docker)"
+dir = "apps/mariastew"
+run = "docker compose up --build"
+
 [tasks."update:apps"]
 description = "Report or apply upstream version bumps"
 run = "./packages/infra/src/update-apps.ts"


### PR DESCRIPTION
Run the whole thing locally — service and aria2 — without deploying:

```
cd apps/mariastew && docker compose up --build
```
then open http://localhost:8080/auth/dev-login.

## Decisions

**A separate `Dockerfile.dev` rather than a build argument on the real one.** The production Dockerfile is what CI publishes; a mistake in a dev-only flag on it would ship. This way there is nothing to get wrong. It uses the same stub-main dependency caching, just without `--release` — which is also what makes `/auth/dev-login` exist at all, since that route is gated on `#[cfg(debug_assertions)]`.

**aria2 joins the service's network namespace** (`network_mode: "service:mariastew"`) rather than sitting on a bridge. That is the actual relationship the Kubernetes pod gives the two containers, and it is what keeps `--rpc-listen-all=false` meaningful: the RPC stays on a loopback nothing else can reach. Putting them on a bridge and opening the RPC up would have been a local setup that does not resemble the thing it is meant to reproduce.

**One image, run twice**, matching production — the aria2 service reuses the same build with its entrypoint overridden and the same flags the Pulumi module passes.

Roots are bind-mounted at the same path inside and out, mirroring the invariant in `config.rs` that a host path and its container path are the same string.

## The loop

Rebuild after a change: the dependency layer stays cached, so only the final compile reruns. There is no hot reload and the README says so — Askama compiles templates into the binary, and `assets/app.css` is a committed artefact, so a template change needs a rebuild and a class change needs `mise run css` first.

## Verification

Not just a page render — the full flow, with Debian 13.6.0 netinst's official torrent: `POST /add` returned 204, the download went from moving to complete (755MB), and `docker compose down` left no containers or networks behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs7qxMHbC1WyagqYLDMxHQ