### PR TITLE
305 feat(mariastew): a mock aria2 that serves every download state

### DIFF
--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -264,6 +264,39 @@ fixtures without a full compose cycle — use the `mise` tasks directly:
 `dev-data/movies` and reseed from scratch — the way back to a clean
 fixture-only state once a test download has piled up in there.
 
+#### Every download state at once
+
+```sh
+mise run mariastew:dev:mock
+```
+
+The fixture library populates the picker; this populates the *list*. A real
+aria2 shows whatever the swarm is doing, and the states most worth designing
+against — stalled, can't connect, no seeders, failed — are the ones a swarm
+produces on its own schedule or not at all. `scripts/mock-aria2.ts` answers
+the JSON-RPC calls `src/aria2.rs` makes (`src/aria2.rs` is the only thing that
+talks to aria2, so that is the whole surface) and serves one download per
+`Health`, plus a queued row and a magnet still resolving.
+
+It advances on each poll rather than serving a fixed list: the moving row
+gains bytes and the magnet resolves after a few seconds into the download
+`follow-torrent` would have spawned. A still list proves only the first paint
+— that a row morphs in place, that an expanded row stays expanded through the
+morph, and that a bar moves at all are things only a changing one can show.
+Pause, resume and remove mutate its state, so the buttons do something.
+
+It is not a simulator and is not trying to be: it holds a list and hands it
+out. Anything that depends on aria2's real behaviour — the metadata pass, the
+selection filter — has its own tests in `src/filter.rs` and
+`routes::tests::add_flow`.
+
+The task is `ARIA2_RPC_URL` plus `--scale aria2=0`, because compose has no way
+to say "this profile replaces that service". Port 6801, so the two can never
+race for a bind and the env var is the only thing deciding which one is
+talked to. For the plain `cargo run` loop, `mise run mariastew:mock` runs it
+alone and `ARIA2_RPC_URL=http://127.0.0.1:6801/jsonrpc cargo run` points at
+it.
+
 This mirrors "One image, run twice" above rather than inventing a second
 image: `docker-compose.yml` builds one image and runs it as both services,
 overriding the aria2 container's entrypoint to run `aria2c` with the same

--- a/apps/mariastew/docker-compose.yml
+++ b/apps/mariastew/docker-compose.yml
@@ -45,7 +45,9 @@ services:
       # tests) rather than a single flat root.
       ROOTS: "tv:/tv,movies:/movies"
       PUBLIC_URL: "http://localhost:8080"
-      ARIA2_RPC_URL: "http://127.0.0.1:6800/jsonrpc"
+      # Overridable so the mock below can be swapped in without editing this
+      # file — see `mise run mariastew:dev:mock`.
+      ARIA2_RPC_URL: "${ARIA2_RPC_URL:-http://127.0.0.1:6800/jsonrpc}"
       # Never actually reached: /auth/dev-login mints a session without
       # touching Hydra. Config::from_env still requires all three to be set.
       OIDC_ISSUER: "https://dev.invalid"
@@ -85,3 +87,29 @@ services:
     volumes:
       - ./dev-data/tv:/tv
       - ./dev-data/movies:/movies
+
+  # Opt-in (profile `mock`), and not a second aria2: it holds a list and
+  # hands it out. See scripts/mock-aria2.ts for why the states it serves are
+  # the ones a real swarm is worst at producing on demand.
+  #
+  # Port 6801 rather than 6800 so it never races the real aria2 for the bind,
+  # which means the choice of which one mariastew talks to is `ARIA2_RPC_URL`
+  # alone. `mise run mariastew:dev:mock` is that env var plus `--scale
+  # aria2=0`, so the real one is not started at all.
+  #
+  # Same node image and read-only scripts mount as `seed` above — this only
+  # ever runs on the host and never ships.
+  mock-aria2:
+    profiles: ["mock"]
+    image: node:24-alpine
+    working_dir: /app
+    depends_on:
+      - mariastew
+    network_mode: "service:mariastew"
+    environment:
+      PORT: "6801"
+      MOCK_DIR: "/tv"
+    volumes:
+      - ./scripts:/app/scripts:ro
+    command:
+      ["node", "--experimental-strip-types", "scripts/mock-aria2.ts"]

