### PR TITLE
fix(mariastew): select the right files, and stop lying about being done

### DIFF
--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -12,14 +12,23 @@ patched over SSE ([Datastar](https://data-star.dev), vendored at
 ## Why files land straight in the library
 
 Downloads are written directly into the media tree the picker offers, not a
-staging directory that something else sweeps later. That is only safe because
-the scene-garbage filter (`src/filter.rs`) runs **before** the real download
+staging directory that something else sweeps later. That is safe because the
+scene-garbage filter (`src/filter.rs`) runs **before** the real download
 starts, not after: adding a magnet does a metadata-only aria2 pass first,
-`filter::is_garbage` picks the indices worth keeping, and the real download is
-started with `select-file` naming only those. Combined with aria2's
-`--file-allocation=none`, a file the filter rejected never touches disk at
-all. This is what removes the need for a separate cleanup sweep of the kind
-`clean-dls` used to do after the fact — there is nothing left behind to clean.
+`follow-torrent` spawns the real download from the resolved metadata,
+`filter::is_garbage` picks the indices worth keeping from *that* download's
+own file list — not the metadata pass's, which always has exactly one entry,
+itself — and `aria2.changeOption` applies the selection to it. Combined with
+aria2's `--file-allocation=none`, a file the filter rejected never touches
+disk for its own sake.
+
+aria2 still downloads whole pieces regardless of selection, though, so a
+small deselected file sharing a piece boundary with a selected one can land
+anyway. `notify::sweep_garbage` runs from the same completion watch that
+sends the Telegram message, deletes whatever is both deselected and
+`filter::is_garbage`, and never touches a selected file or one that is merely
+small. This is the "line of code rather than a design change" a stray
+zero-byte file was always expected to need.
 
 ## One image, run twice
 
@@ -88,7 +97,7 @@ files, and `/auth/*` are the only routes outside that layer (`src/main.rs`).
 |---|---|---|
 | `/` | GET | The page: current roots and the download list |
 | `/stream` | GET | SSE stream, one tick per second (`routes::TICK_SECS`), patching the download list in place |
-| `/add` | POST | `magnet` + `dir` form fields — runs the metadata pass, filters, and starts the real download |
+| `/add` | POST | `magnet` + `dir` form fields — validates and starts the metadata pass, then returns `202` immediately; the poll, the filter, and starting the real download run detached (see `routes::finish_add`), and their outcome shows up through `/stream` like any other download |
 | `/downloads/{gid}/pause` | POST | |
 | `/downloads/{gid}/resume` | POST | |
 | `/downloads/{gid}/remove` | POST | See "Seeding, and why cancel has two meanings" above |

--- a/apps/mariastew/src/aria2.rs
+++ b/apps/mariastew/src/aria2.rs
@@ -79,6 +79,13 @@ pub struct File {
     pub index: u32,
     pub path: String,
     pub length: u64,
+    /// `false` for a file `select-file` left out — aria2 still downloads
+    /// whole pieces regardless, so a small deselected file sharing a piece
+    /// boundary with a selected one can still land on disk. This is what
+    /// tells the completion sweep (`notify::sweep_garbage`) which files were
+    /// never meant to be there in the first place, as opposed to one that
+    /// simply happens to be small.
+    pub selected: bool,
 }
 
 impl From<RawFile> for File {
@@ -87,6 +94,7 @@ impl From<RawFile> for File {
             index: f.index.parse().unwrap_or(0),
             path: f.path,
             length: f.length.parse().unwrap_or(0),
+            selected: f.selected == "true",
         }
     }
 }
@@ -106,6 +114,11 @@ pub struct Download {
     pub files: Vec<File>,
     /// The torrent's own name, once metadata has arrived.
     pub bittorrent_name: Option<String>,
+    /// Gids of downloads aria2 generated from this one. A `bt-metadata-only`
+    /// pass has exactly one once its metadata resolves: the real download,
+    /// spawned by `follow-torrent`, with the torrent's actual file list —
+    /// which the metadata gid's own `files` (one entry: itself) is not.
+    pub followed_by: Vec<String>,
 }
 
 impl Download {
@@ -200,6 +213,8 @@ struct RawDownload {
     files: Vec<RawFile>,
     #[serde(default)]
     bittorrent: Option<RawBittorrent>,
+    #[serde(default, rename = "followedBy")]
+    followed_by: Vec<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -210,6 +225,8 @@ struct RawFile {
     path: String,
     #[serde(default)]
     length: String,
+    #[serde(default)]
+    selected: String,
 }
 
 #[derive(Deserialize, Default)]
@@ -247,6 +264,7 @@ impl RawDownload {
             dir: self.dir,
             files: self.files.into_iter().map(File::from).collect(),
             bittorrent_name,
+            followed_by: self.followed_by,
         })
     }
 }
@@ -373,6 +391,18 @@ impl Aria2 {
             .await?;
         Ok(())
     }
+
+    /// Changes options on a download already added — `dir` and `select-file`
+    /// among them, which is how a torrent's real destination and file
+    /// selection get set on the download `follow-torrent` spawned from a
+    /// resolved magnet, rather than on a second `addUri` racing its infohash.
+    /// aria2 restarts the download internally to apply it; no second gid, no
+    /// caller-visible interruption.
+    pub async fn change_option(&self, gid: &str, options: serde_json::Value) -> AppResult<()> {
+        self.call("changeOption", serde_json::json!([gid, options]))
+            .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -393,6 +423,7 @@ mod tests {
             dir: "/downloads".to_string(),
             files: Vec::new(),
             bittorrent_name: None,
+            followed_by: Vec::new(),
         }
     }
 
@@ -425,7 +456,9 @@ mod tests {
         assert_eq!(d.bittorrent_name.as_deref(), Some("Movie"));
         assert_eq!(d.files.len(), 2);
         assert_eq!(d.files[0].index, 1);
+        assert!(d.files[0].selected);
         assert_eq!(d.files[1].index, 2);
+        assert!(!d.files[1].selected);
     }
 
     #[test]
