### PR TITLE
303 fix(mariastew): destination path starts at the picked root

### DIFF
--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -146,7 +146,7 @@ startup rather than the request that first needs it.
 
 | Variable | Required | Default | What |
 |---|---|---|---|
-| `ROOTS` | Yes | — | `name:/path,name:/path` — each is both a pod mount and a root the picker may browse into or write under |
+| `ROOTS` | Yes | — | `name:/path,name:/path` — each is both a pod mount and a root the picker may browse into or write under. The name is also what the picker calls the place: a destination reads `tv/some-show`, never the mount above it |
 | `PUBLIC_URL` | Yes | — | Where this is reached from outside; must match the OIDC redirect URI, since the pod cannot infer it from a request it hasn't had yet |
 | `OIDC_ISSUER` | Yes | — | Hydra's issuer URL |
 | `OIDC_CLIENT_ID` | Yes | — | |

--- a/apps/mariastew/src/config.rs
+++ b/apps/mariastew/src/config.rs
@@ -117,6 +117,32 @@ impl Config {
             .then(|| candidate.to_path_buf())
     }
 
+    /// What the picker calls a path: the root's name, then whatever is below
+    /// it, so `/mnt/kontent/tv/some-show` reads as `tv/some-show`.
+    ///
+    /// The mount point above a root is a fact about how the pod is assembled
+    /// and answers nothing about where a download lands, but it is the part of
+    /// a path a phone-width line spends its width on first — and the tail, the
+    /// part that does answer, is what gets pushed onto a second line or off the
+    /// end. The root's own name is used rather than its last path segment
+    /// because `ROOTS` names each root independently of where it is mounted.
+    ///
+    /// A path outside every root comes back unchanged. Nothing renders one —
+    /// the picker only labels paths it has already resolved — so there is
+    /// nothing to design for beyond not losing the string.
+    pub fn label(&self, path: &Path) -> String {
+        self.roots
+            .iter()
+            .find_map(|root| {
+                let rest = path.strip_prefix(&root.path).ok()?;
+                Some(match rest.as_os_str().is_empty() {
+                    true => root.name.clone(),
+                    false => format!("{}/{}", root.name, rest.display()),
+                })
+            })
+            .unwrap_or_else(|| path.display().to_string())
+    }
+
     /// Resolve a path that must already exist, following symlinks.
     ///
     /// [`Self::resolve`] cannot answer for symlinks, because it is deciding