--- a/apps/mariastew/scripts/mock-aria2.ts
+++ b/apps/mariastew/scripts/mock-aria2.ts
@@ -1,0 +1,335 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * A fake aria2 JSON-RPC endpoint that serves one download per `Health`.
+ *
+ * The download list is the part of this UI that cannot be looked at on
+ * demand. A stall, a dead magnet, an unconnectable swarm and a disk error are
+ * exactly the states worth designing against, and every one of them is
+ * something a real swarm hands over on its own schedule or not at all — so
+ * the states that most need looking at are the ones least available while
+ * looking. This serves all of them at once, immediately.
+ *
+ * mariastew reaches aria2 over JSON-RPC and nothing else (`src/aria2.rs`), so
+ * answering `tellActive`/`tellWaiting`/`tellStopped` is the whole of what it
+ * takes to drive the page. It is deliberately not a simulator: it holds a
+ * list, hands it out, and lets the mutating calls change it.
+ *
+ * It advances on every poll rather than serving a fixed list. A still list
+ * renders once and proves only the first paint — it cannot show that the SSE
+ * patch morphs a row in place, that an expanded `<details>` survives the
+ * morph, or that a bar moves at all. The moving row therefore gains bytes,
+ * and the resolving one resolves after a few seconds into a real download the
+ * way a magnet does.
+ *
+ * Numbers go out as strings and booleans as "true"/"false" because that is
+ * aria2's wire shape, not an oversight — `RawDownload` parses them back.
+ */
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.PORT ?? 6801);
+const TV = process.env.MOCK_DIR ?? "/tv";
+
+/** aria2 reports every counter as a decimal string. */
+type Download = {
+  gid: string;
+  status: "active" | "waiting" | "paused" | "error" | "complete" | "removed";
+  totalLength: string;
+  completedLength: string;
+  downloadSpeed: string;
+  uploadSpeed: string;
+  connections: string;
+  numSeeders: string;
+  errorMessage?: string;
+  dir: string;
+  files: {
+    index: string;
+    path: string;
+    length: string;
+    completedLength: string;
+    selected: string;
+  }[];
+  bittorrent?: { info?: { name?: string } };
+  followedBy: string[];
+};
+
+const GiB = 1024 ** 3;
+
+/**
+ * A counter, the way aria2 writes one: a decimal string with no fractional
+ * part. Rust parses these into `u64` and falls back to 0 on anything it
+ * cannot read, so a plain `String(1.2 * GiB)` — which JavaScript renders as
+ * `1288490188.8` — arrives as a download of size zero, and the row reads
+ * "starting" forever. Every number below goes through here.
+ */
+const n = (value: number) => String(Math.round(value));
+
+/**
+ * One download. The file list is a single entry sized to match the totals,
+ * which is all `selected_totals` needs — the filter's multi-file cases have
+ * their own tests in `src/filter.rs` and are not what this is for.
+ */
+function download(
+  gid: string,
+  name: string,
+  fields: Partial<Download> & { totalLength: string; completedLength: string },
+): Download {
+  return {
+    gid,
+    status: "active",
+    downloadSpeed: "0",
+    uploadSpeed: "0",
+    connections: "0",
+    numSeeders: "0",
+    dir: `${TV}/${name}`,
+    followedBy: [],
+    bittorrent: { info: { name } },
+    files: [
+      {
+        index: "1",
+        path: `${TV}/${name}/${name}.mkv`,
+        length: fields.totalLength,
+        completedLength: fields.completedLength,
+        selected: "true",
+      },
+    ],
+    ...fields,
+  };
+}
+
+/**
+ * One per `Health`, plus the two rows that are a state of the list rather
+ * than of a download: a queued one and a metadata pass.
+ *
+ * The names are real release names, long ones included — a row's layout is
+ * decided by its name far more than by its numbers, and a tidy `test.iso`
+ * has never reproduced anything.
+ */
+function fixtures(): Download[] {
+  return [
+    // Resolving: a magnet with no metadata yet, so no size and no
+    // percentage. aria2 names it this way and `all_downloads` keeps it
+    // visible for as long as it is the only evidence the add happened.
+    download("1000000000000001", "[METADATA]8f9c2b1d4e6a", {
+      totalLength: "0",
+      completedLength: "0",
+      connections: "3",
+    }),
+    // Moving: the ordinary case, and the only row that advances below.
+    download(
+      "1000000000000002",
+      "Some.Show.S02E04.2160p.WEB-DL.DDP5.1.HDR.H.265-GROUP",
+      {
+        totalLength: n(6 * GiB),
+        completedLength: n(2 * GiB),
+        downloadSpeed: n(3.4 * 1024 * 1024),
+        uploadSpeed: n(180 * 1024),
+        connections: "24",
+        numSeeders: "11",
+      },
+    ),
+    // Stalled: peers connected, nothing arriving. May recover on its own,
+    // which is why it is not an error.
+    download(
+      "1000000000000003",
+      "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1",
+      {
+        totalLength: n(9 * GiB),
+        completedLength: n(1.2 * GiB),
+        connections: "6",
+        numSeeders: "2",
+      },
+    ),
+    // Can't connect: seeders exist and none is connected. Ordinary whenever
+    // the peer port is not forwarded — see `upnp` in the README.
+    download(
+      "1000000000000004",
+      "Paris.Texas.1984.2160p.UHD.BluRay.x265-SOMEONE",
+      {
+        totalLength: n(14 * GiB),
+        completedLength: n(400 * 1024 * 1024),
+        numSeeders: "9",
+      },
+    ),
+    // No seeders: nothing to wait for, and the only row whose fix is a
+    // different magnet.
+    download("1000000000000005", "Obscure.Thing.1971.DVDRip.XviD", {
+      totalLength: n(1.4 * GiB),
+      completedLength: n(30 * 1024 * 1024),
+    }),
+    download("1000000000000006", "Another.Show.S01E01.1080p.WEB-DL", {
+      status: "paused",
+      totalLength: n(2 * GiB),
+      completedLength: n(900 * 1024 * 1024),
+    }),
+    // Ready: every wanted byte has arrived and it is still seeding, which is
+    // what `--seed-ratio=0.0` means and why this stays in the active list.
+    download(
+      "1000000000000007",
+      "Stalker.1979.Criterion.1080p.BluRay.x264-CINEFILE",
+      {
+        totalLength: n(8 * GiB),
+        completedLength: n(8 * GiB),
+        uploadSpeed: n(620 * 1024),
+        connections: "31",
+        numSeeders: "0",
+      },
+    ),
+    download("1000000000000008", "Broken.Release.2019.1080p.WEB-DL", {
+      status: "error",
+      totalLength: n(3 * GiB),
+      completedLength: n(1 * GiB),
+      errorMessage:
+        "File /tv/Broken.Release.2019.1080p.WEB-DL exists, but a control file(*.aria2) does not exist.",
+    }),
+    download("1000000000000009", "Queued.Show.S03E07.1080p.WEB-DL", {
+      status: "waiting",
+      totalLength: n(2.5 * GiB),
+      completedLength: "0",
+    }),
+  ];
+}
+
+let downloads = fixtures();
+
+const MOVING = "1000000000000002";
+const RESOLVING = "1000000000000001";
+/** Polls before the magnet resolves — `routes::TICK_SECS` is one second. */
+const RESOLVE_AFTER = 8;
+let polls = 0;
+
+/**
+ * Called once per list poll, so what the page shows changes between SSE
+ * patches. Only two rows move: everything else is a state, and a state that
+ * drifted would stop being the thing it was put there to show.
+ */
+function advance() {
+  polls += 1;
+
+  const moving = downloads.find((d) => d.gid === MOVING);
+  if (moving && moving.status === "active") {
+    const speed = Number(moving.downloadSpeed);
+    const done = Math.min(
+      Number(moving.totalLength),
+      Number(moving.completedLength) + speed,
+    );
+    moving.completedLength = n(done);
+    moving.files[0].completedLength = n(done);
+  }
+
+  // The magnet resolves into the download `follow-torrent` spawns, and the
+  // metadata gid moves to the stopped list — which is where `all_downloads`
+  // sweeps it, so the real row replaces it rather than joining it.
+  const resolving = downloads.find((d) => d.gid === RESOLVING);
+  if (resolving && polls === RESOLVE_AFTER) {
+    resolving.status = "complete";
+    resolving.followedBy = ["1000000000000010"];
+    downloads.push(
+      download("1000000000000010", "Resolved.Show.S01E02.1080p.WEB-DL", {
+        totalLength: n(1.8 * GiB),
+        completedLength: "0",
+        downloadSpeed: n(900 * 1024),
+        connections: "8",
+        numSeeders: "4",
+      }),
+    );
+  }
+}
+
+const byStatus = (...wanted: Download["status"][]) =>
+  downloads.filter((d) => wanted.includes(d.status));
+
+/**
+ * Only the methods `src/aria2.rs` actually calls. An unknown one is answered
+ * with a JSON-RPC error rather than an empty result, so a method added on the
+ * Rust side shows up here as a visible failure instead of an empty list.
+ */
+function dispatch(method: string, params: unknown[]): unknown {
+  const gid = params[0] as string;
+  const found = () => downloads.find((d) => d.gid === gid);
+
+  switch (method) {
+    case "aria2.tellActive":
+      advance();
+      return byStatus("active");
+    case "aria2.tellWaiting":
+      return byStatus("waiting", "paused");
+    case "aria2.tellStopped":
+      return byStatus("complete", "error", "removed");
+    case "aria2.tellStatus": {
+      const d = found();
+      if (!d) throw new Error(`No such download: ${gid}`);
+      return d;
+    }
+    case "aria2.pause":
+    case "aria2.forcePause": {
+      const d = found();
+      if (d) {
+        d.status = "paused";
+        d.downloadSpeed = "0";
+        d.uploadSpeed = "0";
+      }
+      return gid;
+    }
+    case "aria2.unpause": {
+      const d = found();
+      if (d) {
+        d.status = "active";
+        d.downloadSpeed = n(2 * 1024 * 1024);
+      }
+      return gid;
+    }
+    case "aria2.remove":
+    case "aria2.forceRemove":
+    case "aria2.removeDownloadResult":
+      downloads = downloads.filter((d) => d.gid !== gid);
+      return gid;
+    case "aria2.addUri": {
+      // Answers the way a magnet does: a metadata gid that resolves later,
+      // which is the path `finish_add` polls. `changeOption` then applies a
+      // selection to whatever `followedBy` names.
+      const newGid = String(2000000000000000 + downloads.length);
+      downloads.push(
+        download(newGid, `[METADATA]${newGid.slice(-12)}`, {
+          totalLength: "0",
+          completedLength: "0",
+        }),
+      );
+      return newGid;
+    }
+    case "aria2.changeOption":
+      return "OK";
+    default:
+      throw new Error(`Unhandled method: ${method}`);
+  }
+}
+
+createServer((req, res) => {
+  let body = "";
+  req.on("data", (chunk) => (body += chunk));
+  req.on("end", () => {
+    let payload: { id?: unknown; method?: string; params?: unknown[] } = {};
+    try {
+      payload = JSON.parse(body);
+      const result = dispatch(payload.method ?? "", payload.params ?? []);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ jsonrpc: "2.0", id: payload.id, result }));
+    } catch (e) {
+      // aria2's own shape for a refusal, so the Rust side takes the same
+      // path it would in production rather than one only this can produce.
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id ?? null,
+          error: {
+            code: 1,
+            message: String(e instanceof Error ? e.message : e),
+          },
+        }),
+      );
+    }
+  });
+}).listen(PORT, () => {
+  console.log(`mock aria2 on http://127.0.0.1:${PORT}/jsonrpc`);
+  console.log(`${downloads.length} downloads, one per state`);
+});

