### PR TITLE
fix(mariastew): stop telling aria2 to fetch the metadata and stop

### DIFF
--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -13,22 +13,32 @@ patched over SSE ([Datastar](https://data-star.dev), vendored at
 
 Downloads are written directly into the media tree the picker offers, not a
 staging directory that something else sweeps later. That is safe because the
-scene-garbage filter (`src/filter.rs`) runs **before** the real download
-starts, not after: adding a magnet does a metadata-only aria2 pass first,
-`follow-torrent` spawns the real download from the resolved metadata,
-`filter::is_garbage` picks the indices worth keeping from *that* download's
-own file list — not the metadata pass's, which always has exactly one entry,
-itself — and `aria2.changeOption` applies the selection to it. Combined with
-aria2's `--file-allocation=none`, a file the filter rejected never touches
-disk for its own sake.
+scene-garbage filter (`src/filter.rs`) runs as early as it can: adding a
+magnet resolves under its own gid first, `follow-torrent` spawns the real
+download from the resolved metadata, `filter::is_garbage` picks the indices
+worth keeping from *that* download's own file list — not the resolving gid's,
+which always has exactly one entry, itself — and `aria2.changeOption` applies
+the selection to it. `finish_add_inner` pauses the download the moment it
+exists and unpauses it only after `changeOption` has taken, which closes most
+(not all — see below) of the window a full, unfiltered selection would
+otherwise fetch in.
 
-aria2 still downloads whole pieces regardless of selection, though, so a
-small deselected file sharing a piece boundary with a selected one can land
-anyway. `notify::sweep_garbage` runs from the same completion watch that
-sends the Telegram message, deletes whatever is both deselected and
-`filter::is_garbage`, and never touches a selected file or one that is merely
-small. This is the "line of code rather than a design change" a stray
-zero-byte file was always expected to need.
+There is no `bt-metadata-only` pass ahead of this that stops before any
+content flows: it stops `follow-torrent` from ever spawning the real download
+at all, so `finish_add_inner` would poll for a `followedBy` that never
+arrives (see the commit that removed it for the production incident this
+caused). Selection is applied to a download that is already running, not one
+that hasn't started yet — the pause above is what limits the exposure, not
+a delay before it exists.
+
+aria2 also downloads whole pieces regardless of selection, so a small
+deselected file sharing a piece boundary with a selected one can land anyway
+even once selection is correct. `notify::sweep_garbage` runs from the same
+completion watch that sends the Telegram message, deletes whatever is both
+deselected and `filter::is_garbage`, and never touches a selected file or one
+that is merely small. This is the "line of code rather than a design change"
+a stray zero-byte file was always expected to need — and now also the
+backstop for whatever the pause above does not catch in time.
 
 ## One image, run twice
 
@@ -97,7 +107,7 @@ files, and `/auth/*` are the only routes outside that layer (`src/main.rs`).
 |---|---|---|
 | `/` | GET | The page: current roots and the download list |
 | `/stream` | GET | SSE stream, one tick per second (`routes::TICK_SECS`), patching the download list in place |
-| `/add` | POST | `magnet` + `dir` form fields — validates and starts the metadata pass, then returns `202` immediately; the poll, the filter, and starting the real download run detached (see `routes::finish_add`), and their outcome shows up through `/stream` like any other download |
+| `/add` | POST | `magnet` + `dir` form fields — validates and starts the magnet resolving, then returns `202` immediately; the poll, the filter, and applying the selection run detached (see `routes::finish_add`), and their outcome shows up through `/stream` like any other download |
 | `/downloads/{gid}/pause` | POST | |
 | `/downloads/{gid}/resume` | POST | |
 | `/downloads/{gid}/remove` | POST | See "Seeding, and why cancel has two meanings" above |

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -47,14 +47,15 @@ pub(crate) async fn all_downloads(state: &AppState) -> AppResult<Vec<Download>> 
     let mut downloads = state.aria2.tell_active().await?;
     downloads.extend(state.aria2.tell_waiting(0, 100).await?);
     downloads.extend(state.aria2.tell_stopped(0, 100).await?);
-    // `add`'s metadata-only pass exists to learn a magnet's file list before
-    // the real download starts (see `finish_add_inner`), and aria2 keeps it
-    // in the stopped list forever afterward — nothing here ever removes it,
-    // since the real download is applied to the gid `follow-torrent` spawned
-    // from it rather than a second `addUri` that would need the metadata
-    // pass's own gid freed first. aria2 names it `[METADATA]<torrent name>`
-    // for as long as it exists, which is how it is told apart from a real
-    // download: it is never something the user asked to watch.
+    // Every magnet `add` starts resolves under its own gid before
+    // `follow-torrent` spawns the real download from it (see
+    // `finish_add_inner`), and aria2 keeps that resolving gid in the stopped
+    // list forever afterward — nothing here ever removes it, since the real
+    // download is applied to the gid `follow-torrent` spawned rather than a
+    // second `addUri` that would need this one's gid freed first. aria2
+    // names it `[METADATA]<torrent name>` for as long as it exists, which is
+    // how it is told apart from a real download: it is never something the
+    // user asked to watch.
     downloads.retain(|d| !is_metadata_row(d));
     Ok(downloads)
 }
@@ -218,11 +219,19 @@ pub async fn add(
     })?;
     let dir = dir.to_string_lossy().into_owned();
 