@@ -223,6 +249,45 @@ mod tests {
         assert_eq!(c.resolve("/etc/passwd"), None);
         assert_eq!(c.resolve("relative/path"), None);
         assert_eq!(c.resolve(""), None);
+    }
+
+    #[test]
+    fn label_starts_at_the_root_that_was_picked() {
+        let c = conf(&[("tv", "/mnt/kontent/tv"), ("movies", "/mnt/kontent/movies")]);
+        assert_eq!(
+            c.label(Path::new("/mnt/kontent/tv/some-show")),
+            "tv/some-show"
+        );
+        assert_eq!(c.label(Path::new("/mnt/kontent/tv")), "tv");
+        assert_eq!(
+            c.label(Path::new("/mnt/kontent/movies/2046/disc 1")),
+            "movies/2046/disc 1"
+        );
+    }
+
+    /// The root's name is the label, not its last path segment — `ROOTS` sets
+    /// the two independently and the picker offers the name, so a label built
+    /// from the mount would disagree with the entry that was tapped to get
+    /// here.
+    #[test]
+    fn label_uses_the_configured_name_rather_than_the_directory_name() {
+        let c = conf(&[("music", "/mnt/kontent/navidrome-media")]);
+        assert_eq!(
+            c.label(Path::new("/mnt/kontent/navidrome-media/Boards of Canada")),
+            "music/Boards of Canada"
+        );
+    }
+
+    /// Nothing renders a path from outside a root, but losing the string would
+    /// turn a bug into a blank line saying nothing.
+    #[test]
+    fn label_leaves_a_path_outside_every_root_alone() {
+        let c = conf(&[("tv", "/mnt/kontent/tv")]);
+        assert_eq!(c.label(Path::new("/etc/passwd")), "/etc/passwd");
+        assert_eq!(
+            c.label(Path::new("/mnt/kontent/tv-old")),
+            "/mnt/kontent/tv-old"
+        );
     }
 
     /// A sibling whose name merely starts with the root's is not inside it.

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -542,6 +542,7 @@ pub async fn browse(
         views::Browse {
             parent: None,
             path: String::new(),
+            label: String::new(),
             dirs: state
                 .config
                 .roots
@@ -606,8 +607,12 @@ pub async fn browse(
             None => None,
         };
 
+        // Labelled from `dir` rather than from `q.path`: the two differ only
+        // when the request came in through a symlink, and the canonical one is
+        // the place the download actually lands.
         views::Browse {
             parent,
+            label: state.config.label(&dir),
             path: q.path.clone(),
             dirs,
         }

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -127,6 +127,7 @@ impl Page {
         Browse {
             parent: None,
             path: String::new(),
+            label: String::new(),
             dirs: self
                 .roots
                 .iter()
@@ -153,7 +154,13 @@ pub struct Downloads {
 pub struct Browse {
     /// Absent at a root, which is where browsing upward stops.
     pub parent: Option<String>,
+    /// The absolute path, which is what the hidden inputs submit and what
+    /// aria2 is eventually handed — never what is shown.
     pub path: String,
+    /// The same place said the way the picker says it (`Config::label`), which
+    /// is the only form that reaches the screen. Empty at the root list, where
+    /// no destination has been picked yet.
+    pub label: String,
     pub dirs: Vec<DirView>,
 }
 
@@ -209,6 +216,7 @@ mod tests {
         let html = Browse {
             parent: Some("/mnt/kontent".into()),
             path: "/mnt/kontent/tv".into(),
+            label: "tv".into(),
             dirs: vec![DirView {
                 name: "'+alert(1)+'".into(),
                 path: "/mnt/kontent/tv/'+alert(1)+'".into(),
@@ -431,6 +439,7 @@ mod tests {
         let browse = Browse {
             parent: Some("/mnt/tv".into()),
             path: "/mnt/tv/show".into(),
+            label: "tv/show".into(),
             dirs: vec![DirView {
                 name: "season 1".into(),
                 path: "/mnt/tv/show/season 1".into(),
@@ -453,6 +462,7 @@ mod tests {
         let browse = Browse {
             parent: None,
             path: String::new(),
+            label: String::new(),
             dirs: vec![DirView {
                 name: long_name.into(),
                 path: format!("/mnt/kontent/movies/{long_name}"),
@@ -490,6 +500,7 @@ mod tests {
         let browse = Browse {
             parent: None,
             path: String::new(),
+            label: String::new(),
             dirs: vec![
                 DirView {
                     name: part1.clone(),
@@ -515,17 +526,35 @@ mod tests {
     /// reason the directory rows do, and `min-w-0` is load-bearing: without
     /// it a flex item will not shrink to wrap at all, it will just overflow
     /// its row instead.
+    ///
+    /// It is the label that is shown, not the path (#303): the mount point
+    /// above the root is the same on every destination, so it distinguishes
+    /// nothing while costing the line the width the tail needs. The absolute
+    /// path is still in the markup — the hidden inputs submit it — so this
+    /// asserts it is not what gets *rendered*.
     #[test]
-    fn the_current_path_wraps_and_can_shrink_in_its_flex_row() {
-        let long_path = "/mnt/kontent/movies/Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
+    fn the_current_path_is_shown_from_the_picked_root_and_wraps() {
+        let tail = "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
         let browse = Browse {
             parent: Some("/mnt/kontent/movies".into()),
-            path: long_path.into(),
+            path: format!("/mnt/kontent/movies/{tail}"),
+            label: format!("movies/{tail}"),
             dirs: vec![],
         }
         .render()
         .unwrap();
-        assert!(browse.contains(long_path), "the full path must be shown");
+        assert!(
+            browse.contains(&format!(">movies/{tail}</span>")),
+            "the label, whole tail included, is not the line's text: {browse}"
+        );
+        assert!(
+            !browse.contains(&format!(">/mnt/kontent/movies/{tail}")),
+            "the mount point is back on the visible line: {browse}"
+        );
+        assert!(
+            browse.contains(&format!(r#"name="dir" value="/mnt/kontent/movies/{tail}""#)),
+            "the absolute path must still be what is submitted: {browse}"
+        );
         assert!(
             browse.contains("break-words") && browse.contains("min-w-0"),
             "the path cannot wrap or shrink inside its flex row: {browse}"
@@ -737,6 +766,7 @@ mod tests {
         let browse = Browse {
             parent: Some("/mnt/kontent/movies".into()),
             path: "/mnt/kontent/movies/downloads".into(),
+            label: "movies/downloads".into(),
             dirs: vec![],
         }
         .render()
@@ -759,6 +789,7 @@ mod tests {
         let browse = Browse {
             parent: None,
             path: String::new(),
+            label: String::new(),
             dirs: vec![],
         }
         .render()

--- a/apps/mariastew/templates/browse.html
+++ b/apps/mariastew/templates/browse.html
@@ -33,8 +33,14 @@
          truncated: this is the one line whose whole job is saying exactly
          where a download will land, so hiding any of it defeats the point.
          `break-words` is the fallback for one path segment on its own
-         wider than the dialog — a scene-release directory name can be. #}
-    <span class="font-mono opacity-70 break-words min-w-0 flex-1">{% if path.is_empty() %}/{% else %}{{ path }}{% endif %}</span>
+         wider than the dialog — a scene-release directory name can be.
+
+         `label`, not `path`: it starts at the root that was picked, so the
+         mount point above it does not spend the width that the tail — the
+         part that actually distinguishes one destination from another —
+         needs. The absolute path is still what the hidden inputs below
+         submit. #}
+    <span class="font-mono opacity-70 break-words min-w-0 flex-1">{% if label.is_empty() %}All destinations{% else %}{{ label }}{% endif %}</span>
     {# The listing is a `readdir` against spinning disks holding a media
          library, so seconds is its normal speed, not a fault. Without this
          a tap produced nothing observable until the new list appeared and


### PR DESCRIPTION
The picker's path line showed the absolute path. `/mnt/kontent/tv/some-show` is now `tv/some-show`.

The mount point above a root is identical on every destination, so it distinguishes nothing while taking the width away from the tail — which is the part that answers "where will this land", the one question that line exists for, and the first part to wrap or run off a phone-width dialog.

## Load-bearing decisions

- **`Config::label`** maps an absolute path to `<root name>/<rest>`. It uses the root's configured `ROOTS` **name**, not the last segment of its path: `ROOTS` sets the two independently, and the name is what the picker offered to get here — a label built from the mount could disagree with the entry that was tapped. A path outside every root comes back unchanged; nothing renders one, but losing the string would turn a bug into a blank line.
- **Labelled from the canonicalised directory**, not from the query string. They differ only when the request came in through a symlink, and the canonical one is where the download actually lands.
- **`Browse.path` is unchanged and still absolute.** It is what the hidden `dir`/`parent` inputs submit and what aria2 is eventually handed. Only what renders moved to the new `label` field — there is a test asserting exactly that split.
- **The root list says "All destinations" rather than `/`.** Nothing else in the picker refers to a filesystem root any more, so `/` claimed a place that no longer appears anywhere.

## Confirming it

`cargo test` in `apps/mariastew` — 107 pass.

- `config::tests::label_*` — a path under a root, a root itself, a root whose name differs from its directory, and a path outside every root.
- `views::tests::the_current_path_is_shown_from_the_picked_root_and_wraps` — replaces the old assertion that the *full* path is rendered. Asserts the label is the line's text, that the absolute form is not rendered as text, and that `name="dir"` still submits the absolute path.

## Not in scope

The download list (`downloads.html`) still shows each row's `dir` as an absolute path. `Row` is built by `From<&Download>` with no access to `Config`, so giving it the same treatment is a separate change to a different surface. Filed separately rather than ridden along.

Closes #303