### PR TITLE
fix(mariastew): stop the UDP hostPort eating aria2's own tracker replies

### DIFF
--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -56,6 +56,23 @@ multicast the pod network does not carry — being on the LAN means leaving the
 NetworkPolicy, and the pod that writes to the media library is not the one to
 take out of its confinement for that.
 
+**TCP only, and the UDP half must stay unpublished.** aria2 sends its tracker
+announces and DHT queries from the same port it listens on. Give that port a
+UDP `hostPort` and the replies arrive addressed to it, so Cilium matches them
+against the hostPort service on the way into the pod and rewrites their source
+port; aria2 keys a reply to the endpoint it asked, sees a stranger, and drops
+it. Every announce then times out
+(`UDPT received CONNECT reply from <tracker>:<random> invalid transaction_id`)
+and every DHT lookup goes unanswered — a client with no way to find a peer, so
+magnets sit on "starting" forever while the swarm is healthy. Outbound DHT and
+uTP are unaffected, which is how any client behind a NAT operates anyway.
+
+DHT needs one more thing to be real: a bootstrap node (`--dht-entry-point`)
+and a routing-table file it can actually write. `--dht-file-path` defaults
+under `$HOME/.cache`, and HOME is unset here, so aria2 resolved it to
+`//.cache` and could neither load nor save — leaving every peer lookup to run
+against an empty table.
+
 Being reachable is not only about seeding. A peer nobody can dial connects
 only to those who accept its own connections, and clients rank unconnectable
 peers last when choking, so it depresses download speed too — the usual