+    // No `bt-metadata-only`: that option means "fetch the metadata and stop"
+    // — aria2 never spawns the followed download at all, so `followed_by`
+    // below would never appear and every add would run out the clock and
+    // fail. Measured against the real compose stack: plain `follow-torrent`
+    // (`mem`) still splits into the same parent-resolves/child-downloads
+    // shape `finish_add_inner` depends on, it just does not pause for
+    // anyone's benefit at the metadata boundary — see the pause/changeOption
+    // /unpause dance below for what that costs.
     let metadata_gid = match state
         .aria2
         .add_uri(
             &form.magnet,
-            serde_json::json!({"bt-metadata-only": "true", "follow-torrent": "mem"}),
+            serde_json::json!({"dir": dir, "follow-torrent": "mem"}),
         )
         .await
     {
@@ -276,30 +285,43 @@ async fn finish_add(
     }
 }
 
-/// Selects and starts the real download by following the metadata pass to
-/// the download aria2 spawned from it, rather than issuing a second `addUri`
-/// for the same magnet.
+/// How long to wait for a magnet to resolve before giving up. Measured
+/// against the real compose stack: a well-seeded torrent resolved in ~24s,
+/// so a minute is thin for anything sparser — this is not a request the
+/// caller is waiting on anymore (see `add`), so there is no UX cost to
+/// affording a slow swarm real time rather than optimising for a fast one.
+const RESOLVE_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Selects and starts the real download by following the metadata-resolving
+/// gid to the download aria2 spawned from it, rather than issuing a second
+/// `addUri` for the same magnet.
 ///
-/// A `bt-metadata-only` gid's own `files` describes the metadata pass
-/// itself — one entry, regardless of how many files the torrent actually
-/// has, which is why a three-file torrent used to log `magnet_files=1` and
-/// select whichever file happened to be index 1. `follow-torrent` (`mem`)
-/// spawns a second download from the resolved metadata and links the two by
-/// gid — `followedBy` on this one, `following` on that one — and it is that
-/// second gid's `files` that lists what the torrent actually contains.
-/// Reading the selection from anywhere else means the filter never sees most
-/// of the torrent and the choice of what to keep is decided by file order.
+/// A magnet's own `files` describes the resolving gid itself — one entry,
+/// regardless of how many files the torrent actually has, which is why a
+/// three-file torrent used to log `magnet_files=1` and select whichever file
+/// happened to sit at index 1. `follow-torrent` (`mem`) spawns a second
+/// download from the resolved metadata and links the two by gid —
+/// `followedBy` on this one, `following` on that one — and it is that second
+/// gid's `files` that lists what the torrent actually contains. Reading the
+/// selection from anywhere else means the filter never sees most of the
+/// torrent and the choice of what to keep is decided by file order.
 ///
 /// Applying the selection through `changeOption` rather than a second
 /// `addUri` also means there is no infohash collision to resolve: one
 /// download exists for this magnet from start to finish, under one gid.
