### PR TITLE
300 feat(mariastew): read the clipboard when the add sheet opens

### DIFF
--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -9,6 +9,17 @@ memory, so a deploy signs everyone out. The frontend is server-rendered HTML
 patched over SSE ([Datastar](https://data-star.dev), vendored at
 `assets/datastar.js`), not a client-side app.
 
+## Adding one
+
+Tapping Add reads the clipboard and fills the field if what is there is a
+magnet. It happens in the click handler because `readText()` needs the user
+gesture and `showModal()` does not spend it; what the browser does with that
+request is the browser's own business — Safari draws a Paste button, Chrome
+grants it silently, an insecure origin has no clipboard API — and every
+outcome other than "a magnet came back" leaves an empty field to type into. A
+field already typed into is never overwritten, since the prompt can outlive
+someone's patience with it.
+
 ## What a row says it is doing
 
 A collapsed row answers "how is it going" — name, state, bar, destination, and

--- a/apps/mariastew/templates/page.html
+++ b/apps/mariastew/templates/page.html
@@ -30,10 +30,20 @@
      adding downloads does not need saying twice. It keeps its accessible
      name in `aria-label` — the icon is `aria-hidden`, so without it the
      button would announce as nothing at all. #}
+{# The clipboard read happens here, in the click handler, because that is the
+     only place it can: every browser gates `readText()` on transient user
+     activation, and `showModal()` does not spend it. Whether a prompt appears
+     is the browser's call — Safari draws its own Paste button, Chrome grants
+     it silently on the gesture, an insecure origin has no `navigator.clipboard`
+     at all — so both arms are handled and none of them are an error: a refusal
+     or a clipboard holding something else just leaves an empty field to type
+     into. Only a magnet is pasted, since that is the only thing `/add` accepts,
+     and only into a field still empty, because the prompt can outlast the
+     moment someone gives up waiting and starts typing. #}
 <header class="bg-base-100 shadow-sm p-4">
   <button type="button" class="btn btn-primary btn-lg min-h-14 w-full"
     aria-label="Add download" title="Add download"
-    data-on:click="$add = {status: null, message: null}; document.getElementById('add-dialog').showModal()">{% call icons::plus(class="text-3xl") %}{% endcall %}</button>
+    data-on:click="$add = {status: null, message: null}; document.getElementById('add-dialog').showModal(); navigator.clipboard?.readText().then((text) => { const field = document.querySelector('#add-form [name=magnet]'); if (!field.value && text.trim().startsWith('magnet:?')) field.value = text.trim() }, () => {})">{% call icons::plus(class="text-3xl") %}{% endcall %}</button>
 </header>
 
 {% if aria2_unreachable %}


### PR DESCRIPTION
Closes #300.

Tapping Add now reads the clipboard and fills the magnet field if what is
there is a magnet. The paste that every add started with is gone.

## The load-bearing bits

- **It lives in the header button's `data-on:click`, not on the dialog.**
  `readText()` is gated on transient user activation in every browser, and
  `showModal()` does not spend it. Anywhere later — a `data-effect`, a
  `dialog` open handler — is past the gesture and rejects.
- **Both arms of the promise are handled, and neither is an error.** Safari
  draws its own Paste button, Chrome grants the read silently on the gesture,
  an insecure origin has no `navigator.clipboard` at all (the `?.`
  short-circuits the whole chain). A refusal, or a clipboard holding something
  else, leaves the empty field that was already there.
- **`magnet:?` only**, because that is the only thing `/add` accepts — pasting
  a URL would just walk into "That is not a magnet link."
- **Never overwrites a non-empty field.** The permission prompt can outlive
  the moment someone gives up waiting for it and starts typing.

No server change: `routes::add` and its validation are untouched.

## Confirming it

- `cargo test` (145 pass) — the template is compiled by Askama, so `cargo
  check` is what proves the changed HTML still parses. There is no test for
  the browser behaviour; it is four lines of DOM against an API no test
  harness here can grant, and asserting it would mean asserting a mock.
- By hand on `dl.blit.cc` after deploy: copy a magnet, tap Add, the field is
  filled. Copy anything else, tap Add, the field is empty. Deny the Safari
  paste prompt, the field is empty and nothing shows an error.

Version bumped to 0.1.16 — 0.1.15 was taken by `8af2f67` on main while this
was in flight.