### PR TITLE
feat(mariastew): rate and time left on the collapsed row

### DIFF
--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -11,7 +11,13 @@ patched over SSE ([Datastar](https://data-star.dev), vendored at
 
 ## What a row says it is doing
 
-A collapsed row answers "how is it going" — name, state, bar, destination.
+A collapsed row answers "how is it going" — name, state, bar, destination, and
+beside the destination the current rate and the time left. Those last two are
+there because a bar raises "will this be done tonight" and cannot settle it;
+behind a tap they were one tap too many. Both are absent rather than zeroed
+when nothing is moving, which is also why there is no countdown on a seeding
+row.
+
 Expanding it answers "what is aria2 actually doing", which needs rather more
 than a percentage:
 
@@ -24,10 +30,10 @@ than a percentage:
   "no seeders", which looks like a fault and is not one), or *checking files*
   (aria2 is hashing data that was already on disk, which reads as zero speed
   with peers connected and was otherwise indistinguishable from stalled).
-- **Readings, not just a bar:** time left, bytes given back and the share
-  ratio, peers against seeders, and the piece count and size — which is the
-  explanation for both lumpy progress and for a deselected file landing
-  anyway.
+- **Readings, not just a bar:** bytes done against total, up and down rates,
+  bytes given back and the share ratio, peers against seeders, and the piece
+  count and size — which is the explanation for both lumpy progress and for a
+  deselected file landing anyway.
 - **The file list, deselected files included.** What `filter::is_garbage`
   refused reached the disk and the pod's log and nowhere else, so "why did it
   not download that one" had no answer on the page.

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -65,12 +65,17 @@ pub struct Row {
     /// length. The icons carry the same meaning for a washed-out screen.
     pub bar_class: &'static str,
     pub state: &'static str,
-    pub down: String,
-    pub up: String,
+    /// Absent when nothing is moving — a rate of `0 B/s` reads as a
+    /// measurement, and an idle row has not measured anything. The collapsed
+    /// row shows `down` beside the destination and shows neither when it is
+    /// absent, so this has to be the absence rather than a dash.
+    pub down: Option<String>,
+    pub up: Option<String>,
     pub size: String,
     pub done: String,
     /// Time left at the current rate, absent whenever that rate would make one
-    /// up. See `Download::eta_secs`.
+    /// up. See `Download::eta_secs` — it is `None` whenever `down` is, so the
+    /// collapsed row can nest the two rather than combine them.
     pub eta: Option<String>,
     /// Given back to the swarm, and as a multiple of what was taken. The
     /// ratio is absent until something has actually been downloaded to divide
@@ -302,13 +307,13 @@ pub fn bytes(n: u64) -> String {
     format!("{value:.digits$} {}", UNITS[unit])
 }
 
-/// A transfer rate, or a dash when nothing is moving — a rate of `0 B/s` reads
-/// as a measurement, and an idle row has not measured anything.
-pub fn rate(n: u64) -> String {
-    if n == 0 {
-        return "—".to_string();
-    }
-    format!("{}/s", bytes(n))
+/// A transfer rate, or nothing when nothing is moving — a rate of `0 B/s`
+/// reads as a measurement, and an idle row has not measured anything. Whether
+/// that absence is drawn as a dash or as nothing at all is the caller's
+/// decision: the expanded panel is a table of readings and wants the dash, the
+/// collapsed row wants the space back.
+pub fn rate(n: u64) -> Option<String> {
+    (n > 0).then(|| format!("{}/s", bytes(n)))
 }
 
 /// A span of time in the two largest units it needs. Nobody waiting on a film
@@ -445,13 +450,13 @@ mod tests {
     }
 
     #[test]
-    fn rate_at_zero_is_a_dash() {
-        assert_eq!(rate(0), "—");
+    fn rate_at_zero_is_nothing_at_all() {
+        assert_eq!(rate(0), None);
     }
 
     #[test]
     fn rate_is_bytes_per_second() {
-        assert_eq!(rate(1024), "1.00 KiB/s");
+        assert_eq!(rate(1024).as_deref(), Some("1.00 KiB/s"));
     }
 
     #[test]
@@ -996,6 +1001,61 @@ mod tests {
         });
         assert!(finished.contains("badge-success"));
         assert!(!render(&moving()).contains("badge-success"));
+    }
+
+    /// The collapsed half of a row, which is what these assert about — the
+    /// rate and the time left are also in the readings panel below it, so
+    /// searching the whole document would pass on markup that never promoted
+    /// anything.
+    fn summary(page: &str) -> String {
+        let start = page.find("<summary").expect("a row has a summary");
+        let end = page.find("</summary>").expect("a row has a summary");
+        page[start..end].to_string()
+    }
+
+    /// #308: the two numbers that answer "will this be done tonight" were a
+    /// tap away, behind the same disclosure as the piece size and the
+    /// infohash. They now sit on the destination's line without one.
+    #[test]
+    fn the_collapsed_row_shows_the_rate_and_the_time_left() {
+        // 512 MiB left at 1 MiB/s.
+        let summary = summary(&render(&moving()));
+        assert!(summary.contains("1.00 MiB/s"), "no rate: {summary}");
+        assert!(summary.contains("8m 32s left"), "no time left: {summary}");
+    }
+
+    /// Nothing is moving, so there is no rate to show and no rate to divide
+    /// the remaining bytes by — a "0 B/s · 0s left" on a finished row is two
+    /// measurements nobody took. The badge already says "ready".
+    #[test]
+    fn an_idle_row_shows_neither_and_keeps_the_dash_in_the_readings() {
+        let page = render(&Download {
+            completed_length: 1_073_741_824,
+            download_speed: 0,
+            ..moving()
+        });
+        let summary = summary(&page);
+        assert!(
+            !summary.contains("B/s") && !summary.contains("left"),
+            "an idle row still shows a rate or a countdown: {summary}"
+        );
+        assert!(page.contains("—"), "the readings lost their dash: {page}");
+    }
+
+    /// The destination shares its line now, and a flex child will not shrink
+    /// to wrap without `min-w-0` — it overflows the row instead, which is the
+    /// bug this markup exists to avoid (see the picker's own path, #257).
+    #[test]
+    fn the_destination_can_still_shrink_and_wrap_beside_the_rate() {
+        let summary = summary(&render(&Download {
+            dir: "/mnt/kontent/tv/Show.Name.S01.2160p.UHD.BluRay.REMUX.HEVC.DTS-HD.MA.5.1/S01"
+                .to_string(),
+            ..moving()
+        }));
+        assert!(
+            summary.contains("min-w-0") && summary.contains("break-words"),
+            "the destination cannot wrap or shrink in its flex row: {summary}"
+        );
     }
 
     /// The other half of "idk where it has put the file": every row shows

--- a/apps/mariastew/templates/downloads.html
+++ b/apps/mariastew/templates/downloads.html
@@ -39,8 +39,24 @@
              is a full path and the tail is exactly what answers "which
              season folder did it land in", so hiding it with an ellipsis
              would recreate the problem that fix solved, just here instead
-             of there. #}
-        <p class="mt-1 text-xs break-words opacity-60">→ {{ row.dir }}</p>
+             of there. `min-w-0` is load-bearing now that it shares a flex
+             row: without it the path will not shrink to wrap, it overflows.
+
+             Sharing that row is the rate and the time left, which are the
+             answer to the question a bar raises and cannot settle — "is
+             this going to be done tonight". They were a tap away in the
+             readings panel, which is one tap too many for the two numbers
+             most likely to be the reason for opening the page at all.
+             Nested rather than combined because `eta` is `None` whenever
+             `down` is: there is no rate to divide the remaining bytes by.
+             Absent entirely when idle — a seeding or paused row has no
+             countdown, and the badge beside the name already says so. #}
+        <div class="mt-1 flex items-baseline justify-between gap-2 text-xs">
+          <p class="min-w-0 break-words opacity-60">→ {{ row.dir }}</p>
+          {% if let Some(down) = row.down %}
+          <span class="shrink-0 font-medium tabular-nums">↓ {{ down }}{% if let Some(eta) = row.eta %} · {{ eta }} left{% endif %}</span>
+          {% endif %}
+        </div>
       </div>
     </summary>
 
@@ -62,11 +78,11 @@
         </div>
         <div class="flex justify-between gap-2">
           <dt class="opacity-60">down</dt>
-          <dd class="text-right">{{ row.down }}</dd>
+          <dd class="text-right">{% if let Some(down) = row.down %}{{ down }}{% else %}—{% endif %}</dd>
         </div>
         <div class="flex justify-between gap-2">
           <dt class="opacity-60">up</dt>
-          <dd class="text-right">{{ row.up }}</dd>
+          <dd class="text-right">{% if let Some(up) = row.up %}{{ up }}{% else %}—{% endif %}</dd>
         </div>
         <div class="flex justify-between gap-2">
           <dt class="opacity-60">peers</dt>


### PR DESCRIPTION
Closes #308.

The rate and the time left are the two numbers that answer "will this be done
tonight", and a progress bar raises that question without settling it. Both sat
behind the row's disclosure, alongside the piece size and the infohash — one tap
too many for the readings most likely to be the reason for opening the page.
They now share the destination's line, right-aligned against it.

## Load-bearing decisions

**Absent, not zeroed.** `views::rate` returns `Option<String>` rather than a
dash. The expanded panel is a table of readings and still wants the dash for an
idle row; the collapsed row wants the space back. Making the absence the
caller's decision is what avoids a second field duplicating `down`. `up` got the
same treatment for symmetry — the rendered readings panel is unchanged.

**Nested, not combined.** `Download::eta_secs` is `None` whenever the rate is
zero (there is nothing to divide the remaining bytes by), so the countdown is
nested inside the rate rather than guarded separately. A seeding or paused row
shows neither, and the badge beside the name already says why.

**`min-w-0` on the destination.** It is now a flex child, and a flex child will
not shrink to wrap without it — it overflows the row instead. That is the same
trap the picker's own path hit in #257, so it is pinned by a test rather than
left to the next person to rediscover.

## Verifying

`cd apps/mariastew && cargo test` — 132 pass. The new ones render through
`Row::new` like the rest of the suite and assert against the `<summary>`
substring specifically, since searching the whole document would also match the
readings panel and pass on markup that promoted nothing:

- `the_collapsed_row_shows_the_rate_and_the_time_left` — 512 MiB left at
  1 MiB/s reads `1.00 MiB/s · 8m 32s left`
- `an_idle_row_shows_neither_and_keeps_the_dash_in_the_readings`
- `the_destination_can_still_shrink_and_wrap_beside_the_rate`

Version bumped to 0.1.10, which is what cuts the image and moves the pin.
Deploying is manual, as ever.