+///
+/// `bt-metadata-only` used to stop aria2 right at that boundary, so the
+/// selection was in place before a single content byte arrived. Without it
+/// (see `add` for why it had to go — it also stops `followedBy` from ever
+/// appearing), the child starts downloading everything the instant it
+/// exists. That is what the pause/change/unpause sequence below is for.
 async fn finish_add_inner(
     state: &AppState,
     sub: &str,
     dir: &str,
     metadata_gid: &str,
 ) -> AppResult<()> {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    let deadline = tokio::time::Instant::now() + RESOLVE_TIMEOUT;
     let child_gid = loop {
         let status = state.aria2.tell_status(metadata_gid).await?;
         if status.status == Status::Error {
@@ -313,16 +335,29 @@ async fn finish_add_inner(
             break gid;
         }
         if tokio::time::Instant::now() >= deadline {
-            return Err(AppError::BadRequest(
-                "the magnet did not resolve".to_string(),
-            ));
+            // Not the caller's mistake — a sparse swarm, or one that never
+            // shows up at all, is an upstream condition and reads as one.
+            return Err(AppError::Upstream(format!(
+                "the magnet did not resolve within {}s",
+                RESOLVE_TIMEOUT.as_secs()
+            )));
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     };
 
-    // The child exists only once aria2 has parsed a complete torrent out of
-    // the resolved metadata, so its file list is already known the moment it
-    // is queryable — there is nothing left to wait for here.
+    // Freshly created and, without `bt-metadata-only`, already fetching
+    // aria2's default selection — every file. Pausing closes most of that
+    // window before `changeOption` narrows it; best-effort, because a
+    // download that will not pause just keeps fetching everything for the
+    // few seconds this takes, which `notify::sweep_garbage` already exists
+    // to clean up after. Unpausing back out is not best-effort: if the pause
+    // took, it must be undone, or the download sits paused forever with
+    // nothing left to tell anyone it is stuck.
+    let paused = state.aria2.pause(&child_gid).await.is_ok();
+
+    // The child's file list is already known the moment it is queryable —
+    // aria2 only creates it once it has parsed a complete torrent out of the
+    // resolved metadata, so there is nothing left to wait for here.
     let files = state.aria2.tell_status(&child_gid).await?.files;
     if files.is_empty() {
         return Err(AppError::Upstream(
@@ -367,6 +402,10 @@ async fn finish_add_inner(
             serde_json::json!({"dir": dir, "select-file": indices.join(",")}),
         )
         .await?;
+
+    if paused {
+        state.aria2.unpause(&child_gid).await?;
+    }
 
     Ok(())
 }
@@ -702,6 +741,9 @@ mod tests {
             change_option_calls: Arc<Mutex<Vec<serde_json::Value>>>,
             metadata_add_result: Arc<serde_json::Value>,
             metadata_outcome: MetadataOutcome,
+            /// Lets a test exercise the case where the child will not pause —
+            /// `finish_add_inner` treats that as tolerable and best-effort.
+            pause_should_succeed: bool,
         }
 
         fn download_result(gid: &str, status: &str, files: serde_json::Value) -> serde_json::Value {
@@ -723,15 +765,28 @@ mod tests {
             Json(body): Json<serde_json::Value>,
         ) -> Json<serde_json::Value> {
             let method = body["method"].as_str().unwrap_or_default().to_string();
-            mock.calls.lock().unwrap().push(method.clone());
+            let calls_so_far = {
+                let mut calls = mock.calls.lock().unwrap();
+                calls.push(method.clone());
+                calls.iter().filter(|m| *m == "aria2.addUri").count()
+            };
             let response = match method.as_str() {
+                // No `bt-metadata-only` field to key off any more — there is
+                // exactly one `addUri` for a magnet's whole life now, so a
+                // second one is the duplicate-infohash bug back, not a
+                // legitimate second call to tell apart from the first.
+                "aria2.addUri" if calls_so_far == 1 => (*mock.metadata_add_result).clone(),
                 "aria2.addUri" => {
-                    if body["params"][1].get("bt-metadata-only").is_some() {
-                        (*mock.metadata_add_result).clone()
+                    panic!("a second addUri means the duplicate-infohash bug is back")
+                }
+                "aria2.pause" => {
+                    if mock.pause_should_succeed {
+                        serde_json::json!({"result": "OK"})
                     } else {
-                        panic!("a second addUri means the duplicate-infohash bug is back")
+                        serde_json::json!({"error": {"code": 1, "message": "not pausable"}})
                     }
                 }
+                "aria2.unpause" => serde_json::json!({"result": "OK"}),
                 "aria2.tellStatus" => {
                     let gid = body["params"][0].as_str().unwrap_or_default();
                     match (&mock.metadata_outcome, gid) {
@@ -779,6 +834,14 @@ mod tests {
             metadata_add_result: serde_json::Value,
             metadata_outcome: MetadataOutcome,
         ) -> Mock {
+            mock_server_with_pause(metadata_add_result, metadata_outcome, true).await
+        }
+
+        async fn mock_server_with_pause(
+            metadata_add_result: serde_json::Value,
+            metadata_outcome: MetadataOutcome,
+            pause_should_succeed: bool,
+        ) -> Mock {
             let calls = Arc::new(Mutex::new(Vec::new()));
             let change_option_calls = Arc::new(Mutex::new(Vec::new()));
             let mock = MockAria2 {
@@ -786,6 +849,7 @@ mod tests {
                 change_option_calls: change_option_calls.clone(),
                 metadata_add_result: Arc::new(metadata_add_result),
                 metadata_outcome,
+                pause_should_succeed,
             };
             let app = axum::Router::new().route("/", post(rpc)).with_state(mock);
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -911,14 +975,16 @@ mod tests {
                 .await
                 .unwrap();
 
-            wait_for_calls(&mock.calls, 4).await;
+            wait_for_calls(&mock.calls, 6).await;
             assert_eq!(
                 mock.calls.lock().unwrap().as_slice(),
                 [
                     "aria2.addUri",
                     "aria2.tellStatus",
+                    "aria2.pause",
                     "aria2.tellStatus",
                     "aria2.changeOption",
+                    "aria2.unpause",
                 ]
             );
 
@@ -928,6 +994,46 @@ mod tests {
             assert_eq!(params[0], "child-gid");
             assert_eq!(params[1]["select-file"], "2");
             assert_eq!(params[1]["dir"], "/mnt/kontent/movies");
+        }
+
+        /// The pause is best-effort — a child that will not pause must not
+        /// stop the add, since `notify::sweep_garbage` is the backstop for
+        /// whatever it fetches in the meantime. What must not happen is an
+        /// `unpause` call for a pause that never took: that would either
+        /// error against a gid aria2 never actually paused, or (worse, if
+        /// aria2 tolerated it) mask a real pause/unpause mismatch elsewhere.
+        #[tokio::test]
+        async fn finish_add_tolerates_a_child_that_will_not_pause() {
+            let child_files = serde_json::json!([
+                {"index": "1", "path": "/mnt/kontent/movies/movie.mkv", "length": "100", "selected": "true"},
+            ]);
+            let mock = mock_server_with_pause(
+                serde_json::json!({"result": "metadata-gid"}),
+                MetadataOutcome::ResolvesWithChild {
+                    child_gid: "child-gid".to_string(),
+                    child_files,
+                },
+                false,
+            )
+            .await;
+            let state = test_state(mock.url);
+
+            add(State(state), CurrentSession(session()), Form(add_form()))
+                .await
+                .unwrap();
+
+            wait_for_calls(&mock.calls, 5).await;
+            assert_eq!(
+                mock.calls.lock().unwrap().as_slice(),
+                [
+                    "aria2.addUri",
+                    "aria2.tellStatus",
+                    "aria2.pause",
+                    "aria2.tellStatus",
+                    "aria2.changeOption",
+                ],
+                "a failed pause must not be followed by an unpause"
+            );
         }
 
         /// This magnet already being known to aria2 is not a server fault —


### PR DESCRIPTION
Every add failed. `bt-metadata-only=true` means exactly what it says: fetch the torrent's metadata and go no further. aria2 therefore never spawned the download the code then waited for, so `followedBy` never appeared and each attempt died after its timeout with "the magnet did not resolve".

The previous fix's live verification missed this because it drove an HTTP-served `.torrent` rather than a magnet, and `bt-metadata-only` only applies to magnets — so it exercised everything except the flag combination the real path uses.

Measured against the running stack, same magnet each time:

- `bt-metadata-only=true` + `follow-torrent=mem` — after 25s: `{"connections":"30","status":"active","totalLength":"14871"}`. That is the metadata, and no `followedBy` ever appears.
- `pause: true` — `{"connections":"0","status":"paused"}` for 60s. A paused magnet does not fetch metadata at all.
- `follow-torrent: mem` with `dir` — parent completes at ~24s with `followedBy`, and the child carries the right directory and the real size.

So the initial `addUri` now passes `dir` and `follow-torrent` alone. The child is paused the moment it appears, the selection is applied, and it is unpaused — which closes the window where it would otherwise fetch files the filter rejects. Pausing is best-effort, since the completion sweep already backstops what leaks through; unpausing is not, because a download left paused with nothing to say so is worse than one that was never paused.

The resolve timeout moves from 60s to 10 minutes, which costs nothing now the work is detached from the request, and a timeout is no longer reported as a bad request — a sparse swarm is not the caller's mistake.

## Verification

Driven through the app in compose with a real, legally-distributed magnet (Debian's netinst ISO). `/add` answered `202` in 9.7ms; the RPC sequence was `addUri → tellStatus ×6 → pause → tellStatus → changeOption → unpause`; and afterwards aria2 reported `completedLength == totalLength == 791674880` with the file present at 755MB on the host bind mount. The page rendered it complete, which exercises the selective-completion fix live as well.

A new test proves the best-effort split holds rather than merely compiling: with `pause` failing, the flow still completes and `unpause` is correctly not called.

93 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs7qxMHbC1WyagqYLDMxHQ