### PR TITLE
feat(mariastew): seed the dev roots with a library that looks like the real one

### DIFF
--- a/apps/mariastew/.gitignore
+++ b/apps/mariastew/.gitignore
@@ -1,4 +1,3 @@
-# docker-compose's bind mount for local aria2 downloads — real content, not
-# fixtures, so only the directory itself is tracked.
-dev-data/downloads/*
-!dev-data/downloads/.gitkeep
+# docker-compose's bind-mounted roots: real downloads plus the directory
+# tree scripts/seed-dev-fixtures.ts generates. Neither belongs in git.
+dev-data/

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -185,19 +185,46 @@ downloads move.
 
 ### docker compose, if you want aria2 too
 
-`docker compose up --build` (or `mise run mariastew:dev` from the repo root)
-brings up the full flow — mariastew and a real aria2c — with one command:
+`mise run mariastew:dev` from the repo root seeds the fixture library (below)
+and brings up the full flow — mariastew and a real aria2c — with one command.
+Equivalently, by hand:
 
 ```sh
 cd apps/mariastew
+./scripts/seed-dev-fixtures.ts
 docker compose up --build
 ```
 
-Then visit `http://localhost:8080/auth/dev-login`. Downloads land in
-`apps/mariastew/dev-data/downloads/` on the host, bind-mounted into both
-containers at `/downloads`, and `ROOTS` is preset to point at it. `docker
-compose down` stops and removes both containers and the network; the
-downloads directory is yours and is left alone.
+Then visit `http://localhost:8080/auth/dev-login`. `ROOTS` is preset to
+`tv:/tv,movies:/movies`, both bind-mounted from `apps/mariastew/dev-data/`
+into both containers at the same path — real downloads land there
+alongside the fixtures. `docker compose down` stops and removes both
+containers and the network; `dev-data/` is yours and is left alone.
+
+#### Fixture library
+
+An empty picker cannot reproduce a layout bug — every one found so far only
+showed up because of what a real name does to the layout. `mise run
+mariastew:seed` (`scripts/seed-dev-fixtures.ts`) populates `dev-data/movies`
+with ~140 entries: a fixed set of real names from the owner's library, kept
+verbatim (full-width CJK brackets, runs of consecutive spaces, a leading
+`www.` prefix, square brackets, commas, names past 70 characters), padded
+out with deterministically generated filler so the picker's scroll cap is
+exercised against a realistic count rather than three tidy names. It also
+seeds `dev-data/tv` with a few shows carrying `Season 01`/`Season 02`
+children, plus `Show Name S02` and `Show.Name.Season.2` as two
+top-level entries — the same show named two different real ways, which is
+the exact case the destination picker exists to tell apart (#257).
+
+The filler is generated from a seeded PRNG, not `Math.random()`, so it is
+the same list on every machine and every run — a bug report against "the
+17th entry" stays reproducible. Re-running the seed script is a no-op for
+anything that already exists (`mkdir` with `recursive: true`), so it is
+safe to run again without disturbing whatever aria2 has since downloaded
+into the same directories. `mise run mariastew:seed:reset` (or
+`./scripts/seed-dev-fixtures.ts --reset`) wipes `dev-data/tv` and
+`dev-data/movies` first — the way back to a clean fixture-only state once a
+test download has piled up in there.
 
 This mirrors "One image, run twice" above rather than inventing a second
 image: `docker-compose.yml` builds one image and runs it as both services,

--- a/apps/mariastew/docker-compose.yml
+++ b/apps/mariastew/docker-compose.yml
@@ -1,7 +1,10 @@
-# One-command local dev loop: `docker compose up --build`, then
-# http://localhost:8080/auth/dev-login. See README's "Local development" for
-# what dev-login does and does not need, and Dockerfile.dev for why this
-# builds a debug binary rather than reusing the production Dockerfile.
+# One-command local dev loop: `mise run mariastew:seed` (or --reset) to
+# populate ../dev-data/{tv,movies} with names shaped like the owner's real
+# library, then `docker compose up --build`, then
+# http://localhost:8080/auth/dev-login. `mise run mariastew:dev` does both.
+# See README's "Local development" for what dev-login does and does not
+# need, and Dockerfile.dev for why this builds a debug binary rather than
+# reusing the production Dockerfile.
 services:
   # Owns the shared network namespace and the published port, mirroring the
   # pod: one image, two containers, aria2's RPC reachable only from
@@ -15,7 +18,9 @@ services:
     ports:
       - "8080:8080"
     environment:
-      ROOTS: "downloads:/downloads"
+      # tv before movies, matching production's shape (see config.rs's own
+      # tests) rather than a single flat root.
+      ROOTS: "tv:/tv,movies:/movies"
       PUBLIC_URL: "http://localhost:8080"
       ARIA2_RPC_URL: "http://127.0.0.1:6800/jsonrpc"
       # Never actually reached: /auth/dev-login mints a session without
@@ -25,12 +30,15 @@ services:
       OIDC_CLIENT_SECRET: "dev"
       RUST_LOG: "info,mariastew=debug"
     volumes:
-      - ./dev-data/downloads:/downloads
+      - ./dev-data/tv:/tv
+      - ./dev-data/movies:/movies
 
   # Same image, run as aria2c instead of mariastew — see "One image, run
   # twice" in the README. `--rpc-listen-all=false` binds the RPC port to
   # loopback only, which is why this has to share mariastew's network
-  # namespace rather than talk to it over a compose bridge network.
+  # namespace rather than talk to it over a compose bridge network. Both
+  # roots are mounted here too, same as production (`mounts` in
+  # packages/mariastew/src/mariastew.ts) — a download can land in either.
   aria2:
     image: mariastew-dev
     depends_on:
@@ -41,7 +49,7 @@ services:
       - --enable-rpc
       - --rpc-listen-all=false
       - --rpc-listen-port=6800
-      - --dir=/downloads
+      - --dir=/tv
       - --continue=true
       - --check-integrity=true
       # Nothing is preallocated, so a file the filter rejected never touches
@@ -52,4 +60,5 @@ services:
       - --bt-enable-lpd=true
       - --enable-peer-exchange=true
     volumes:
-      - ./dev-data/downloads:/downloads
+      - ./dev-data/tv:/tv
+      - ./dev-data/movies:/movies

--- a/apps/mariastew/scripts/seed-dev-fixtures.ts
+++ b/apps/mariastew/scripts/seed-dev-fixtures.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * Populates docker-compose's bind-mounted roots (../dev-data/{tv,movies})
+ * with directory names shaped like the owner's real library.
+ *
+ * One empty `downloads` folder cannot reproduce a layout bug — every picker
+ * bug found so far only showed up because of what a real name does to the
+ * layout: full-width CJK brackets, runs of consecutive spaces, a leading
+ * `www.` site prefix, square brackets, commas, names past 70 characters. The
+ * real names below are verbatim from that library, not sanitised, and stay
+ * present alongside generated filler so the ~140-entry scroll cap is
+ * genuinely exercised rather than tested against three tidy names.
+ *
+ * The filler is deterministic (seeded PRNG, not Math.random()) so a bug
+ * report against "entry #83" points at the same name on every machine and
+ * every re-run — a fresh random draw each time would make that unreproducible.
+ *
+ * Only creates directories: this is the same tree the app's own picker reads
+ * with tokio::fs::read_dir, so a directory is all a fixture needs to be.
+ * mkdir with recursive:true is a no-op on an existing path, which is what
+ * makes re-running this safe without deleting anything --reset didn't ask
+ * for — including whatever a docker-compose aria2 run has since downloaded
+ * into these same directories.
+ */
+import { mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEV_DATA = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dev-data",
+);
+
+// Verbatim from the owner's library — the actual adversarial cases, not a
+// paraphrase of them.
+const REAL_MOVIES = [
+  "Atomic Blonde (2017) (2160p BluRay x265 HEVC 10bit HDR AAC 7.1 Tigole)",
+  "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1",
+  "Citizenfour (2014) [1080p]",
+  "Clerks Trilogy 1994,2006,2022 1080p BluRay HEVC x265",
+  "Crash (1996) Criterion (1080p BluRay x265 HEVC 10bit AAC 5.1)",
+  "Deliverance (1972) [1080p]",
+  "El Mariachi (1992) (1080p BluRay x265 HEVC 10bit AAC 2.0)",
+  "England is Mine",
+  "Four Lions 2010 (1080p Bluray x265 HEVC 10bit AAC 5.1 Tigole)",
+  "Furiosa.A.Mad.Max.Saga.2024.2160p.WEB.H265-FuriousMax",
+  "Heavy.Metal.1981.1080p.BluRay.DDP5.1.x265.10bit-Galaxy",
+  "Louis Theroux Inside The Manosphere (2026) 1080p WEBRip x265 LAMA",
+  "Mad.Max.3.Beyond.Thunderdome.1985.1080p.BrRip.x264.【ThumperDC】",
+  "Mystify.Michael.Hutchence.2019.1080p.BluRay.x264-GETiT[TGx]",
+  "O.Brother.Where.Art.Thou.2000.1080p.BluRay.DDP5.1.x265.GalaxyRG265[TGx]",
+  "Once Upon a Time in Mexico (2003) (1080p BluRay x265 HEVC 10bit Tigole)",
+  "The.7th.Voyage.Of.Sinbad.1958.Eng.REMASTERED.1080p.BluRay",
+  "V for Vendetta (2005) (2160p BluRay x265 HEVC 10bit HDR AAC 7.1 Tigole)",
+  "www.UIndex.org    -    Made In Britain 1982 BluRay 1080p DTS 2 0 AVC REMUX-FraMeSToR",
+  "www.UIndex.org    -    Obsession.2026.1080p.TELESYNC.x264-UNiON",
+  "Zoolander (2001) [1080p] [YTS.AG]",
+];
+
+// Two shows named for the same problem two different ways — #257 exists
+// because telling these apart at a glance, on a phone, is genuinely hard.
+// Left as leaf directories rather than given Season subfolders: the season
+// number is already baked into the name, which is its own real pattern.
+const DIVERGENT_SPELLINGS = ["Show Name S02", "Show.Name.Season.2"];
+
+const SHOWS: Record<string, string[]> = {
+  Deadwood: ["Season 01", "Season 02", "Season 03"],
+  "Chernobyl (2019)": ["Season 01"],
+  "The Wire": ["Season 01", "Season 02", "Season 03", "Season 04", "Season 05"],
+  Fargo: ["Season 01", "Season 02", "Season 03", "Season 04", "Season 05"],
+};
+
+const TARGET_MOVIE_COUNT = 140;
+
+// mulberry32 — small, dependency-free, and seeded so every run generates the
+// same filler names in the same order.
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rand = mulberry32(0x6d617269); // "mari"
+
+function pick<T>(items: readonly T[]): T {
+  return items[Math.floor(rand() * items.length)]!;
+}
+
+const TITLE_WORDS = [
+  "Nightfall",
+  "Silver",
+  "Creek",
+  "Harbour",
+  "Static",
+  "Low",
+  "Tide",
+  "Glass",
+  "Hollow",
+  "Vantage",
+  "North",
+  "Wire",
+  "Signal",
+  "Ash",
+  "Field",
+  "Ember",
+  "Rust",
+  "Salt",
+  "Marrow",
+  "Drift",
+  "Quiet",
+  "Ridge",
+  "Fault",
+  "Line",
+  "Verge",
+  "Amber",
+  "Copper",
+  "Basin",
+  "Wake",
+  "Frost",
+];
+const RESOLUTIONS = ["1080p", "2160p", "720p"];
+const SOURCES = ["BluRay", "WEBRip", "WEB", "BDRip", "DVDRip", "REMUX"];
+const CODECS = ["x264", "x265", "HEVC"];
+const AUDIO = ["AAC 5.1", "DDP5.1", "AC3", "DTS", "AAC 2.0"];
+const GROUPS = [
+  "Tigole",
+  "GalaxyRG",
+  "YTS.AG",
+  "FraMeSToR",
+  "LAMA",
+  "GETiT",
+  "RARBG",
+  "EVO",
+  "SPARKS",
+  "NTG",
+];
+
+function fillerMovieName(): string {
+  const title = `${pick(TITLE_WORDS)} ${pick(TITLE_WORDS)}`;
+  const year = 1971 + Math.floor(rand() * 54);
+  const res = pick(RESOLUTIONS);
+  const source = pick(SOURCES);
+  const codec = pick(CODECS);
+  const audio = pick(AUDIO);
+  const group = pick(GROUPS);
+  return `${title} (${year}) ${res} ${source} ${codec} ${audio}-${group}`;
+}
+
+function movieNames(): string[] {
+  const filler = Array.from(
+    { length: Math.max(0, TARGET_MOVIE_COUNT - REAL_MOVIES.length) },
+    fillerMovieName,
+  );
+  return [...REAL_MOVIES, ...filler];
+}
+
+async function seedRoot(root: string, names: string[]) {
+  await Promise.all(
+    names.map((name) => mkdir(join(DEV_DATA, root, name), { recursive: true })),
+  );
+}
+
+async function main() {
+  if (process.argv.includes("--reset")) {
+    await rm(join(DEV_DATA, "movies"), { recursive: true, force: true });
+    await rm(join(DEV_DATA, "tv"), { recursive: true, force: true });
+  }
+
+  const movies = movieNames();
+  await seedRoot("movies", movies);
+
+  const tvDirs = [
+    ...Object.entries(SHOWS).flatMap(([show, seasons]) =>
+      seasons.map((s) => `${show}/${s}`),
+    ),
+    ...DIVERGENT_SPELLINGS,
+  ];
+  await seedRoot("tv", tvDirs);
+
+  const longest = movies.reduce((a, b) => (b.length > a.length ? b : a));
+  console.log(
+    `movies: ${movies.length} entries, longest ${longest.length} chars`,
+  );
+  console.log(
+    `tv: ${Object.keys(SHOWS).length} shows, ${tvDirs.length} directories total`,
+  );
+}
+
+main();

