### PR TITLE
fix(hetzner): route tailnet destinations before tailscale's mark-bypass rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Components live in their own packages and know nothing about this deployment;
 
 - **`@jaritanet/k8s`** — Deployment/Service/PV/PVC templates and the primitives the others share (`ImageSchema`, `LimitsSchema`, `cpuRequests`, `sha256hex`)
 - **`@jaritanet/vpn`** — the transports: Xray VLESS-REALITY, Hysteria2, tailnet relay, `unbound`, ss-rust exits, and the sing-box profile builder. Each has a DaemonSet form and a `-systemd` form; the latter takes an SSH connection and opaque `dependsOn`, so it works on any reachable box rather than one cloud's server type
-- **`@jaritanet/hetzner`** — the VPS, its firewall rules, network tuning, k3s over SSH, Cilium as the CNI, and the upgrade Plans that carry the k3s version to nodes Pulumi cannot reach
+- **`@jaritanet/hetzner`** — the VPS, its firewall rules, network tuning, k3s over SSH, Cilium as the CNI, the tailnet-rule DaemonSet that keeps Cilium's identity marks from tripping tailscaled's bypass routing (see docs/architecture.md), and the upgrade Plans that carry the k3s version to nodes Pulumi cannot reach
 - **`@jaritanet/ingress`** — Traefik Helm chart, IngressRoute CRDs, and the redirect middleware
 - **`@jaritanet/dns`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
 - **`@jaritanet/mcp-gateway`** — OAuth-fronted gateway for self-hosted MCP servers (Hydra + Postgres)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -869,6 +869,21 @@ Live tradeoffs worth knowing, not necessarily bugs:
   change. Anything that talks to anything should be assumed broken until shown
   otherwise.
 
+- **Cilium's packet marks collide with tailscaled's routing rules, and the
+  collision selects victims by identity arithmetic.** Cilium stamps the
+  sender's security identity into skb mark bits 16–31 on overlay traffic;
+  Tailscale claims mark `0x80000/0xff0000` as "bypass table 52" and routes
+  matches via the main table — out the public interface. So a pod whose
+  identity is ≡ 8 (mod 256) has its cross-node VXLAN packets silently exit
+  eth0 toward CGNAT space: one pod unreachable between nodes while its
+  neighbours answer, appearing and disappearing as identity allocation
+  happens to land on a colliding value. CoreDNS drew identity 21000 (0x5208)
+  and cluster DNS died for every pod on the agent node. Neither side has a
+  knob, so `createTailnetRule` (a DaemonSet) holds an `ip rule` at pref 5209
+  — one before the bypass rules — sending 100.64.0.0/10 to the tailnet table
+  regardless of mark. If cross-node traffic to *one specific pod* ever
+  blackholes again, check that rule is present before anything else.
+
 - **hy2 uses adaptive congestion control (BBR) everywhere; Brutal is not
   offered.** Setting bandwidth hints switches Hysteria2 to Brutal, which paces
   to a fixed rate and ignores loss — it stomps through lossy censored *fat*

--- a/packages/hetzner/src/index.ts
+++ b/packages/hetzner/src/index.ts
@@ -3,6 +3,7 @@ export { CILIUM_K8S_SUPPORT, checkCiliumSupport } from "./compat.ts";
 export { createK3s } from "./k3s.ts";
 export { K3sConfSchema } from "./k3s.schemas.ts";
 export { createK3sUpgrades } from "./upgrades.ts";
