### PR TITLE
301 chore(mariastew): invented names in fixtures, not real releases

### DIFF
--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -362,8 +362,8 @@ containers and the network; `dev-data/` is yours and is left alone.
 
 An empty picker cannot reproduce a layout bug — every one found so far only
 showed up because of what a real name does to the layout. `scripts/seed-dev-fixtures.ts`
-populates `dev-data/movies` with ~140 entries: a fixed set of real names
-from the owner's library, kept verbatim (full-width CJK brackets, runs of
+populates `dev-data/movies` with ~140 entries: a fixed set of invented names
+carrying the shapes that break layouts (full-width CJK brackets, runs of
 consecutive spaces, a leading `www.` prefix, square brackets, commas, names
 past 70 characters), padded out with deterministically generated filler so
 the picker's scroll cap is exercised against a realistic count rather than

--- a/apps/mariastew/scripts/mock-aria2.ts
+++ b/apps/mariastew/scripts/mock-aria2.ts
@@ -100,9 +100,9 @@ function download(
  * One per `Health`, plus the two rows that are a state of the list rather
  * than of a download: a queued one and a metadata pass.
  *
- * The names are real release names, long ones included — a row's layout is
- * decided by its name far more than by its numbers, and a tidy `test.iso`
- * has never reproduced anything.
+ * The names are invented but shaped like real release names, long ones
+ * included — a row's layout is decided by its name far more than by its
+ * numbers, and a tidy `test.iso` has never reproduced anything.
  */
 function fixtures(): Download[] {
   return [
@@ -131,7 +131,7 @@ function fixtures(): Download[] {
     // which is why it is not an error.
     download(
       "1000000000000003",
-      "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1",
+      "Static.Tide.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1",
       {
         totalLength: n(9 * GiB),
         completedLength: n(1.2 * GiB),
@@ -143,7 +143,7 @@ function fixtures(): Download[] {
     // the peer port is not forwarded — see `upnp` in the README.
     download(
       "1000000000000004",
-      "Paris.Texas.1984.2160p.UHD.BluRay.x265-SOMEONE",
+      "Marrow.Ridge.1984.2160p.UHD.BluRay.x265-SOMEONE",
       {
         totalLength: n(14 * GiB),
         completedLength: n(400 * 1024 * 1024),
@@ -165,7 +165,7 @@ function fixtures(): Download[] {
     // what `--seed-ratio=0.0` means and why this stays in the active list.
     download(
       "1000000000000007",
-      "Stalker.1979.Criterion.1080p.BluRay.x264-CINEFILE",
+      "Quiet.Fault.1979.Criterion.1080p.BluRay.x264-CINEFILE",
       {
         totalLength: n(8 * GiB),
         completedLength: n(8 * GiB),

--- a/apps/mariastew/scripts/seed-dev-fixtures.ts
+++ b/apps/mariastew/scripts/seed-dev-fixtures.ts
@@ -1,15 +1,16 @@
 #!/usr/bin/env -S node --experimental-strip-types
 /**
  * Populates docker-compose's bind-mounted roots (../dev-data/{tv,movies})
- * with directory names shaped like the owner's real library.
+ * with directory names shaped like a real media library.
  *
  * One empty `downloads` folder cannot reproduce a layout bug — every picker
  * bug found so far only showed up because of what a real name does to the
  * layout: full-width CJK brackets, runs of consecutive spaces, a leading
  * `www.` site prefix, square brackets, commas, names past 70 characters. The
- * real names below are verbatim from that library, not sanitised, and stay
- * present alongside generated filler so the ~140-entry scroll cap is
- * genuinely exercised rather than tested against three tidy names.
+ * titles and release groups below are invented, but each carries one of those
+ * shapes verbatim, and they stay present alongside generated filler so the
+ * ~140-entry scroll cap is genuinely exercised rather than tested against
+ * three tidy names.
  *
  * The filler is deterministic (seeded PRNG, not Math.random()) so a bug
  * report against "entry #83" points at the same name on every machine and
@@ -32,30 +33,32 @@ const DEV_DATA = join(
   "dev-data",
 );
 
-// Verbatim from the owner's library — the actual adversarial cases, not a
-// paraphrase of them.
-const REAL_MOVIES = [
-  "Atomic Blonde (2017) (2160p BluRay x265 HEVC 10bit HDR AAC 7.1 Tigole)",
-  "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1",
-  "Citizenfour (2014) [1080p]",
-  "Clerks Trilogy 1994,2006,2022 1080p BluRay HEVC x265",
-  "Crash (1996) Criterion (1080p BluRay x265 HEVC 10bit AAC 5.1)",
-  "Deliverance (1972) [1080p]",
-  "El Mariachi (1992) (1080p BluRay x265 HEVC 10bit AAC 2.0)",
-  "England is Mine",
-  "Four Lions 2010 (1080p Bluray x265 HEVC 10bit AAC 5.1 Tigole)",
-  "Furiosa.A.Mad.Max.Saga.2024.2160p.WEB.H265-FuriousMax",
-  "Heavy.Metal.1981.1080p.BluRay.DDP5.1.x265.10bit-Galaxy",
-  "Louis Theroux Inside The Manosphere (2026) 1080p WEBRip x265 LAMA",
-  "Mad.Max.3.Beyond.Thunderdome.1985.1080p.BrRip.x264.【ThumperDC】",
-  "Mystify.Michael.Hutchence.2019.1080p.BluRay.x264-GETiT[TGx]",
-  "O.Brother.Where.Art.Thou.2000.1080p.BluRay.DDP5.1.x265.GalaxyRG265[TGx]",
-  "Once Upon a Time in Mexico (2003) (1080p BluRay x265 HEVC 10bit Tigole)",
-  "The.7th.Voyage.Of.Sinbad.1958.Eng.REMASTERED.1080p.BluRay",
-  "V for Vendetta (2005) (2160p BluRay x265 HEVC 10bit HDR AAC 7.1 Tigole)",
-  "www.UIndex.org    -    Made In Britain 1982 BluRay 1080p DTS 2 0 AVC REMUX-FraMeSToR",
-  "www.UIndex.org    -    Obsession.2026.1080p.TELESYNC.x264-UNiON",
-  "Zoolander (2001) [1080p] [YTS.AG]",
+// Invented titles and groups carrying the adversarial shapes: nested
+// parentheses, dot separators, square brackets, commas, a bare title with no
+// metadata at all, full-width CJK brackets, a `www.` prefix with runs of
+// consecutive spaces, and names past 70 characters.
+const SHAPED_MOVIES = [
+  "Nightfall Harbour (2017) (2160p BluRay x265 HEVC 10bit HDR AAC 7.1 Cormorant)",
+  "Static.Tide.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1",
+  "Glass Vantage (2014) [1080p]",
+  "Hollow Creek Trilogy 1994,2006,2022 1080p BluRay HEVC x265",
+  "Ash Field (1996) Criterion (1080p BluRay x265 HEVC 10bit AAC 5.1)",
+  "Marrow Ridge (1972) [1080p]",
+  "Silver Basin (1992) (1080p BluRay x265 HEVC 10bit AAC 2.0)",
+  "Copper Is Mine",
+  "Quiet Fault 2010 (1080p Bluray x265 HEVC 10bit AAC 5.1 Cormorant)",
+  "Amberline.The.Salt.Saga.2024.2160p.WEB.H265-SaltRush",
+  "Ember.Signal.1981.1080p.BluRay.DDP5.1.x265.10bit-Meridian",
+  "Rust Drift Inside The Long Dark (2026) 1080p WEBRip x265 PELICAN",
+  "Low.Tide.3.Beyond.The.Verge.1985.1080p.BrRip.x264.【WinterFold】",
+  "Vantage.North.2019.1080p.BluRay.x264-KESTREL[QTx]",
+  "Wake.Of.The.Ember.Line.2000.1080p.BluRay.DDP5.1.x265.MeridianRG265[QTx]",
+  "Once Upon a Tide in Harbour (2003) (1080p BluRay x265 HEVC 10bit Cormorant)",
+  "The.7th.Crossing.Of.Marrow.1958.Eng.REMASTERED.1080p.BluRay",
+  "N for Nightfall (2005) (2160p BluRay x265 HEVC 10bit HDR AAC 7.1 Cormorant)",
+  "www.QIndex.test    -    Made In Copper 1982 BluRay 1080p DTS 2 0 AVC REMUX-StoneWork",
+  "www.QIndex.test    -    Fault.Line.2026.1080p.TELESYNC.x264-QUARRY",
+  "Driftwood (2001) [1080p] [LOFT.AG]",
 ];
 
 // Two shows named for the same problem two different ways — #257 exists
@@ -65,10 +68,16 @@ const REAL_MOVIES = [
 const DIVERGENT_SPELLINGS = ["Show Name S02", "Show.Name.Season.2"];
 
 const SHOWS: Record<string, string[]> = {
-  Deadwood: ["Season 01", "Season 02", "Season 03"],
-  "Chernobyl (2019)": ["Season 01"],
-  "The Wire": ["Season 01", "Season 02", "Season 03", "Season 04", "Season 05"],
-  Fargo: ["Season 01", "Season 02", "Season 03", "Season 04", "Season 05"],
+  "Deadfall Creek": ["Season 01", "Season 02", "Season 03"],
+  "Ashfield (2019)": ["Season 01"],
+  "The Ember Line": [
+    "Season 01",
+    "Season 02",
+    "Season 03",
+    "Season 04",
+    "Season 05",
+  ],
+  Saltmarsh: ["Season 01", "Season 02", "Season 03", "Season 04", "Season 05"],
 };
 
 const TARGET_MOVIE_COUNT = 140;
@@ -128,16 +137,16 @@ const SOURCES = ["BluRay", "WEBRip", "WEB", "BDRip", "DVDRip", "REMUX"];
 const CODECS = ["x264", "x265", "HEVC"];
 const AUDIO = ["AAC 5.1", "DDP5.1", "AC3", "DTS", "AAC 2.0"];
 const GROUPS = [
-  "Tigole",
-  "GalaxyRG",
-  "YTS.AG",
-  "FraMeSToR",
-  "LAMA",
-  "GETiT",
-  "RARBG",
-  "EVO",
-  "SPARKS",
-  "NTG",
+  "Cormorant",
+  "MeridianRG",
+  "LOFT.AG",
+  "StoneWork",
+  "PELICAN",
+  "KESTREL",
+  "QUARRY",
+  "VELD",
+  "EMBERS",
+  "NTQ",
 ];
 
 function fillerMovieName(): string {
@@ -153,10 +162,10 @@ function fillerMovieName(): string {
 
 function movieNames(): string[] {
   const filler = Array.from(
-    { length: Math.max(0, TARGET_MOVIE_COUNT - REAL_MOVIES.length) },
+    { length: Math.max(0, TARGET_MOVIE_COUNT - SHAPED_MOVIES.length) },
     fillerMovieName,
   );
-  return [...REAL_MOVIES, ...filler];
+  return [...SHAPED_MOVIES, ...filler];
 }
 
 async function seedRoot(root: string, names: string[]) {

--- a/apps/mariastew/src/config.rs
+++ b/apps/mariastew/src/config.rs
@@ -260,8 +260,8 @@ mod tests {
         );
         assert_eq!(c.label(Path::new("/mnt/kontent/tv")), "tv");
         assert_eq!(
-            c.label(Path::new("/mnt/kontent/movies/2046/disc 1")),
-            "movies/2046/disc 1"
+            c.label(Path::new("/mnt/kontent/movies/Harbourlight/disc 1")),
+            "movies/Harbourlight/disc 1"
         );
     }
 

--- a/apps/mariastew/src/filter.rs
+++ b/apps/mariastew/src/filter.rs
@@ -51,7 +51,7 @@ fn strip_copy_suffix(stem: &str) -> &str {
 }
 
 /// Whether a `.txt` stem is nothing but a bare hostname — `sitename.tld` and
-/// nothing else, the shape of `AhaShare.com.txt`.
+/// nothing else, the shape of `SiteName.com.txt`.
 ///
 /// Deliberately narrow: the *entire* stem has to be domain-shaped, not
 /// merely contain something that looks like one. That is what keeps a real
@@ -168,34 +168,36 @@ mod tests {
         assert!(is_garbage("FILE_ID.DIZ"));
     }
 
-    /// The three real filenames a fake torrent left in the library, verbatim.
+    /// The three shapes tracker spam arrives in, with the site names invented:
+    /// a bare domain used as the filename, and the attribution phrase with and
+    /// without Windows' duplicate marker.
     #[test]
-    fn real_tracker_spam_filenames_are_garbage() {
-        assert!(is_garbage("Other/AhaShare.com.txt"));
+    fn tracker_spam_filenames_are_garbage() {
+        assert!(is_garbage("Other/SiteName.com.txt"));
         assert!(is_garbage(
-            "Other/Torrent downloaded from Demonoid.com - Copy.txt"
+            "Other/Torrent downloaded from TrackerSite.com - Copy.txt"
         ));
         assert!(is_garbage(
-            "Other/Torrent Downloaded From ExtraTorrent.com.txt"
+            "Other/Torrent Downloaded From AnotherTracker.net.txt"
         ));
     }
 
     #[test]
     fn tracker_spam_is_garbage_regardless_of_case() {
-        assert!(is_garbage("AHASHARE.COM.TXT"));
+        assert!(is_garbage("SITENAME.COM.TXT"));
         assert!(is_garbage(
-            "torrent downloaded from demonoid.com - copy.txt"
+            "torrent downloaded from trackersite.com - copy.txt"
         ));
-        assert!(is_garbage("TORRENT DOWNLOADED FROM EXTRATORRENT.COM.TXT"));
+        assert!(is_garbage("TORRENT DOWNLOADED FROM ANOTHERTRACKER.NET.TXT"));
     }
 
     /// The `" - Copy"` suffix combined with a bare-hostname stem rather than
-    /// the attribution phrase — the one shape none of the three real names
-    /// happens to exercise, since the only one carrying the suffix is caught
-    /// by the phrase rule regardless of what follows it.
+    /// the attribution phrase — the one shape none of the three above happens
+    /// to exercise, since the only one carrying the suffix is caught by the
+    /// phrase rule regardless of what follows it.
     #[test]
     fn a_bare_hostname_txt_is_garbage_even_with_a_copy_suffix() {
-        assert!(is_garbage("AhaShare.com - Copy.txt"));
+        assert!(is_garbage("SiteName.com - Copy.txt"));
     }
 
     /// The failure mode that matters more: a real `.txt` must never be

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -1117,9 +1117,9 @@ mod tests {
             // metadata gid's own, always length 1) could only ever have
             // picked the right one by coincidence.
             let child_files = serde_json::json!([
-                {"index": "1", "path": "/mnt/kontent/movies/Pulp Fiction (1994) [1080p]/RARBG.nfo", "length": "473", "selected": "true"},
-                {"index": "2", "path": "/mnt/kontent/movies/Pulp Fiction (1994) [1080p]/Pulp.Fiction.1994.1080p.BrRip.x264.YIFY.mp4", "length": "1932735283", "selected": "true"},
-                {"index": "3", "path": "/mnt/kontent/movies/Pulp Fiction (1994) [1080p]/Other/YTS.MX.jpg", "length": "53226", "selected": "true"},
+                {"index": "1", "path": "/mnt/kontent/movies/Nightfall Harbour (1994) [1080p]/PACKGRP.nfo", "length": "473", "selected": "true"},
+                {"index": "2", "path": "/mnt/kontent/movies/Nightfall Harbour (1994) [1080p]/Nightfall.Harbour.1994.1080p.BrRip.x264.QUARRY.mp4", "length": "1932735283", "selected": "true"},
+                {"index": "3", "path": "/mnt/kontent/movies/Nightfall Harbour (1994) [1080p]/Other/COVERART.jpg", "length": "53226", "selected": "true"},
             ]);
             let mock = mock_server(
                 serde_json::json!({"result": "metadata-gid"}),
@@ -1163,7 +1163,7 @@ mod tests {
         async fn the_history_of_an_add_follows_the_download_it_produced() {
             let child_files = serde_json::json!([
                 {"index": "1", "path": "/mnt/kontent/movies/movie.mkv", "length": "100", "selected": "true"},
-                {"index": "2", "path": "/mnt/kontent/movies/RARBG.nfo", "length": "473", "selected": "true"},
+                {"index": "2", "path": "/mnt/kontent/movies/PACKGRP.nfo", "length": "473", "selected": "true"},
             ]);
             let mock = mock_server(
                 serde_json::json!({"result": "metadata-gid"}),

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -759,7 +759,7 @@ mod tests {
     /// hide on exactly the two entries a picker most needs to tell apart.
     #[test]
     fn long_directory_names_wrap_instead_of_being_cut_off() {
-        let long_name = "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
+        let long_name = "Static.Tide.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
         let browse = Browse {
             parent: None,
             path: String::new(),
@@ -795,7 +795,8 @@ mod tests {
     /// full names must be in the markup, not just their common prefix.
     #[test]
     fn two_directory_names_differing_only_near_the_end_are_both_fully_present() {
-        let common = "2046.2004.Criterion.Collection.2160p.UHD.BluRay.REMUX.HEVC.HDR.DTS-HD.MA.5.1";
+        let common =
+            "Harbourlight.2004.Criterion.Collection.2160p.UHD.BluRay.REMUX.HEVC.HDR.DTS-HD.MA.5.1";
         let part1 = format!("{common}.PART1");
         let part2 = format!("{common}.PART2");
         let browse = Browse {
@@ -835,7 +836,7 @@ mod tests {
     /// asserts it is not what gets *rendered*.
     #[test]
     fn the_current_path_is_shown_from_the_picked_root_and_wraps() {
-        let tail = "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
+        let tail = "Static.Tide.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
         let browse = Browse {
             parent: Some("/mnt/kontent/movies".into()),
             path: format!("/mnt/kontent/movies/{tail}"),
@@ -893,7 +894,7 @@ mod tests {
     /// list it needs to stay distinguishable from at a glance.
     #[test]
     fn a_long_torrent_name_still_truncates_to_one_line_in_the_collapsed_row() {
-        let long_name = "Chungking.Express.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
+        let long_name = "Static.Tide.1994.Criterion.1080p.BluRay.x265.HEVC.10bit.AAC.5.1";
         let page = render(&Download {
             bittorrent_name: Some(long_name.to_string()),
             ..moving()
@@ -1317,17 +1318,23 @@ mod tests {
     fn the_file_list_shows_what_was_kept_and_what_the_filter_refused() {
         let page = render(&Download {
             files: vec![
-                file(1, "/mnt/kontent/movies/Pulp/RARBG.nfo", 473, 0, false),
+                file(
+                    1,
+                    "/mnt/kontent/movies/Nightfall/PACKGRP.nfo",
+                    473,
+                    0,
+                    false,
+                ),
                 file(
                     2,
-                    "/mnt/kontent/movies/Pulp/Pulp.Fiction.mp4",
+                    "/mnt/kontent/movies/Nightfall/Nightfall.Harbour.mp4",
                     1000,
                     500,
                     true,
                 ),
                 file(
                     3,
-                    "/mnt/kontent/movies/Pulp/Other/YTS.jpg",
+                    "/mnt/kontent/movies/Nightfall/Other/COVERART.jpg",
                     53_226,
                     0,
                     false,
@@ -1338,10 +1345,10 @@ mod tests {
         assert!(page.contains("keeping 1 of 3"), "{page}");
         assert!(page.contains("2 skipped"), "{page}");
         assert!(
-            page.contains("RARBG.nfo") && page.contains("YTS.jpg"),
+            page.contains("PACKGRP.nfo") && page.contains("COVERART.jpg"),
             "{page}"
         );
-        assert!(page.contains("Pulp.Fiction.mp4"), "{page}");
+        assert!(page.contains("Nightfall.Harbour.mp4"), "{page}");
         assert!(page.contains("skipped"), "{page}");
     }
 

--- a/apps/mariastew/templates/browse.html
+++ b/apps/mariastew/templates/browse.html
@@ -84,7 +84,7 @@
   {# Each name is wrapped with no line cap, not truncated with an ellipsis
        and not clamped to a fixed number of lines either. A real release name
        puts the title and year first and encoding detail last
-       (`Chungking.Express.1994.Criterion.1080p.BluRay.x265...`), so an
+       (`Static.Tide.1994.Criterion.1080p.BluRay.x265...`), so an
        end-ellipsis usually only hides junk — except when two folders differ
        near the end (a part number, a disc, a cut), which is exactly the case
        a picker has to get right. A 2-line clamp was tried first and


### PR DESCRIPTION
Closes #301.

Committed fixtures documented an actual media library. `seed-dev-fixtures.ts` said so in its own docblock ("verbatim from the owner's library"), and real film titles, release-group tags and tracker-site names were spread across the mock aria2 server, the picker layout tests, the file-list tests and the browse template's comment.

Every one of those is now invented. Nothing about what the fixtures *test* changes: they exist because a name's shape breaks layouts, not because of what the name says.

## What to check

The shapes are the deliverable, so verify they survived the swap. `apps/mariastew/scripts/seed-dev-fixtures.ts` still carries one entry per adversarial case — nested parentheses, dot separators, square brackets, commas, a bare title with no metadata at all, full-width CJK brackets (`【WinterFold】`), a `www.` prefix with runs of consecutive spaces, and names past 70 characters. `./apps/mariastew/scripts/seed-dev-fixtures.ts --reset` prints `movies: 140 entries, longest 84 chars`, unchanged from before.

`src/filter.rs` is the only place where a swapped name could have weakened a test. It can't: the tracker-spam rules are shape-based (`looks_like_a_bare_hostname` plus a `"torrent downloaded from"` phrase match), never a denylist of sites, so `SiteName.com.txt` exercises them exactly as `AhaShare.com.txt` did. The made-up domains keep the same label counts and TLD lengths the rule's 3–4 character floor turns on.

`cargo test` (145) and `mise run test` (156) pass; fmt, lint and typecheck are clean.