### PR TITLE
feat(mariastew): compose seeds its own fixtures

### DIFF
--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -185,17 +185,16 @@ downloads move.
 
 ### docker compose, if you want aria2 too
 
-`mise run mariastew:dev` from the repo root seeds the fixture library (below)
-and brings up the full flow — mariastew and a real aria2c — with one command.
-Equivalently, by hand:
-
 ```sh
 cd apps/mariastew
-./scripts/seed-dev-fixtures.ts
 docker compose up --build
 ```
 
-Then visit `http://localhost:8080/auth/dev-login`. `ROOTS` is preset to
+is the whole command — no separate seeding step. `docker-compose.yml`'s
+`seed` service populates the picker (below) before mariastew starts, so
+there is nothing to remember and no way to end up looking at an empty
+library that only looks like a working one. Then visit
+`http://localhost:8080/auth/dev-login`. `ROOTS` is preset to
 `tv:/tv,movies:/movies`, both bind-mounted from `apps/mariastew/dev-data/`
 into both containers at the same path — real downloads land there
 alongside the fixtures. `docker compose down` stops and removes both
@@ -204,27 +203,31 @@ containers and the network; `dev-data/` is yours and is left alone.
 #### Fixture library
 
 An empty picker cannot reproduce a layout bug — every one found so far only
