### PR TITLE
289 perf(ci): compile mariastew and auth on the runner, not in docker build

### DIFF
--- a/.github/workflows/build-auth-container.yml
+++ b/.github/workflows/build-auth-container.yml
@@ -54,16 +54,80 @@ jobs:
           echo "release=$release" >> "$GITHUB_OUTPUT"
           echo "version $version, release $release"
 
+  # Compiled here rather than inside `docker build`, because a cargo build in a
+  # Dockerfile is one atomic layer: bumping a single crate recompiles all ~200
+  # of them. rust-cache restores cargo's own cache, which is per-crate, so only
+  # what actually moved is rebuilt. Still one runner per architecture,
+  # natively, so nothing is emulated and musl is the host's own target rather
+  # than a cross.
+  binary:
+    name: Compile ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install musl tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          # Pinned, because this is what ships — the floating `rust = "1"` in
+          # mise.toml covers clippy and the tests, where a compiler bump
+          # breaking is the point.
+          toolchain: "1.97"
+          targets: ${{ matrix.target }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: apps/auth
+          key: ${{ matrix.target }}
+          # A pull request restores main's cache but writes none of its own: a
+          # branch's cache is invisible to every other branch and still evicts
+          # from the repository's 10GB, which is how main ends up cold.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build
+        working-directory: apps/auth
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      # The publish job unpacks `<context-artifact>-<arch>` into the build
+      # context of the leg with that architecture, so the suffix is the
+      # contract rather than a label.
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: auth-bin-${{ matrix.arch }}
+          path: apps/auth/target/${{ matrix.target }}/release/auth
+          if-no-files-found: error
+          # Only has to survive the hop to the publish job.
+          retention-days: 1
+
   publish:
     name: Build and Publish
-    needs: [version]
+    needs: [version, binary]
     # Builds each architecture on a native runner. `version` publishes the semver
     # tags, which metadata-action cannot derive here because the build runs on a
     # branch push with no tag to read.
-    uses: radiosilence/blit-workflows/.github/workflows/build-publish-container.yml@dd9d9c97a8c1ee1e27f285a96cbb50b2b6c16e06 # native-arm-runners
+    uses: radiosilence/blit-workflows/.github/workflows/build-publish-container.yml@ba88a6fd90ee99c9a8a7681cd8712dff55ab83a2 # context-artifact-input (blit-workflows#3, unmerged)
     with:
       working-directory: "./apps/auth"
       image: "auth"
+      context-artifact: "auth-bin"
       version: ${{ needs.version.outputs.release == 'true' && needs.version.outputs.version || '' }}
     secrets:
       PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-mariastew-container.yml
+++ b/.github/workflows/build-mariastew-container.yml
@@ -54,16 +54,81 @@ jobs:
           echo "release=$release" >> "$GITHUB_OUTPUT"
           echo "version $version, release $release"
 
+  # Compiled here rather than inside `docker build`, because a cargo build in a
+  # Dockerfile is one atomic layer: bumping a single crate recompiles all ~200
+  # of them, 168s against the 15s our own code costs. rust-cache restores
+  # cargo's own cache, which is per-crate, so only what actually moved is
+  # rebuilt. Still one runner per architecture, natively, so nothing is
+  # emulated and musl is the host's own target rather than a cross.
+  binary:
+    name: Compile ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install musl tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          # Pinned, because this is what ships — the floating `rust = "1"` in
+          # mise.toml covers clippy and the tests, where a compiler bump
+          # breaking is the point. Dockerfile.dev keeps its own copy for the
+          # dev image, which ships nowhere.
+          toolchain: "1.97"
+          targets: ${{ matrix.target }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: apps/mariastew
+          key: ${{ matrix.target }}
+          # A pull request restores main's cache but writes none of its own: a
+          # branch's cache is invisible to every other branch and still evicts
+          # from the repository's 10GB, which is how main ends up cold.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build
+        working-directory: apps/mariastew
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      # The publish job unpacks `<context-artifact>-<arch>` into the build
+      # context of the leg with that architecture, so the suffix is the
+      # contract rather than a label.
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mariastew-bin-${{ matrix.arch }}
+          path: apps/mariastew/target/${{ matrix.target }}/release/mariastew
+          if-no-files-found: error
+          # Only has to survive the hop to the publish job.
+          retention-days: 1
+
   publish:
     name: Build and Publish
-    needs: [version]
+    needs: [version, binary]
     # Builds each architecture on a native runner. `version` publishes the semver
     # tags, which metadata-action cannot derive here because the build runs on a
     # branch push with no tag to read.
-    uses: radiosilence/blit-workflows/.github/workflows/build-publish-container.yml@dd9d9c97a8c1ee1e27f285a96cbb50b2b6c16e06 # native-arm-runners
+    uses: radiosilence/blit-workflows/.github/workflows/build-publish-container.yml@ba88a6fd90ee99c9a8a7681cd8712dff55ab83a2 # context-artifact-input (blit-workflows#3, unmerged)
     with:
       working-directory: "./apps/mariastew"
       image: "mariastew"
+      context-artifact: "mariastew-bin"
       version: ${{ needs.version.outputs.release == 'true' && needs.version.outputs.version || '' }}
     secrets:
       PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -145,6 +145,18 @@ jobs:
       - name: Setup Environment
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
+      # Same reason the container builds moved their compile onto the runner:
+      # without this every leg recompiles ~200 crates from cold on every push.
+      # After mise, which is what puts this cargo on PATH.
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ${{ matrix.crate }}
+          # A pull request restores main's cache but writes none of its own: a
+          # branch's cache is invisible to every other branch and still evicts
+          # from the repository's 10GB, which is how main ends up cold.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Check and Test
         working-directory: ${{ matrix.crate }}
         run: cargo fmt --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@ node_modules
 
 apps/*/target
 
+# Where CI unpacks the compiled binary for the container build, and where a
+# local reproduction of that build has to put it. Same name as the crate, so
+# only these two can be spelled out rather than globbed.
+/apps/mariastew/mariastew
+/apps/auth/auth
+
 
 # harness-managed agent worktrees
 .claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,8 +193,24 @@ Rewrites go through the YAML document API and mutate the existing scalar, so a b
 
 Builds and publishes each container on changes to its own directory, one job per
 architecture on a runner of that architecture (via `blit-workflows`) rather than
-emulating arm64 under QEMU. The Rust one is also checked by the `containers` job
-in `ci-cd.yml` (fmt, clippy, `cargo test`).
+emulating arm64 under QEMU. The Rust ones are also checked by the `containers`
+job in `ci-cd.yml` (fmt, clippy, `cargo test`).
+
+**Where the compile happens is the difference between the two Rust shapes.** A
+`cargo build` inside a Dockerfile is one atomic layer, so a single crate moving
+in `Cargo.lock` recompiles all of them — measured on `mariastew` at 168s of
+dependencies against 15s of its own code. Neither the stub-`main` layer nor
+`cargo-chef` subdivides that; they reorder it. Cargo's own cache does have the
+right granularity, and the only place it survives between runs is the runner, so
+`mariastew` and `auth` compile there under `Swatinem/rust-cache` and hand the
+binary to `build-publish-container.yml` as an artefact (`context-artifact`),
+leaving their Dockerfiles a `COPY` into a base image. The price is that those
+two Dockerfiles no longer build from a bare checkout. `serve-from-env` still
+compiles inline at 46 crates, where a second job shape costs more than it saves.
+
+Caches are written from `main` only (`save-if`). A branch's cache is invisible
+to every other branch and still evicts from the repository's 10GB, which is how
+`main` ends up cold — the one state this is all meant to avoid.
 
 Our containers are versioned and released from here, so the updater can track
 them like any upstream. The version lives in each app's `Cargo.toml`, or

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,27 +1,13 @@
-# Compiled inside the Dockerfile rather than copied in from CI: the reusable
-# workflow this repo standardises on (blit-workflows/build-publish-container.yml)
-# builds from a Dockerfile context and cannot consume a pre-built artefact. Each
-# architecture builds on its own native runner, so there is no emulation penalty
-# for compiling here.
-FROM rust:1.97-alpine AS build
-
-RUN apk add --no-cache musl-dev ca-certificates
-WORKDIR /src
-
-# Dependencies first, against a stub main, so editing the source doesn't rebuild
-# them.
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
-    cargo build --release --locked && \
-    rm -rf src
-
-COPY src ./src
-COPY templates ./templates
-COPY assets ./assets
-# Cargo would otherwise reuse the stub's artefact — same crate, and the only
-# newer input is a path it has already built.
-RUN touch src/main.rs && cargo build --release --locked
-
+# `auth` is compiled by the CI job that calls this build, not here: a
+# `cargo build` inside a Dockerfile is one atomic layer, so any movement in
+# Cargo.lock recompiles every dependency. Cargo's cache subdivides by crate,
+# but it only survives between runs somewhere Docker isn't, which is the
+# runner. See .github/workflows/build-auth-container.yml.
+#
+# So this file no longer builds on its own: it wants an `auth` binary for the
+# target architecture sitting beside it, which CI unpacks from the artefact its
+# compile job uploaded.
+#
 # scratch, unlike mariastew's alpine: this pod runs one static binary and shells
 # out to nothing, so there is no userland here for anything to find.
 FROM scratch
@@ -31,11 +17,15 @@ FROM scratch
 # system trust store and does NOT fall back to the webpki roots compiled into
 # the binary. Every login calls GitHub, and without a CA bundle on disk the TLS
 # client fails at construction rather than at request time — so there is no
-# request log to debug it from. Taken from the build stage so there is no second
-# base image involved.
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# request log to debug it from. Alpine's base image already carries the bundle
+# (`ca-certificates-bundle`), so this is a copy out of it rather than a stage
+# that installs anything — and a base that stopped shipping it fails the build
+# rather than the first login.
+COPY --from=alpine:3.24 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY --from=build /src/target/release/auth /auth
+# --chmod because actions/upload-artifact does not preserve modes, so the
+# binary arrives in the context without its exec bit.
+COPY --chmod=755 auth /auth
 
 EXPOSE 8080
 ENV BIND_ADDR=0.0.0.0:8080

--- a/apps/mariastew/Dockerfile
+++ b/apps/mariastew/Dockerfile
@@ -1,29 +1,16 @@
-# Compiled inside the Dockerfile rather than copied in from CI like
-# mcp-gateway's static binary: the reusable workflow this repo standardises on
-# (blit-workflows/build-publish-container.yml) builds from a Dockerfile
-# context and has no way to consume a pre-built artefact, so a copied-in
-# binary means a bespoke pipeline instead of the working one — the cost that
-# pattern exists to avoid. Each architecture builds on its own native runner,
-# so there is no emulation penalty to pay for compiling here.
-FROM rust:1.97-alpine AS build
-
-RUN apk add --no-cache musl-dev
-WORKDIR /src
-
-# Dependencies first, against a stub main, so editing the source doesn't rebuild
-# them.
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
-    cargo build --release --locked && \
-    rm -rf src
-
-COPY src ./src
-COPY templates ./templates
-COPY assets ./assets
-# Cargo would otherwise reuse the stub's artefact — same crate, and the only
-# newer input is a path it has already built.
-RUN touch src/main.rs && cargo build --release --locked
-
+# `mariastew` is compiled by the CI job that calls this build, not here: a
+# `cargo build` inside a Dockerfile is one atomic layer, so any movement in
+# Cargo.lock recompiles every dependency — 168s of them against 15s of our own
+# code. Cargo's cache subdivides by crate, but it only survives between runs
+# somewhere Docker isn't, which is the runner. See
+# .github/workflows/build-mariastew-container.yml.
+#
+# So this file no longer builds on its own: it wants a `mariastew` binary for
+# the target architecture sitting beside it, which CI unpacks from the artefact
+# its compile job uploaded. Local iteration never comes through here — `mise
+# run mariastew:dev` builds Dockerfile.dev, which still compiles inline
+# because no job feeds it.
+#
 # alpine, not scratch: the pod runs this image twice, service and an aria2c
 # sidecar, so the image has to carry aria2c itself, not just the compiled
 # binary.
@@ -43,7 +30,9 @@ FROM alpine:3.24
 # at once because they share the OS trust store.
 RUN apk add --no-cache aria2 ca-certificates
 
-COPY --from=build /src/target/release/mariastew /mariastew
+# --chmod because actions/upload-artifact does not preserve modes, so the
+# binary arrives in the context without its exec bit.
+COPY --chmod=755 mariastew /mariastew
 
 EXPOSE 8080
 ENV BIND_ADDR=0.0.0.0:8080

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -309,13 +309,19 @@ it's replacing.
 Two decisions worth stating plainly, because they diverge from what an
 initial plan for this service assumed:
 
-- **The crate compiles inside the `Dockerfile`**, rather than a CI job
-  building a binary that the image then copies in. The repository's reusable
-  container workflow builds from a Dockerfile context and has no way to
-  consume a pre-built artefact, so a copied-in binary would mean a bespoke
-  pipeline instead of the one every other container here already uses. Each
-  architecture builds on its own native runner, so nothing is paid in QEMU
-  emulation for compiling on-image.
+- **The crate compiles on the CI runner, not inside the `Dockerfile`.** A
+  `cargo build` in a Dockerfile is one atomic layer, so any movement in
+  `Cargo.lock` recompiles every dependency — 168s of them against the 15s
+  this crate's own code costs. The stub-`main` layer reorders that; it does
+  not subdivide it, and neither does `cargo-chef`. Cargo's own cache has the
+  right granularity but cannot survive between runs inside `docker build`,
+  since the `type=gha` backend does not export cache mounts. So the compile
+  job holds it with `Swatinem/rust-cache` and hands the binary over as an
+  artefact, which the reusable container workflow unpacks into the build
+  context (`context-artifact`). Still one native runner per architecture, so
+  nothing is paid in QEMU emulation either way. The cost is that
+  `Dockerfile` no longer builds on its own — it wants the binary beside it —
+  which is why local iteration goes through `Dockerfile.dev` instead.
 - **The runtime base is `alpine`, not `scratch`.** It has to carry `aria2c`
   regardless, and needs a CA bundle even for the Rust binary alone: reqwest's
   `rustls` feature pulls in `rustls-platform-verifier`, which reads the
@@ -445,9 +451,10 @@ compose bridge network — the same shared-netns relationship the pod gives
 the two containers for free.
 
 The image is built from `Dockerfile.dev`, not the production `Dockerfile`:
-same two-stage layout and dependency-caching trick, but a debug build, so
-`/auth/dev-login` is actually compiled in. The production Dockerfile is
-untouched and still `--release` — nothing here can affect what CI ships.
+a debug build, so `/auth/dev-login` is actually compiled in. It is also the
+only one of the two that still compiles inside `docker build` — the
+production `Dockerfile` wants a binary handed to it by CI and will not build
+from a bare checkout. Nothing here can affect what CI ships.
 
 **Iteration loop:** `docker compose up --build` again after a source change.
 The dependency-caching trick means only the final `cargo build` layer


### PR DESCRIPTION
Closes #289.

`mariastew` and `auth` stop compiling inside `docker build`. Their Dockerfiles become a `COPY` into a base image; a per-architecture job compiles the binary on the runner under `Swatinem/rust-cache` and hands it over as an artefact, which the reusable container workflow unpacks into the build context.

## Why

A `cargo build` in a Dockerfile is one atomic layer. The stub-`main` layer reorders the work but does not subdivide it, so bumping one crate recompiles all ~206 — **167.9s of dependencies against 13-18s of the app's own code**, measured cold on mariastew/amd64. `cargo-chef` reorders it differently and has the same property. Cargo's own cache is per-crate, but it cannot survive between runs inside `docker build`: the `type=gha` backend does not export `RUN --mount=type=cache`. The only place it survives is the runner.

## What changed

- **`build-mariastew-container.yml` / `build-auth-container.yml`** — new `binary` job, one leg per architecture on a runner of that architecture (`ubuntu-latest` / `ubuntu-24.04-arm`), building the host's own musl target. `publish` gains it as a `needs` and passes `context-artifact`.
- **`apps/mariastew/Dockerfile`** — build stage gone; `COPY --chmod=755 mariastew /mariastew`. The `--chmod` is load-bearing: `actions/upload-artifact` does not preserve modes.
- **`apps/auth/Dockerfile`** — same, plus the CA bundle now comes from `COPY --from=alpine:3.24` rather than the build stage that no longer exists. Alpine's base image ships `ca-certificates-bundle`, so nothing is installed and a base that stopped shipping it fails the build rather than the first login. The `scratch` runtime is unchanged.
- **`ci-cd.yml`** — `rust-cache` on the `containers` job, which recompiled all three crates from cold on every push.
- **Toolchain pinned to 1.97** in the compile jobs, matching the `rust:1.97-alpine` the Dockerfiles used to pin. `mise.toml`'s floating `rust = "1"` still governs clippy and the tests, where a compiler bump breaking things is the point.
- **`save-if: main`** on every cache. A branch's cache is invisible to other branches and still evicts from the repository's 10GB, which is exactly how `main` ends up cold.

`serve-from-env` (46 crates) and `files` (nginx) are untouched — a second job shape costs more than it saves there, and `serve-from-env` keeps the in-Dockerfile pattern documented in one place. `Dockerfile.dev` still compiles inline; nothing feeds it.

## Measured

mariastew, wall-clock per job, all from runs today:

| | amd64 | arm64 |
|---|---|---|
| old shape, dependency layer **missed** ([run](https://github.com/radiosilence/jaritanet/actions/runs/31253274843)) | 225s | 189s |
| old shape, dependency layer **hit** ([run](https://github.com/radiosilence/jaritanet/actions/runs/31253484382)) | 72s | 62s |
| this PR, **stone cold** — no cache exists yet ([run](https://github.com/radiosilence/jaritanet/actions/runs/31253426020)) | 96s compile + 29s image = **125s** | 98s + 16s = **114s** |

So the worst case this branch can produce already beats the old shape's cache-miss case, which is the case #289 is about. The warm case cannot be measured from a PR — `save-if: main` means nothing is written until this merges — but a one-crate bump should land near the "hit" row rather than the "miss" row, because cargo, not Docker, decides what to rebuild.

## Dependency

⚠️ **Blocked on radiosilence/blit-workflows#3**, which adds the `context-artifact` input. The `uses:` pins currently point at that PR's branch commit (`ba88a6f`) so CI here exercises the change — which it did, both container workflows are green end to end. They move to the merge commit on `main` before this leaves draft.

## How to confirm the images still work

Both were built and run locally on `linux/arm64` from binaries built for `aarch64-unknown-linux-musl` and deliberately `chmod 644` first, reproducing what an artefact download hands over:

- `mariastew` — lands as `-rwxr-xr-x /mariastew`, starts and exits on `ROOTS is not set`.
- `auth` — starts on `scratch` and exits on `GH_ALLOWED is empty`, so the binary runs and the CA bundle copy resolved.

The PR builds but publishes nothing, so nothing reaches `ghcr.io` until merge.