--- a/mise.toml
+++ b/mise.toml
@@ -84,6 +84,19 @@ description = "Run mariastew + aria2 locally against a debug build (needs docker
 dir = "apps/mariastew"
 run = "docker compose up --build"
 
+[tasks."mariastew:dev:mock"]
+description = "Run mariastew against the mock aria2 — every download state at once (needs docker)"
+dir = "apps/mariastew"
+# `--scale aria2=0` because the real one is not wanted here at all, and the
+# env var is what decides which RPC mariastew talks to. Compose has no way to
+# express "this profile replaces that service", so both halves are stated.
+run = "ARIA2_RPC_URL=http://127.0.0.1:6801/jsonrpc docker compose --profile mock up --build --scale aria2=0"
+
+[tasks."mariastew:mock"]
+description = "Run the mock aria2 alone, for the plain `cargo run` loop"
+dir = "apps/mariastew"
+run = "./scripts/mock-aria2.ts"
+
 [tasks."update:apps"]
 description = "Report or apply upstream version bumps"
 run = "./packages/infra/src/update-apps.ts"


### PR DESCRIPTION
Closes #305.

The picker has had a fixture library for a while. The list has had nothing —
a real aria2 shows whatever the swarm is doing, and the states most worth
designing against (stalled, can't connect, no seeders, failed) are the ones a
swarm produces on its own schedule or not at all.

## What it does

`apps/mariastew/scripts/mock-aria2.ts` answers the JSON-RPC calls
`src/aria2.rs` makes. That is the entire surface — nothing else in the service
talks to aria2 — so a list held in memory drives the whole page.

- **One download per `Health`**: starting, downloading, stalled, can't
  connect, no seeders, paused, ready, failed. Plus a queued row and a magnet
  still resolving. Names are real release names, long ones included: a row's
  layout is decided by its name far more than by its numbers.
- **It moves.** The downloading row gains bytes each poll and the magnet
  resolves after ~8s into the download `follow-torrent` would have spawned,
  with the metadata gid moving to the stopped list so `all_downloads` sweeps
  it. A still list proves only the first paint — that a row morphs in place,
  that an expanded `<details>` survives the morph, and that a bar moves at all
  need a changing one.
- **Pause, resume and remove mutate it**, so the buttons do something.
- Not a simulator, and not trying to be. Anything depending on aria2's real
  behaviour (the metadata pass, the selection filter) already has tests in
  `src/filter.rs` and `routes::tests::add_flow`.

## Wiring

`mise run mariastew:dev:mock`. It is profile `mock` on port **6801** — never
6800 — so the two can't race for a bind and `ARIA2_RPC_URL` is the only thing
deciding which one is talked to. The task is that variable plus
`--scale aria2=0`, because compose has no way to say "this profile replaces
that service"; `docker compose up` alone is byte-for-byte unchanged. For the
plain `cargo run` loop, `mise run mariastew:mock` runs it standalone.

## One thing worth reading

Counters go out rounded. aria2 never emits a fractional one, `RawDownload`
falls back to 0 on a string Rust can't parse, and `String(1.2 * GiB)` is
`1288490188.8` — so an unrounded fixture arrives as a download of size zero
and the row reads "starting" forever. The first version had exactly that, and
it was caught by looking at the rendered output rather than by any assertion.

## Verifying

Run the task and read the list: nine rows, one per state, the top one
advancing and the magnet resolving into `Resolved.Show.S01E02`. Verified here
against the real binary — all nine states rendered with the right badge, and
the progress value moved between two reads.

`docker compose config --services` still lists exactly `seed mariastew aria2`
without `--profile mock`, so the default path cannot have changed.

Filed separately from what it turned up: a queued download reads **"no
seeders"** (#313), because `Health` has no branch for `Status::Waiting`.