-showed up because of what a real name does to the layout. `mise run
-mariastew:seed` (`scripts/seed-dev-fixtures.ts`) populates `dev-data/movies`
-with ~140 entries: a fixed set of real names from the owner's library, kept
-verbatim (full-width CJK brackets, runs of consecutive spaces, a leading
-`www.` prefix, square brackets, commas, names past 70 characters), padded
-out with deterministically generated filler so the picker's scroll cap is
-exercised against a realistic count rather than three tidy names. It also
-seeds `dev-data/tv` with a few shows carrying `Season 01`/`Season 02`
-children, plus `Show Name S02` and `Show.Name.Season.2` as two
-top-level entries — the same show named two different real ways, which is
-the exact case the destination picker exists to tell apart (#257).
+showed up because of what a real name does to the layout. `scripts/seed-dev-fixtures.ts`
+populates `dev-data/movies` with ~140 entries: a fixed set of real names
+from the owner's library, kept verbatim (full-width CJK brackets, runs of
+consecutive spaces, a leading `www.` prefix, square brackets, commas, names
+past 70 characters), padded out with deterministically generated filler so
+the picker's scroll cap is exercised against a realistic count rather than
+three tidy names. It also seeds `dev-data/tv` with a few shows carrying
+`Season 01`/`Season 02` children, plus `Show Name S02` and
+`Show.Name.Season.2` as two top-level entries — the same show named two
+different real ways, which is the exact case the destination picker exists
+to tell apart (#257).
 
 The filler is generated from a seeded PRNG, not `Math.random()`, so it is
 the same list on every machine and every run — a bug report against "the
-17th entry" stays reproducible. Re-running the seed script is a no-op for
-anything that already exists (`mkdir` with `recursive: true`), so it is
-safe to run again without disturbing whatever aria2 has since downloaded
-into the same directories. `mise run mariastew:seed:reset` (or
-`./scripts/seed-dev-fixtures.ts --reset`) wipes `dev-data/tv` and
-`dev-data/movies` first — the way back to a clean fixture-only state once a
-test download has piled up in there.
+17th entry" stays reproducible. The script is a no-op for anything that
+already exists (`mkdir` with `recursive: true`), so `docker-compose.yml`
+running it on every `up` costs nothing on the second one and never disturbs
+whatever aria2 has since downloaded into the same directories.
+
+Outside docker — the plain `cargo run` flow above, or resetting the
+fixtures without a full compose cycle — use the `mise` tasks directly:
+`mise run mariastew:seed`, or `mise run mariastew:seed:reset` (equivalently
+`./scripts/seed-dev-fixtures.ts --reset`) to wipe `dev-data/tv` and
+`dev-data/movies` and reseed from scratch — the way back to a clean
+fixture-only state once a test download has piled up in there.
 
 This mirrors "One image, run twice" above rather than inventing a second
 image: `docker-compose.yml` builds one image and runs it as both services,

--- a/apps/mariastew/docker-compose.yml
+++ b/apps/mariastew/docker-compose.yml
@@ -1,11 +1,31 @@
-# One-command local dev loop: `mise run mariastew:seed` (or --reset) to
-# populate ../dev-data/{tv,movies} with names shaped like the owner's real
-# library, then `docker compose up --build`, then
-# http://localhost:8080/auth/dev-login. `mise run mariastew:dev` does both.
-# See README's "Local development" for what dev-login does and does not
-# need, and Dockerfile.dev for why this builds a debug binary rather than
-# reusing the production Dockerfile.
+# One-command local dev loop: `docker compose up --build`, then
+# http://localhost:8080/auth/dev-login. The `seed` service below populates
+# the picker before mariastew starts, so there is no separate step and no
+# way to end up looking at an empty library that only looks like a working
+# one. See README's "Local development" for what dev-login does and does
+# not need, and Dockerfile.dev for why this builds a debug binary rather
+# than reusing the production Dockerfile.
 services:
+  # Guarantees `docker compose up` alone gives a populated, realistic
+  # library — an empty picker that looks like a working picker is worse
+  # than an error, and "run this other command first" is how that happens.
+  # Runs the same scripts/seed-dev-fixtures.ts as `mise run mariastew:seed`
+  # (mounted read-only, single source of truth) against the same bind
+  # mounts mariastew and aria2 use below, and exits; mariastew waits for it
+  # to succeed before starting. Idempotent, so this costs nothing on a
+  # second `up` and never touches a download already sitting in dev-data.
+  # A plain node image rather than baking node into Dockerfile.dev: this
+  # only ever runs on the host, never ships, and pinning it to the same
+  # major version mise installs (see mise.toml) is enough to keep it in
+  # step.
+  seed:
+    image: node:24-alpine
+    working_dir: /app
+    volumes:
+      - ./scripts:/app/scripts:ro
+      - ./dev-data:/app/dev-data
+    command: ["node", "--experimental-strip-types", "scripts/seed-dev-fixtures.ts"]
+
   # Owns the shared network namespace and the published port, mirroring the
   # pod: one image, two containers, aria2's RPC reachable only from
   # 127.0.0.1 inside it. aria2 below joins this network rather than getting
@@ -15,6 +35,9 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     image: mariastew-dev
+    depends_on:
+      seed:
+        condition: service_completed_successfully
     ports:
       - "8080:8080"
     environment:

--- a/mise.toml
+++ b/mise.toml
@@ -66,6 +66,9 @@ run = "./node_modules/.bin/tailwindcss -i styles/app.css -o assets/app.css --min
 description = "Validate every profile shape against the real sing-box binary (needs docker)"
 run = "./scripts/check-profiles.ts"
 
+# docker-compose's own `seed` service seeds these roots on every `up` — these
+# two are for outside docker: the plain `cargo run` flow in "Local
+# development", or resetting the fixtures without a full compose cycle.
 [tasks."mariastew:seed"]
 description = "Populate the local tv/movies roots with names shaped like the real library"
 dir = "apps/mariastew"
@@ -79,7 +82,6 @@ run = "./scripts/seed-dev-fixtures.ts --reset"
 [tasks."mariastew:dev"]
 description = "Run mariastew + aria2 locally against a debug build (needs docker)"
 dir = "apps/mariastew"
-depends = ["mariastew:seed"]
 run = "docker compose up --build"
 
 [tasks."update:apps"]


### PR DESCRIPTION
`docker compose up --build` is now the whole command. A `seed` service runs the existing fixture script and must exit cleanly before the app starts, so a fresh checkout gets the full library with nothing to remember.

It reuses `scripts/seed-dev-fixtures.ts` mounted read-only rather than reimplementing the logic, so there is one definition of what the fixtures are. Seeding is idempotent, so repeat runs cost a no-op rather than duplicating anything.

Auto-seeding rather than failing with an instruction: the point of the compose setup is that one command gives you something to work with, and an error telling you to run a second command is just the missing step with extra steps.

`mise run mariastew:seed` and `:seed:reset` stay, since they still matter for the plain `cargo run` flow and for resetting without a full compose cycle.

Verified from a genuinely clean state — no `dev-data/` directory at all: `seed` runs first and reports 140 movie entries and 16 tv directories, then the app starts, and the picker serves all of them. Running it twice leaves the count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs7qxMHbC1WyagqYLDMxHQ