+export { createTailnetRule } from "./tailnet-rule.ts";
 export {
   createAdminSshAccess,
   createAutomaticPatching,

--- a/packages/hetzner/src/tailnet-rule.ts
+++ b/packages/hetzner/src/tailnet-rule.ts
@@ -1,0 +1,76 @@
+import * as k8s from "@pulumi/kubernetes";
+import type * as pulumi from "@pulumi/pulumi";
+
+/**
+ * Routes tailnet-bound traffic to the tailnet regardless of packet mark.
+ *
+ * Cilium stamps the sender's security identity into skb mark bits 16-31 on
+ * traffic it hands to the overlay. Tailscale claims mark `0x80000/0xff0000`
+ * as "not mine, bypass table 52" and installs policy rules at pref 5210-5250
+ * that send matching packets to the main table — which routes them out the
+ * default interface. Any pod whose identity has `0x08` as its low byte
+ * (identity ≡ 8 mod 256) therefore has its VXLAN packets to the peer's
+ * tailnet address silently exit the public interface toward CGNAT space
+ * instead of the tunnel. It presents as one specific pod being unreachable
+ * across nodes while its neighbours answer, coming and going as identity
+ * allocation happens to land on a colliding value — CoreDNS held identity
+ * 21000 (0x5208) for days.
+ *
+ * Neither side has a knob: tailscaled's bypass mark is hardcoded, and
+ * Cilium's overlay mark (magic 0x400) carries the identity unconditionally —
+ * `enable-identity-mark: false` governs a different path and was measured to
+ * change nothing. So the fix is a routing rule at pref 5209, one before the
+ * bypass rules: destinations in 100.64.0.0/10 consult the tailnet table
+ * first, mark or no mark. tailscaled's own marked packets are unaffected —
+ * they go to peers' underlay addresses, never to 100.64/10.
+ *
+ * A DaemonSet because the rule must hold on every node and does not survive
+ * a reboot: each pod asserts it once a minute, which also restores it after
+ * tailscaled reinstalls its own rules. hostNetwork for the host's netns,
+ * NET_ADMIN and nothing else.
+ */
+export function createTailnetRule(
+  provider: k8s.Provider,
+  dependsOn: pulumi.Resource[] = [],
+) {
+  const app = "tailnet-rule";
+  return new k8s.apps.v1.DaemonSet(
+    app,
+    {
+      metadata: { name: app, namespace: "kube-system" },
+      spec: {
+        selector: { matchLabels: { app } },
+        template: {
+          metadata: { labels: { app } },
+          spec: {
+            hostNetwork: true,
+            dnsPolicy: "Default",
+            automountServiceAccountToken: false,
+            // Every node, including the control plane and anything cordoned:
+            // a node without the rule blackholes a slice of the pod network.
+            tolerations: [{ operator: "Exists" }],
+            containers: [
+              {
+                name: app,
+                image: "busybox:1.37",
+                command: [
+                  "sh",
+                  "-c",
+                  `while true; do ip rule list | grep -q '^5209:' || ip rule add pref 5209 to 100.64.0.0/10 lookup 52; sleep 60; done`,
+                ],
+                securityContext: {
+                  capabilities: { add: ["NET_ADMIN"], drop: ["ALL"] },
+                },
+                resources: {
+                  requests: { cpu: "5m", memory: "8Mi" },
+                  limits: { memory: "16Mi" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    { provider, dependsOn },
+  );
+}

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -3,7 +3,11 @@ import {
   createFastmailRecords,
   createServiceRecord,
 } from "@jaritanet/dns";
-import { createCilium, createK3sUpgrades } from "@jaritanet/hetzner";
+import {
+  createCilium,
+  createK3sUpgrades,
+  createTailnetRule,
+} from "@jaritanet/hetzner";
 import { createIngress, createRedirectMiddleware } from "@jaritanet/ingress";
 import {
   createExit,
@@ -235,6 +239,9 @@ export default async function () {
   // Deployment and stays Pending without one.
   if (gatewayConf?.k3s && cilium) {
     createK3sUpgrades(provider, gatewayConf.k3s, [cilium]);
+    // The pod network rides the tailnet between nodes, and Cilium's packet
+    // marks collide with tailscaled's routing rules — see createTailnetRule.
+    createTailnetRule(provider, [cilium]);
   }
 
   // Every resource below takes its namespace from this output rather than the


### PR DESCRIPTION
Fixes #274.

## What was wrong

Cilium stamps the sender's security identity into skb mark bits 16–31 on traffic it hands to the overlay (magic `0x400`, set unconditionally — `enable-identity-mark: false` governs a different path and was measured to change nothing). Tailscale claims mark `0x80000/0xff0000` as its "bypass table 52" mark, with policy rules at pref 5210–5250 routing matches via the main table.

So any pod whose identity ≡ 8 (mod 256) had its cross-node VXLAN packets routed **out eth0 toward CGNAT space** instead of into the tunnel. CoreDNS drew identity 21000 (`0x5208`, low byte `0x08`) and held it for days — cluster DNS dead for every pod on lady, while neighbouring pods on sympathy answered fine. Identity re-rolls on pod recreation are why it looked intermittent.

Caught red-handed with an nft log rule on sympathy:

```
VXMARK IN=cilium_vxlan OUT=eth0        DST=100.74.66.121 DPT=8472 MARK=0x52080400   <- coredns reply, blackholed
VXMARK IN=cilium_vxlan OUT=tailscale0  DST=100.74.66.121 DPT=8472 MARK=0x37bc0400   <- metrics-server reply, fine
```

The same mechanism explains the never-ready CoreDNS replica on lady (#274's second symptom): it carries the same identity 21000, so its own egress to the API server misrouted out lady's LAN default route.

## The fix

A `tailnet-rule` DaemonSet (kube-system, hostNetwork, NET_ADMIN only) asserts:

```
ip rule add pref 5209 to 100.64.0.0/10 lookup 52
```

one pref before tailscale's bypass rules — tailnet destinations consult the tailnet table regardless of mark. tailscaled's own marked packets are unaffected (they go to peers' underlay addresses, never 100.64/10). A DaemonSet because the rule must hold on every node and doesn't survive reboot; each pod re-asserts once a minute.

## Verification

Rule hand-applied to both nodes ahead of this PR: ping to the CoreDNS pod from lady went 100% loss → 4/4, and `nslookup github.com 10.43.0.10` resolves from a pod on lady. The DaemonSet landing via `pulumi up` converges the same state. Note the next `up` also reverts the live mcp-gateway control-plane pin (drift, not in git) — correct now that cross-node DNS works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnYwb2qEN9sLnwdSAsqrVo