--- a/mise.toml
+++ b/mise.toml
@@ -66,9 +66,20 @@ run = "./node_modules/.bin/tailwindcss -i styles/app.css -o assets/app.css --min
 description = "Validate every profile shape against the real sing-box binary (needs docker)"
 run = "./scripts/check-profiles.ts"
 
+[tasks."mariastew:seed"]
+description = "Populate the local tv/movies roots with names shaped like the real library"
+dir = "apps/mariastew"
+run = "./scripts/seed-dev-fixtures.ts"
+
+[tasks."mariastew:seed:reset"]
+description = "Wipe the local tv/movies roots and reseed from scratch"
+dir = "apps/mariastew"
+run = "./scripts/seed-dev-fixtures.ts --reset"
+
 [tasks."mariastew:dev"]
 description = "Run mariastew + aria2 locally against a debug build (needs docker)"
 dir = "apps/mariastew"
+depends = ["mariastew:seed"]
 run = "docker compose up --build"
 
 [tasks."update:apps"]


### PR DESCRIPTION
`docker compose up` gave one empty directory. Every UI defect found so far only appeared because of what real names do to the layout, so a local environment that cannot reproduce them gives false confidence.

`mise run mariastew:dev` now seeds two roots first — `movies` with 140 entries and `tv` with shows and season folders — and points `ROOTS` at both, matching production's shape rather than the single `downloads:` root that exists nowhere else.

## The names are the point

Twenty-one are verbatim from the owner's actual library, unsanitised, because the awkward ones are the test: full-width CJK brackets (`【ThumperDC】`), runs of consecutive spaces (`www.UIndex.org    -    Made In Britain…`, the 84-character worst case), commas, square brackets and site prefixes. Filler is generated to reach 140 so the picker's scroll cap is genuinely exercised.

Filler comes from a seeded PRNG rather than `Math.random()`, so the list is identical on every machine and across every run. "The longest name" and "the 17th entry" then mean the same thing to everyone reading a bug report.

The `tv` root carries both `Show Name S02` and `Show.Name.Season.2`, which sort adjacently — the divergence #257 says the picker exists to make distinguishable, sitting side by side where it can actually be judged.

Fixtures are generated, never committed; `dev-data/` stays ignored. Seeding is idempotent, so bringing the stack up repeatedly neither duplicates entries nor disturbs anything a test download has since written. `mise run mariastew:seed:reset` wipes and reseeds when a clean slate is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs7qxMHbC1WyagqYLDMxHQ