@@ -537,6 +570,7 @@ mod tests {
             index: 1,
             path: "/downloads/Show/S01E01.mkv".to_string(),
             length: 0,
+            selected: true,
         });
         assert_eq!(d.name(), "S01E01.mkv");
 

--- a/apps/mariastew/src/notify.rs
+++ b/apps/mariastew/src/notify.rs
@@ -18,7 +18,8 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::aria2::Status;
+use crate::aria2::{Download, Status};
+use crate::filter;
 use crate::routes::all_downloads;
 use crate::state::AppState;
 
@@ -68,6 +69,7 @@ pub fn spawn_watcher(state: AppState) {
                         let error = d.error_message.as_deref().unwrap_or("unknown error");
                         failed(&state, d.name(), error).await;
                     } else {
+                        sweep_garbage(&state, d).await;
                         finished(&state, d.name(), &d.dir).await;
                     }
                 }
@@ -80,6 +82,44 @@ pub fn spawn_watcher(state: AppState) {
             announced.retain(|gid, _| live.contains_key(gid.as_str()));
         }
     });
+}
+
+/// Deletes the deselected garbage that landed anyway. aria2 downloads whole
+/// pieces regardless of `select-file`, so a small deselected file sharing a
+/// piece boundary with a selected one still reaches disk — `#260` anticipated
+/// exactly this and left it as a line of code rather than a design change.
+/// `--file-allocation=none` (see the README) prevents preallocation, not
+/// this.
+///
+/// A file is removed only when it is both deselected *and*
+/// `filter::is_garbage` — never a selected file no matter how it scores, and
+/// never a small file that merely happens to be small. Every path still goes
+/// through `resolve_existing` immediately before the delete, the same
+/// containment check `routes::delete_partial` uses: a path aria2 reports is
+/// still a path this process is about to unlink.
+async fn sweep_garbage(state: &AppState, d: &Download) {
+    for f in &d.files {
+        if f.selected || !filter::is_garbage(&f.path) {
+            continue;
+        }
+        if state.config.resolve_existing(&f.path).await.is_none() {
+            tracing::warn!(
+                path = %f.path,
+                "refusing to delete a deselected garbage file outside any root"
+            );
+            continue;
+        }
+        if let Err(e) = tokio::fs::remove_file(&f.path).await {
+            tracing::warn!(path = %f.path, error = %e, "failed to delete deselected garbage file");
+            continue;
+        }
+        tracing::info!(
+            gid = %d.gid,
+            path = %f.path,
+            "removed deselected garbage left by a piece boundary"
+        );
+        let _ = tokio::fs::remove_file(format!("{}.aria2", f.path)).await;
+    }
 }
 
 /// Escape what Telegram's HTML parse mode treats as markup. `&` first, or the