--- a/packages/mariastew/src/mariastew.schemas.ts
+++ b/packages/mariastew/src/mariastew.schemas.ts
@@ -59,7 +59,9 @@ export const Aria2ConfSchema = z.strictObject({
    * Nothing can forward a port that changes on restart, so pinning it is the
    * prerequisite for every way of becoming reachable — a router forward, a
    * DNAT on the gateway, or IPv6 — and it costs nothing while none of them is
-   * in place. The same number serves TCP peers and the UDP DHT.
+   * in place. The same number serves TCP peers and the UDP DHT, but only the
+   * TCP half is published on the node — see the `ports` comment for why a UDP
+   * hostPort on this number silently disables trackers and DHT.
    *
    * Being unreachable is not only a seeding problem. A peer nobody can dial
    * connects only to those who accept its own connections, and many clients

--- a/packages/mariastew/src/mariastew.ts
+++ b/packages/mariastew/src/mariastew.ts
@@ -29,13 +29,12 @@ lan() { ip -4 route get 1.1.1.1 | awk '{for (i = 1; i < NF; i++) if ($i == "src"
 
 while :; do
   ip=$(lan)
-  for proto in TCP UDP; do
-    if upnpc -e aria2 -a "$ip" "$PORT" "$PORT" "$proto" "$LEASE" >/dev/null 2>&1; then
-      echo "mapped $proto $PORT -> $ip:$PORT for $LEASE""s"
-    else
-      echo "WARNING: could not map $proto $PORT — aria2 stays outbound-only"
-    fi
-  done
+  # TCP only. There is no UDP hostPort to forward to — see the ports below.
+  if upnpc -e aria2 -a "$ip" "$PORT" "$PORT" TCP "$LEASE" >/dev/null 2>&1; then
+    echo "mapped TCP $PORT -> $ip:$PORT for $LEASE""s"
+  else
+    echo "WARNING: could not map TCP $PORT — aria2 stays outbound-only"
+  fi
   # Half the lease, so a refusal has a full cycle to recover in before the
   # router drops the mapping.
   sleep $((LEASE / 2))
@@ -228,6 +227,16 @@ export function createMariastew(
                   `--listen-port=${conf.aria2.listenPort}`,
                   `--dht-listen-port=${conf.aria2.listenPort}`,
                   "--enable-dht=true",
+                  // Without one of these the routing table starts empty and
+                  // stays empty: every peer lookup runs against zero nodes, so
+                  // DHT contributes nothing and a magnet has only its trackers.
+                  // transmissionbt rather than the more familiar
+                  // router.bittorrent.com, which does not answer from here.
+                  "--dht-entry-point=dht.transmissionbt.com:6881",
+                  // Somewhere writable. The default is under `$HOME/.cache`,
+                  // and HOME is unset, so aria2 resolved it to `//.cache` and
+                  // failed to both read and write it.
+                  "--dht-file-path=/tmp/dht.dat",
                   "--bt-enable-lpd=true",
                   "--enable-peer-exchange=true",
                 ],
@@ -235,16 +244,21 @@ export function createMariastew(
                 // which is what any forward has to aim at — without it the
                 // port exists only inside the pod network and nothing
                 // upstream can be pointed anywhere useful.
+                //
+                // TCP only, deliberately. aria2 sends UDP — tracker announces
+                // and every DHT query — from the port it listens on, so a UDP
+                // hostPort on that number collides with its own replies:
+                // Cilium matches them against the hostPort service on the way
+                // in and rewrites their source port, and aria2 keys replies on
+                // (endpoint, transaction id) and discards the lot. That is a
+                // client with no tracker and no DHT, which is a magnet that
+                // never resolves. Losing the UDP forward costs unsolicited
+                // inbound DHT and uTP; both still work outbound, which is how
+                // every client behind a NAT lives.
                 ports: [
                   {
                     name: "bt-tcp",
                     protocol: "TCP",
-                    containerPort: conf.aria2.listenPort,
-                    hostPort: conf.aria2.listenPort,
-                  },
-                  {
-                    name: "bt-udp",
-                    protocol: "UDP",
                     containerPort: conf.aria2.listenPort,
                     hostPort: conf.aria2.listenPort,
                   },


### PR DESCRIPTION
## What this does

Publishes aria2's peer port over TCP only, and gives DHT a bootstrap node and a
routing-table path it can write.

aria2 sends its tracker announces and DHT queries *from* the port it listens on,
so the replies arrive addressed to that port. `hostPort` on the UDP side put a
service in front of that number, Cilium matched the replies against it on the
way into the pod and rewrote their source port, and aria2 — which keys a reply
to the endpoint it asked — discarded every one of them. No announce, no DHT, no
way to learn a peer, so a magnet sat in metadata resolution ("starting" in the
UI) indefinitely against a swarm with twenty seeders in it.

## Load-bearing decisions

- **TCP forward stays, UDP forward goes.** TCP is what a peer dials, so
  reachability — the whole point of #287 — is intact. What is lost is
  unsolicited inbound DHT and uTP; both still work outbound, which is how any
  client behind a NAT operates.
- **The UPnP mapper drops its UDP mapping too**, since there is now nothing on
  the node for it to point at.
- **`dht.transmissionbt.com:6881` as the entry point**, not the more familiar
  `router.bittorrent.com:6881`, which does not answer from this network.
- **`--dht-file-path=/tmp/dht.dat`.** The default sits under `$HOME/.cache` and
  HOME is unset in this container, so aria2 resolved it to `//.cache` and could
  neither load nor save the routing table.

## How to confirm

The claim is a source-port rewrite that happens between the node and the pod,
and it is directly observable on the running deployment:

- On the node's uplink, a tracker reply carries source port 1337. Inside the
  pod's network namespace (`nsenter -t <aria2 pid> -n tcpdump`) the same packet
  carries a random high port.
- Only the hostPort number is affected. A UDP socket bound to 51414, 6881 or
  1337 in that same namespace gets replies with correct source ports.
- An unsolicited packet sent to the hostPort from another node is *not*
  rewritten — so it is the collision with the pod's own egress, not the hostPort
  DNAT on its own.
- aria2's own account of it, with `log-level=debug` set over the RPC:
  `UDPT received CONNECT reply from <tracker>:<random> invalid transaction_id`,
  then `Force fail infohash=...`, once per tracker on a 60s timeout.
- DHT: `Failed to load DHT routing table from //.cache/aria2/dht.dat`, then
  `DHTGetPeersCommand: Issuing PeerLookup` next to
  `DHTTaskExecutor: Executing 0 Task(s)`.

Not caused by the network, and worth not re-investigating: egress UDP to
trackers, DNS, and outbound TCP BitTorrent handshakes to swarm peers all succeed
from the pod, and the NetworkPolicy permits `0.0.0.0/0` minus RFC1918.

Deploys are manual for this service, and a deploy erases the aria2 queue — so
this wants to land when nothing is mid-download.

Closes #311