@@ -121,7 +161,129 @@ pub async fn failed(state: &AppState, name: &str, error: &str) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use crate::aria2::{Aria2, File};
+    use crate::auth::session::Sessions;
+    use crate::config::{Config, Oidc, Root};
+
+    fn file(index: u32, path: &str, selected: bool) -> File {
+        File {
+            index,
+            path: path.to_string(),
+            length: 100,
+            selected,
+        }
+    }
+
+    fn download(files: Vec<File>) -> Download {
+        Download {
+            gid: "gid1".to_string(),
+            status: Status::Complete,
+            total_length: 100,
+            completed_length: 100,
+            download_speed: 0,
+            upload_speed: 0,
+            connections: 0,
+            num_seeders: 0,
+            error_message: None,
+            dir: String::new(),
+            files,
+            bittorrent_name: None,
+            followed_by: Vec::new(),
+        }
+    }
+
+    fn state(root: std::path::PathBuf) -> AppState {
+        AppState {
+            config: Arc::new(Config {
+                bind_addr: String::new(),
+                aria2_rpc_url: String::new(),
+                roots: vec![Root {
+                    name: "media".to_string(),
+                    path: root,
+                }],
+                public_url: String::new(),
+                oidc: Oidc {
+                    issuer: String::new(),
+                    client_id: String::new(),
+                    client_secret: String::new(),
+                },
+                telegram: None,
+            }),
+            aria2: Aria2::new(String::new(), reqwest::Client::new()),
+            sessions: Sessions::new(),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// The bug this exists to fix: a torrent completes with garbage files
+    /// aria2 wrote anyway (piece-boundary spillover, not a selection
+    /// mistake), and until this ran they just sat there. A selected file and
+    /// a deselected-but-not-garbage file (e.g. a `.txt` `filter::is_garbage`
+    /// does not flag) must both survive — this is not "delete whatever is
+    /// unselected", only what is unselected *and* garbage.
+    #[tokio::test]
+    async fn sweep_garbage_removes_only_deselected_garbage_inside_a_root() {
+        let root = std::env::temp_dir().join("mariastew-sweep-test-inside-root");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let movie = root.join("movie.mkv");
+        let cover = root.join("cover.jpg");
+        let cover_control = root.join("cover.jpg.aria2");
+        let notes = root.join("notes.txt");
+        tokio::fs::write(&movie, b"video").await.unwrap();
+        tokio::fs::write(&cover, b"jpeg").await.unwrap();
+        tokio::fs::write(&cover_control, b"partial").await.unwrap();
+        tokio::fs::write(&notes, b"not garbage per filter.rs")
+            .await
+            .unwrap();
+
+        let d = download(vec![
+            file(1, movie.to_str().unwrap(), true),
+            file(2, cover.to_str().unwrap(), false),
+            file(3, notes.to_str().unwrap(), false),
+        ]);
+        sweep_garbage(&state(root.clone()), &d).await;
+
+        assert!(movie.exists(), "a selected file must never be removed");
+        assert!(
+            notes.exists(),
+            "a deselected file that is not garbage must survive"
+        );
+        assert!(!cover.exists(), "deselected garbage must be removed");
+        assert!(
+            !cover_control.exists(),
+            "the .aria2 control file must go with it"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    /// The containment boundary applies here exactly as it does to every
+    /// other delete in the service: a path aria2 reports is still just a
+    /// report, re-checked against the canonicalised roots before anything is
+    /// unlinked. A garbage, deselected file sitting outside every configured
+    /// root must be left alone even though every other condition for
+    /// deletion is met.
+    #[tokio::test]
+    async fn sweep_garbage_refuses_a_path_outside_every_root() {
+        let root = std::env::temp_dir().join("mariastew-sweep-test-root-only");
+        let outside = std::env::temp_dir().join("mariastew-sweep-test-outside.jpg");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        tokio::fs::write(&outside, b"jpeg").await.unwrap();
+
+        let d = download(vec![file(1, outside.to_str().unwrap(), false)]);
+        sweep_garbage(&state(root.clone()), &d).await;
+
+        assert!(
+            outside.exists(),
+            "a path outside every configured root must never be deleted"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        let _ = tokio::fs::remove_file(&outside).await;
+    }
 
     #[test]
     fn esc_escapes_all_three_markup_characters() {

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -48,12 +48,13 @@ pub(crate) async fn all_downloads(state: &AppState) -> AppResult<Vec<Download>> 
     downloads.extend(state.aria2.tell_waiting(0, 100).await?);
     downloads.extend(state.aria2.tell_stopped(0, 100).await?);
     // `add`'s metadata-only pass exists to learn a magnet's file list before
-    // the real download starts (see `free_infohash`) and is gone by the time
-    // this runs in the ordinary case — `add` removes it once it has what it
-    // needs. aria2 names one `[METADATA]<torrent name>` for as long as it
-    // exists, which is how a stray one is told apart from a real download:
-    // it is never something the user asked to watch, so if one lingers
-    // because a previous `add` died mid-flight, it still must not appear.
+    // the real download starts (see `finish_add_inner`), and aria2 keeps it
+    // in the stopped list forever afterward — nothing here ever removes it,
+    // since the real download is applied to the gid `follow-torrent` spawned
+    // from it rather than a second `addUri` that would need the metadata
+    // pass's own gid freed first. aria2 names it `[METADATA]<torrent name>`
+    // for as long as it exists, which is how it is told apart from a real
+    // download: it is never something the user asked to watch.
     downloads.retain(|d| !is_metadata_row(d));
     Ok(downloads)
 }
@@ -227,13 +228,13 @@ pub async fn add(
     {
         Ok(gid) => gid,
         // Not a server fault: this infohash is already known to aria2,
-        // either genuinely downloading or a metadata pass a previous attempt
-        // never got to free — the pod dying mid-`add` being the likely way,
-        // now that finishing it runs detached from the request that started
-        // it. aria2's error does not say which, and guessing wrong is worse
-        // than asking: forcibly clearing it here would silently cancel a
-        // real download if it guessed wrong. The download list is already on
-        // the page — that is where "which one is it" gets answered.
+        // either genuinely downloading already or a metadata pass a previous
+        // attempt left registered — the pod dying mid-`add` being the likely
+        // way, now that finishing it runs detached from the request that
+        // started it. aria2's error does not say which, and guessing wrong
+        // is worse than asking: forcibly clearing it here could silently
+        // cancel a real download. The download list is already on the page —
+        // that is where "which one is it" gets answered.
         Err(AppError::Upstream(msg)) if is_already_registered(&msg) => {
             return Err(AppError::BadRequest(
                 "this magnet is already added or downloading".to_string(),
@@ -265,7 +266,7 @@ async fn finish_add(
     dir: String,
     metadata_gid: String,
 ) {
-    if let Err(e) = finish_add_inner(&state, &sub, &magnet, &dir, &metadata_gid).await {
+    if let Err(e) = finish_add_inner(&state, &sub, &dir, &metadata_gid).await {
         tracing::error!(
             gid = %metadata_gid,
             infohash = magnet_infohash(&magnet).unwrap_or("unknown"),
@@ -275,20 +276,31 @@ async fn finish_add(
     }
 }
 
+/// Selects and starts the real download by following the metadata pass to
+/// the download aria2 spawned from it, rather than issuing a second `addUri`
+/// for the same magnet.
+///
+/// A `bt-metadata-only` gid's own `files` describes the metadata pass
+/// itself — one entry, regardless of how many files the torrent actually
+/// has, which is why a three-file torrent used to log `magnet_files=1` and
+/// select whichever file happened to be index 1. `follow-torrent` (`mem`)
+/// spawns a second download from the resolved metadata and links the two by
+/// gid — `followedBy` on this one, `following` on that one — and it is that
+/// second gid's `files` that lists what the torrent actually contains.
+/// Reading the selection from anywhere else means the filter never sees most
+/// of the torrent and the choice of what to keep is decided by file order.
+///
+/// Applying the selection through `changeOption` rather than a second
+/// `addUri` also means there is no infohash collision to resolve: one
+/// download exists for this magnet from start to finish, under one gid.
 async fn finish_add_inner(
     state: &AppState,
     sub: &str,
-    magnet: &str,
     dir: &str,
     metadata_gid: &str,
 ) -> AppResult<()> {
-    // `Complete` is what "the metadata has arrived" actually means. Waiting for a
-    // non-empty file list instead is racy: aria2 populates `files` slightly
-    // before it flips the status, so the pass could still be active when the
-    // infohash was freed below — which is how the real download came to be
-    // rejected as a duplicate of a download that had not finished letting go.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
-    let files = loop {
+    let child_gid = loop {
         let status = state.aria2.tell_status(metadata_gid).await?;
         if status.status == Status::Error {
             return Err(AppError::Upstream(
@@ -297,8 +309,8 @@ async fn finish_add_inner(
                     .unwrap_or_else(|| "metadata fetch failed".to_string()),
             ));
         }
-        if status.status == Status::Complete {
-            break status.files;
+        if let Some(gid) = status.followed_by.into_iter().next() {
+            break gid;
         }
         if tokio::time::Instant::now() >= deadline {
             return Err(AppError::BadRequest(
@@ -307,6 +319,16 @@ async fn finish_add_inner(
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     };
+
+    // The child exists only once aria2 has parsed a complete torrent out of
+    // the resolved metadata, so its file list is already known the moment it
+    // is queryable — there is nothing left to wait for here.
+    let files = state.aria2.tell_status(&child_gid).await?.files;
+    if files.is_empty() {
+        return Err(AppError::Upstream(
+            "aria2 followed the metadata pass but the download it created has no files".to_string(),
+        ));
+    }
 
     let indices: Vec<String> = files
         .iter()
@@ -338,45 +360,15 @@ async fn finish_add_inner(
         "starting download"
     );
 
-    free_infohash(state, metadata_gid).await?;
-
     state
         .aria2
-        .add_uri(
-            magnet,
+        .change_option(
+            &child_gid,
             serde_json::json!({"dir": dir, "select-file": indices.join(",")}),
         )
         .await?;
 
     Ok(())
-}
-
-/// Stop and purge the metadata-only pass so its infohash is free again.
-///
-/// aria2 refuses to register a second download under an infohash that is
-/// still active — the metadata pass above is that download, and it is still
-/// registered right up until this runs. Without this, the real `addUri` a
-/// few lines below fails every single time with "InfoHash ... is already
-/// registered", the metadata's 30KB placeholder is all that ever lands, and
-/// nothing the user asked for downloads. `remove` already falls back to
-/// `forceRemove` for a download that will not stop cleanly, which is exactly
-/// the case here — it is told to stop the instant it has told us what it
-/// resolved to, not once it is ready to.
-///
-/// Both calls are attempted and tolerated individually: depending on how far
-/// the metadata pass got on its own, one may already be a no-op. Only if
-/// both fail is there no evidence the infohash was actually released, and
-/// that is the one case this returns an error for — proceeding to the real
-/// `addUri` anyway would be issuing a request already known to be rejected.
-async fn free_infohash(state: &AppState, metadata_gid: &str) -> AppResult<()> {
-    let removed = state.aria2.remove(metadata_gid).await;
-    let purged = state.aria2.remove_download_result(metadata_gid).await;
-    match (removed, purged) {
-        (Err(remove_err), Err(_)) => Err(AppError::Upstream(format!(
-            "could not free the metadata pass ({metadata_gid}) before starting the real download: {remove_err}"
-        ))),
-        _ => Ok(()),
-    }
 }
 
 pub async fn pause(State(state): State<AppState>, Path(gid): Path<String>) -> AppResult<Response> {
@@ -657,23 +649,6 @@ mod tests {
         );
     }
 
-    /// The bug this whole function exists to fix: the real `addUri` used to
-    /// run while the metadata pass was still registered under the same
-    /// infohash, and aria2 rejected it every time with "already registered"
-    /// — nothing anyone asked to download ever actually downloaded. This
-    /// pins the guard that replaced it: if neither call that is supposed to
-    /// free the infohash succeeds, `add` must stop rather than issue an
-    /// `addUri` already known to fail the same way.
-    #[tokio::test]
-    async fn free_infohash_errors_when_neither_call_can_reach_aria2() {
-        let app_state = state(unreachable_url().await);
-        let result = free_infohash(&app_state, "some-gid").await;
-        assert!(
-            result.is_err(),
-            "must not report the infohash free as fine when aria2 could not be reached at all"
-        );
-    }
-
     #[test]
     fn already_registered_is_recognised_by_aria2s_own_wording() {
         assert!(is_already_registered(
@@ -709,20 +684,38 @@ mod tests {
         use super::*;
 
         /// What the mock hands back for `aria2.tellStatus` on the metadata
-        /// gid — `Active` forever pins "the caller never waits for this",
-        /// `Complete` on the first poll lets the rest of the flow run to
-        /// completion inside a test.
-        #[derive(Clone, Copy)]
+        /// gid — `NeverResolves` pins "the caller never waits for this" (no
+        /// `followedBy` ever appears), `ResolvesWithChild` lets the rest of
+        /// the flow run to completion against `child_gid`'s own file list.
+        #[derive(Clone)]
         enum MetadataOutcome {
             NeverResolves,
-            ResolvesImmediately,
+            ResolvesWithChild {
+                child_gid: String,
+                child_files: serde_json::Value,
+            },
         }
 
         #[derive(Clone)]
         struct MockAria2 {
             calls: Arc<Mutex<Vec<String>>>,
+            change_option_calls: Arc<Mutex<Vec<serde_json::Value>>>,
             metadata_add_result: Arc<serde_json::Value>,
             metadata_outcome: MetadataOutcome,
+        }
+
+        fn download_result(gid: &str, status: &str, files: serde_json::Value) -> serde_json::Value {
+            serde_json::json!({"result": {
+                "gid": gid,
+                "status": status,
+                "totalLength": "100",
+                "completedLength": "0",
+                "downloadSpeed": "0",
+                "uploadSpeed": "0",
+                "connections": "0",
+                "dir": "/mnt/kontent/movies",
+                "files": files,
+            }})
         }
 
         async fn rpc(
@@ -736,27 +729,34 @@ mod tests {
                     if body["params"][1].get("bt-metadata-only").is_some() {
                         (*mock.metadata_add_result).clone()
                     } else {
-                        serde_json::json!({"result": "real-gid"})
+                        panic!("a second addUri means the duplicate-infohash bug is back")
                     }
                 }
                 "aria2.tellStatus" => {
-                    let status = match mock.metadata_outcome {
-                        MetadataOutcome::NeverResolves => "active",
-                        MetadataOutcome::ResolvesImmediately => "complete",
-                    };
-                    serde_json::json!({"result": {
-                        "gid": "metadata-gid",
-                        "status": status,
-                        "totalLength": "100",
-                        "completedLength": "0",
-                        "downloadSpeed": "0",
-                        "uploadSpeed": "0",
-                        "connections": "0",
-                        "dir": "/mnt/kontent/movies",
-                        "files": [{"index": "1", "path": "/mnt/kontent/movies/Movie.mkv", "length": "100"}],
-                    }})
+                    let gid = body["params"][0].as_str().unwrap_or_default();
+                    match (&mock.metadata_outcome, gid) {
+                        (MetadataOutcome::NeverResolves, _) => {
+                            download_result("metadata-gid", "active", serde_json::json!([]))
+                        }
+                        (
+                            MetadataOutcome::ResolvesWithChild {
+                                child_gid,
+                                child_files,
+                            },
+                            g,
+                        ) if g == child_gid => {
+                            download_result(child_gid, "active", child_files.clone())
+                        }
+                        (MetadataOutcome::ResolvesWithChild { child_gid, .. }, _) => {
+                            let mut result =
+                                download_result("metadata-gid", "complete", serde_json::json!([]));
+                            result["result"]["followedBy"] = serde_json::json!([child_gid.clone()]);
+                            result
+                        }
+                    }
                 }
-                "aria2.remove" | "aria2.removeDownloadResult" => {
+                "aria2.changeOption" => {
+                    mock.change_option_calls.lock().unwrap().push(body.clone());
                     serde_json::json!({"result": "OK"})
                 }
                 other => panic!("unexpected aria2 method in test: {other}"),
@@ -769,13 +769,21 @@ mod tests {
             Json(envelope)
         }
 
+        struct Mock {
+            url: String,
+            calls: Arc<Mutex<Vec<String>>>,
+            change_option_calls: Arc<Mutex<Vec<serde_json::Value>>>,
+        }
+
         async fn mock_server(
             metadata_add_result: serde_json::Value,
             metadata_outcome: MetadataOutcome,
-        ) -> (String, Arc<Mutex<Vec<String>>>) {
+        ) -> Mock {
             let calls = Arc::new(Mutex::new(Vec::new()));
+            let change_option_calls = Arc::new(Mutex::new(Vec::new()));
             let mock = MockAria2 {
                 calls: calls.clone(),
+                change_option_calls: change_option_calls.clone(),
                 metadata_add_result: Arc::new(metadata_add_result),
                 metadata_outcome,
             };
@@ -785,7 +793,11 @@ mod tests {
             tokio::spawn(async move {
                 axum::serve(listener, app).await.unwrap();
             });
-            (format!("http://{addr}/"), calls)
+            Mock {
+                url: format!("http://{addr}/"),
+                calls,
+                change_option_calls,
+            }
         }
 
         fn test_state(aria2_url: String) -> AppState {
@@ -844,12 +856,12 @@ mod tests {
         /// caller and a response is one `addUri` round trip.
         #[tokio::test]
         async fn add_returns_before_the_metadata_poll_completes() {
-            let (url, _calls) = mock_server(
+            let mock = mock_server(
                 serde_json::json!({"result": "metadata-gid"}),
                 MetadataOutcome::NeverResolves,
             )
             .await;
-            let state = test_state(url);
+            let state = test_state(mock.url);
 
             let response = tokio::time::timeout(
                 StdDuration::from_millis(500),
@@ -862,33 +874,56 @@ mod tests {
             assert_eq!(response.status(), StatusCode::ACCEPTED);
         }
 
-        /// Pins the ordering the original "InfoHash ... is already
-        /// registered" bug lived in, now running detached: the real `addUri`
-        /// must not be issued until `remove`/`removeDownloadResult` have run.
+        /// The bug this whole task exists to fix: the file list used to be
+        /// read from the metadata gid's own `files` (always one entry,
+        /// itself), not the download `follow-torrent` spawned from it. A
+        /// three-file torrent where the video is *not* index 1 is exactly
+        /// the case that got the selection wrong: `magnet_files=1` regardless
+        /// of the torrent's real shape, and whichever file happened to sit at
+        /// index 1 was what got selected — the video only by luck.
         #[tokio::test]
-        async fn finish_add_frees_the_metadata_infohash_before_the_real_add() {
-            let (url, calls) = mock_server(
+        async fn finish_add_reads_the_selection_from_the_followed_downloads_file_list() {
+            // Index 1 and 3 are unambiguous `filter::is_garbage` matches
+            // (`.jpg`, `.nfo`) — the point is that the real video sits at
+            // index 2, not 1, so a selection computed from the wrong file
+            // list (the metadata gid's own, always length 1) could only ever
+            // have picked it by coincidence.
+            let child_files = serde_json::json!([
+                {"index": "1", "path": "/mnt/kontent/movies/www.YTS.MX.jpg", "length": "53226", "selected": "true"},
+                {"index": "2", "path": "/mnt/kontent/movies/Pulp.Fiction.1994.2160p.mkv", "length": "7835426779", "selected": "true"},
+                {"index": "3", "path": "/mnt/kontent/movies/Pulp.Fiction.1994.nfo", "length": "473", "selected": "true"},
+            ]);
+            let mock = mock_server(
                 serde_json::json!({"result": "metadata-gid"}),
-                MetadataOutcome::ResolvesImmediately,
+                MetadataOutcome::ResolvesWithChild {
+                    child_gid: "child-gid".to_string(),
+                    child_files,
+                },
             )
             .await;
-            let state = test_state(url);
+            let state = test_state(mock.url);
 
             add(State(state), CurrentSession(session()), Form(add_form()))
                 .await
                 .unwrap();
 
-            wait_for_calls(&calls, 5).await;
+            wait_for_calls(&mock.calls, 4).await;
             assert_eq!(
-                calls.lock().unwrap().as_slice(),
+                mock.calls.lock().unwrap().as_slice(),
                 [
                     "aria2.addUri",
                     "aria2.tellStatus",
-                    "aria2.remove",
-                    "aria2.removeDownloadResult",
-                    "aria2.addUri",
+                    "aria2.tellStatus",
+                    "aria2.changeOption",
                 ]
             );
+
+            let change_option_calls = mock.change_option_calls.lock().unwrap();
+            assert_eq!(change_option_calls.len(), 1);
+            let params = &change_option_calls[0]["params"];
+            assert_eq!(params[0], "child-gid");
+            assert_eq!(params[1]["select-file"], "2");
+            assert_eq!(params[1]["dir"], "/mnt/kontent/movies");
         }
 
         /// This magnet already being known to aria2 is not a server fault —
@@ -896,12 +931,12 @@ mod tests {
         /// unrecognised upstream error gets.
         #[tokio::test]
         async fn add_maps_an_already_registered_infohash_to_bad_request() {
-            let (url, _calls) = mock_server(
+            let mock = mock_server(
                 serde_json::json!({"error": {"code": 1, "message": "InfoHash abc is already registered."}}),
                 MetadataOutcome::NeverResolves,
             )
             .await;
-            let state = test_state(url);
+            let state = test_state(mock.url);
 
             let result = add(State(state), CurrentSession(session()), Form(add_form())).await;
 
@@ -930,6 +965,7 @@ mod tests {
             dir: String::new(),
             files: Vec::new(),
             bittorrent_name: Some("[METADATA]Some.Show.S01".to_string()),
+            followed_by: Vec::new(),
         };
         assert!(is_metadata_row(&metadata));
 

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -176,7 +176,31 @@ fn is_magnet(s: &str) -> bool {
     s.starts_with("magnet:?")
 }
 
-/// Metadata first, then the real download with only the wanted files selected.
+/// aria2's own wording when an `addUri` names an infohash it already has
+/// registered — not a parse of any structured field, because the RPC error is
+/// a plain string and this is the only thing in it worth matching on.
+fn is_already_registered(message: &str) -> bool {
+    message.contains("is already registered")
+}
+
+/// The `btih:` hash out of a magnet's `xt` parameter, for logging only —
+/// nothing here acts on it, aria2 already knows the download by its gid. Not
+/// a URI parser, in the same spirit as [`is_magnet`]: this only ever needs to
+/// find the one parameter a magnet is expected to carry.
+fn magnet_infohash(magnet: &str) -> Option<&str> {
+    let after = magnet.split_once("btih:")?.1;
+    Some(after.split('&').next().unwrap_or(after))
+}
+
+/// Validates and starts the metadata pass, then hands the rest to the
+/// background — resolving a magnet's metadata can take real time, and the
+/// browser does not hold a `POST` open for it (production: `NS_BINDING_ABORTED`
+/// around two seconds, followed by a retry that collided with the still-
+/// registered infohash from the abandoned first attempt). `addUri` itself is
+/// not what was slow: aria2 answers with a gid immediately and resolves the
+/// magnet on its own side afterward, so it is safe to run synchronously and
+/// is what makes the already-registered case below a real 4xx rather than
+/// something only the background task ever sees.
 pub async fn add(
     State(state): State<AppState>,
     CurrentSession(session): CurrentSession,
@@ -193,14 +217,71 @@ pub async fn add(
     })?;
     let dir = dir.to_string_lossy().into_owned();
 
-    let metadata_gid = state
+    let metadata_gid = match state
         .aria2
         .add_uri(
             &form.magnet,
             serde_json::json!({"bt-metadata-only": "true", "follow-torrent": "mem"}),
         )
-        .await?;
+        .await
+    {
+        Ok(gid) => gid,
+        // Not a server fault: this infohash is already known to aria2,
+        // either genuinely downloading or a metadata pass a previous attempt
+        // never got to free — the pod dying mid-`add` being the likely way,
+        // now that finishing it runs detached from the request that started
+        // it. aria2's error does not say which, and guessing wrong is worse
+        // than asking: forcibly clearing it here would silently cancel a
+        // real download if it guessed wrong. The download list is already on
+        // the page — that is where "which one is it" gets answered.
+        Err(AppError::Upstream(msg)) if is_already_registered(&msg) => {
+            return Err(AppError::BadRequest(
+                "this magnet is already added or downloading".to_string(),
+            ));
+        }
+        Err(e) => return Err(e),
+    };
 
+    tokio::spawn(finish_add(
+        state,
+        session.sub,
+        form.magnet,
+        dir,
+        metadata_gid,
+    ));
+
+    Ok(StatusCode::ACCEPTED.into_response())
+}
+
+/// Everything about adding a magnet that cannot happen inside the request
+/// that asked for it. Detached by `tokio::spawn`, so the only way its outcome
+/// reaches anyone is the SSE stream the page already keeps open — a resolving
+/// magnet shows as the `Resolving` row it always did — and, on failure, the
+/// log: there is no response left to carry it back to.
+async fn finish_add(
+    state: AppState,
+    sub: String,
+    magnet: String,
+    dir: String,
+    metadata_gid: String,
+) {
+    if let Err(e) = finish_add_inner(&state, &sub, &magnet, &dir, &metadata_gid).await {
+        tracing::error!(
+            gid = %metadata_gid,
+            infohash = magnet_infohash(&magnet).unwrap_or("unknown"),
+            error = %e,
+            "add: failed after the request was already accepted"
+        );
+    }
+}
+
+async fn finish_add_inner(
+    state: &AppState,
+    sub: &str,
+    magnet: &str,
+    dir: &str,
+    metadata_gid: &str,
+) -> AppResult<()> {
     // `Complete` is what "the metadata has arrived" actually means. Waiting for a
     // non-empty file list instead is racy: aria2 populates `files` slightly
     // before it flips the status, so the pass could still be active when the
@@ -208,7 +289,7 @@ pub async fn add(
     // rejected as a duplicate of a download that had not finished letting go.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
     let files = loop {
-        let status = state.aria2.tell_status(&metadata_gid).await?;
+        let status = state.aria2.tell_status(metadata_gid).await?;
         if status.status == Status::Error {
             return Err(AppError::Upstream(
                 status
@@ -248,7 +329,7 @@ pub async fn add(
         .filter(|f| filter::is_garbage(&f.path))
         .fold((0u32, 0u64), |(n, b), f| (n + 1, b + f.length));
     tracing::info!(
-        sub = %session.sub,
+        sub = %sub,
         magnet_files = files.len(),
         wanted = indices.len(),
         skipped,
@@ -257,17 +338,17 @@ pub async fn add(
         "starting download"
     );
 
-    free_infohash(&state, &metadata_gid).await?;
+    free_infohash(state, metadata_gid).await?;
 
     state
         .aria2
         .add_uri(
-            &form.magnet,
+            magnet,
             serde_json::json!({"dir": dir, "select-file": indices.join(",")}),
         )
         .await?;
 
-    Ok(StatusCode::NO_CONTENT.into_response())
+    Ok(())
 }
 
 /// Stop and purge the metadata-only pass so its infohash is free again.
@@ -591,6 +672,244 @@ mod tests {
             result.is_err(),
             "must not report the infohash free as fine when aria2 could not be reached at all"
         );
+    }
+
+    #[test]
+    fn already_registered_is_recognised_by_aria2s_own_wording() {
+        assert!(is_already_registered(
+            "InfoHash abcd1234 is already registered."
+        ));
+        assert!(!is_already_registered("connection refused"));
+    }
+
+    #[test]
+    fn magnet_infohash_reads_the_btih_parameter_and_stops_at_the_next_one() {
+        assert_eq!(
+            magnet_infohash("magnet:?xt=urn:btih:ABCD1234&dn=Some.Show"),
+            Some("ABCD1234")
+        );
+        assert_eq!(magnet_infohash("magnet:?dn=no-hash-here"), None);
+    }
+
+    /// Everything below builds a fake aria2 on axum (already a dependency —
+    /// its `hyper` server handles connection reuse without a hand-rolled
+    /// listener) to exercise `add` and the detached `finish_add` together,
+    /// the way a real request does.
+    mod add_flow {
+        use std::sync::{Arc, Mutex};
+        use std::time::Duration as StdDuration;
+
+        use axum::Json;
+        use axum::extract::State as AxumState;
+        use axum::routing::post;
+
+        use crate::auth::session::Session;
+        use crate::config::Root;
+
+        use super::*;
+
+        /// What the mock hands back for `aria2.tellStatus` on the metadata
+        /// gid — `Active` forever pins "the caller never waits for this",
+        /// `Complete` on the first poll lets the rest of the flow run to
+        /// completion inside a test.
+        #[derive(Clone, Copy)]
+        enum MetadataOutcome {
+            NeverResolves,
+            ResolvesImmediately,
+        }
+
+        #[derive(Clone)]
+        struct MockAria2 {
+            calls: Arc<Mutex<Vec<String>>>,
+            metadata_add_result: Arc<serde_json::Value>,
+            metadata_outcome: MetadataOutcome,
+        }
+
+        async fn rpc(
+            AxumState(mock): AxumState<MockAria2>,
+            Json(body): Json<serde_json::Value>,
+        ) -> Json<serde_json::Value> {
+            let method = body["method"].as_str().unwrap_or_default().to_string();
+            mock.calls.lock().unwrap().push(method.clone());
+            let response = match method.as_str() {
+                "aria2.addUri" => {
+                    if body["params"][1].get("bt-metadata-only").is_some() {
+                        (*mock.metadata_add_result).clone()
+                    } else {
+                        serde_json::json!({"result": "real-gid"})
+                    }
+                }
+                "aria2.tellStatus" => {
+                    let status = match mock.metadata_outcome {
+                        MetadataOutcome::NeverResolves => "active",
+                        MetadataOutcome::ResolvesImmediately => "complete",
+                    };
+                    serde_json::json!({"result": {
+                        "gid": "metadata-gid",
+                        "status": status,
+                        "totalLength": "100",
+                        "completedLength": "0",
+                        "downloadSpeed": "0",
+                        "uploadSpeed": "0",
+                        "connections": "0",
+                        "dir": "/mnt/kontent/movies",
+                        "files": [{"index": "1", "path": "/mnt/kontent/movies/Movie.mkv", "length": "100"}],
+                    }})
+                }
+                "aria2.remove" | "aria2.removeDownloadResult" => {
+                    serde_json::json!({"result": "OK"})
+                }
+                other => panic!("unexpected aria2 method in test: {other}"),
+            };
+            let mut envelope = serde_json::json!({"jsonrpc": "2.0", "id": "mariastew"});
+            envelope
+                .as_object_mut()
+                .unwrap()
+                .extend(response.as_object().unwrap().clone());
+            Json(envelope)
+        }
+
+        async fn mock_server(
+            metadata_add_result: serde_json::Value,
+            metadata_outcome: MetadataOutcome,
+        ) -> (String, Arc<Mutex<Vec<String>>>) {
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            let mock = MockAria2 {
+                calls: calls.clone(),
+                metadata_add_result: Arc::new(metadata_add_result),
+                metadata_outcome,
+            };
+            let app = axum::Router::new().route("/", post(rpc)).with_state(mock);
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            (format!("http://{addr}/"), calls)
+        }
+
+        fn test_state(aria2_url: String) -> AppState {
+            let mut s = state(aria2_url.clone());
+            s.config = Arc::new(Config {
+                bind_addr: String::new(),
+                aria2_rpc_url: aria2_url,
+                roots: vec![Root {
+                    name: "movies".to_string(),
+                    path: std::path::PathBuf::from("/mnt/kontent/movies"),
+                }],
+                public_url: String::new(),
+                oidc: Oidc {
+                    issuer: String::new(),
+                    client_id: String::new(),
+                    client_secret: String::new(),
+                },
+                telegram: None,
+            });
+            s
+        }
+
+        fn add_form() -> AddForm {
+            AddForm {
+                magnet: "magnet:?xt=urn:btih:abc".to_string(),
+                dir: "/mnt/kontent/movies".to_string(),
+            }
+        }
+
+        fn session() -> Session {
+            Session {
+                id: "s".to_string(),
+                sub: "tester".to_string(),
+                expires: std::time::Instant::now() + StdDuration::from_secs(60),
+            }
+        }
+
+        async fn wait_for_calls(calls: &Mutex<Vec<String>>, expected: usize) {
+            for _ in 0..200 {
+                if calls.lock().unwrap().len() >= expected {
+                    return;
+                }
+                tokio::time::sleep(StdDuration::from_millis(10)).await;
+            }
+            panic!(
+                "timed out waiting for {expected} calls, saw {:?}",
+                calls.lock().unwrap()
+            );
+        }
+
+        /// The bug this whole task exists to fix: `add` used to hold the
+        /// connection open for as long as the metadata poll took — up to 60s
+        /// — which the browser does not wait for. Here the metadata never
+        /// resolves at all, and `add` still has to return well inside a
+        /// fraction of a second, because the only thing standing between the
+        /// caller and a response is one `addUri` round trip.
+        #[tokio::test]
+        async fn add_returns_before_the_metadata_poll_completes() {
+            let (url, _calls) = mock_server(
+                serde_json::json!({"result": "metadata-gid"}),
+                MetadataOutcome::NeverResolves,
+            )
+            .await;
+            let state = test_state(url);
+
+            let response = tokio::time::timeout(
+                StdDuration::from_millis(500),
+                add(State(state), CurrentSession(session()), Form(add_form())),
+            )
+            .await
+            .expect("add must return promptly, not wait on the metadata poll")
+            .expect("add must accept a valid magnet and destination");
+
+            assert_eq!(response.status(), StatusCode::ACCEPTED);
+        }
+
+        /// Pins the ordering the original "InfoHash ... is already
+        /// registered" bug lived in, now running detached: the real `addUri`
+        /// must not be issued until `remove`/`removeDownloadResult` have run.
+        #[tokio::test]
+        async fn finish_add_frees_the_metadata_infohash_before_the_real_add() {
+            let (url, calls) = mock_server(
+                serde_json::json!({"result": "metadata-gid"}),
+                MetadataOutcome::ResolvesImmediately,
+            )
+            .await;
+            let state = test_state(url);
+
+            add(State(state), CurrentSession(session()), Form(add_form()))
+                .await
+                .unwrap();
+
+            wait_for_calls(&calls, 5).await;
+            assert_eq!(
+                calls.lock().unwrap().as_slice(),
+                [
+                    "aria2.addUri",
+                    "aria2.tellStatus",
+                    "aria2.remove",
+                    "aria2.removeDownloadResult",
+                    "aria2.addUri",
+                ]
+            );
+        }
+
+        /// This magnet already being known to aria2 is not a server fault —
+        /// it must read as a 4xx the caller can act on, not the 502 an
+        /// unrecognised upstream error gets.
+        #[tokio::test]
+        async fn add_maps_an_already_registered_infohash_to_bad_request() {
+            let (url, _calls) = mock_server(
+                serde_json::json!({"error": {"code": 1, "message": "InfoHash abc is already registered."}}),
+                MetadataOutcome::NeverResolves,
+            )
+            .await;
+            let state = test_state(url);
+
+            let result = add(State(state), CurrentSession(session()), Form(add_form())).await;
+
+            assert!(
+                matches!(result, Err(AppError::BadRequest(_))),
+                "expected BadRequest, got {result:?}"
+            );
+        }
     }
 
     /// aria2 marks the metadata-only pass with this literal prefix for as


### PR DESCRIPTION
Two live downloads exposed this. A 4K release got the right file **by luck** and left a `.jpg` and a `.txt` in the library; a 1080p release reported **complete** at 2 MB, having downloaded the wrong entry entirely.

## The file list came from the wrong download

`bt-metadata-only` produces a download whose file list describes *itself* — one entry. The torrent's real contents belong to the download aria2 spawns from it, linked by `followedBy`. We were filtering against the one-entry list, so `select-file=1` was a guess that only held when the video happened to be first. Our own log said `magnet_files=1` for a three-file torrent every time.

Now the selection is read from the followed download and applied to it with `changeOption`. That collapses the whole flow: one gid for a magnet's entire life instead of two, so the second `addUri` and its `InfoHash … is already registered` failure mode are gone rather than worked around — `free_infohash` is deleted.

The mechanism was verified against a real aria2 1.37.0 on the same alpine base the image uses, driving a self-made torrent end to end: `followedBy` → the child's real file list → `changeOption` moving both `dir` and `select-file`. Production evidence already showed the link firing on every add (`gid 0bb46093… following 06e23d02…`); we were simply reading the wrong side of it.

## Deselected files still landed

aria2 fetches whole pieces, so a small file sharing a piece boundary with a selected one is written regardless of `selected: false`. `--file-allocation=none` prevents preallocation, not this. #260 anticipated it.

A sweep now runs on completion, from the watcher that already observes the transition rather than a second poller. It deletes only files that are **both** deselected by aria2 and rejected by the filter, and every path goes through `resolve_existing` first — this is code that unlinks files in the media library, so containment is checked immediately before the delete rather than inferred earlier.

## Tests

The regression test puts the video at **index 2**, which is the case that produced the 2 MB film, and asserts the `changeOption` carries `select-file: "2"` along with the new call order. The sweep is tested against a real temporary filesystem: a selected file survives, a deselected non-garbage file survives, deselected garbage and its `.aria2` sidecar go, and garbage outside every root is refused.

84 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs7qxMHbC1WyagqYLDMxHQ