### PR TITLE
fix(k8s): pull images IfNotPresent, since every tag is a version

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -200,7 +200,7 @@ export function createAuth(
               {
                 name: APP,
                 image: `${conf.image.repository}:${conf.image.tag}`,
-                imagePullPolicy: conf.image.pullPolicy ?? "Always",
+                imagePullPolicy: conf.image.pullPolicy,
                 ports: [{ name: "http", containerPort: 8080 }],
                 env: [
                   { name: "BIND_ADDR", value: "0.0.0.0:8080" },

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -145,7 +145,6 @@ config:
         image:
           repository: "deluan/navidrome"
           tag: 0.63.2
-          pullPolicy: "Always"
         env:
           ND_SCANSCHEDULE: 1h
           ND_LOGLEVEL: info
@@ -197,7 +196,6 @@ config:
         image:
           repository: "ghcr.io/radiosilence/jaritanet-files"
           tag: 1.0.0
-          pullPolicy: "Always"
         replicas: 1
         healthCheck:
           path: "/"
@@ -241,7 +239,6 @@ config:
         image:
           repository: "ghcr.io/radiosilence/blit"
           tag: sha-e7ec682
-          pullPolicy: "Always"
         httpPort: 3000
     # What lady serves off the media drive. Shares are anonymous — `map to
     # guest` turns unknown users into `guestAccount`, which must own the files
@@ -295,7 +292,6 @@ config:
         # to be a sha pushed here by that repo's CI on every build.
         repository: "ghcr.io/radiosilence/mcp-gateway"
         tag: v0.7.0
-        pullPolicy: "Always"
       # Each entry is both a backend pod and its entry in the registry the gateway
       # boots from (MCP_REGISTRY) — declared once, since a registry naming a pod
       # that doesn't exist is just a 502. The in-cluster URL joining them is
@@ -424,7 +420,6 @@ config:
       image:
         repository: "ghcr.io/radiosilence/mariastew"
         tag: 0.1.9
-        pullPolicy: "Always"
       roots:
         - name: tv
           hostPath: /mnt/kontent/tv
@@ -497,7 +492,6 @@ config:
     image:
       repository: "ghcr.io/radiosilence/auth"
       tag: 0.1.0
-      pullPolicy: "Always"
     github:
       clientId: Ov23lig1BPAzKe4qmT4F
       clientSecret:

--- a/packages/k8s/src/schemas.ts
+++ b/packages/k8s/src/schemas.ts
@@ -89,7 +89,15 @@ export const PersistenceSchema = z.strictObject({
 });
 
 export const ImageSchema = z.strictObject({
-  pullPolicy: z.enum(["Always", "IfNotPresent", "Never"]).optional(),
+  // Every tag here is a version, and a version is immutable: a change to an
+  // image is a new number, published by that container's own workflow and
+  // moved by update-apps. So `Always` bought a registry round-trip on every
+  // container start to re-fetch a digest that cannot have moved. It was set
+  // back when the pins were `main`, where it was the only thing that worked.
+  // Anything that does pin a moving tag has to say `Always` for itself.
+  pullPolicy: z
+    .enum(["Always", "IfNotPresent", "Never"])
+    .default("IfNotPresent"),
   repository: z.string(),
   tag: z.string(),
 });

--- a/packages/k8s/src/service.ts
+++ b/packages/k8s/src/service.ts
@@ -238,7 +238,7 @@ export function createService(
               {
                 name: serviceName,
                 image: `${image.repository}:${image.tag}`,
-                imagePullPolicy: image.pullPolicy ?? "Always",
+                imagePullPolicy: image.pullPolicy,
                 ports: [
                   { name: "http", containerPort: httpPort },
                   ...ports.map(([hostPort, containerPort]) => ({

--- a/packages/mariastew/src/mariastew.ts
+++ b/packages/mariastew/src/mariastew.ts
@@ -173,7 +173,7 @@ export function createMariastew(
               {
                 name: "session-file",
                 image,
-                imagePullPolicy: conf.image.pullPolicy ?? "Always",
+                imagePullPolicy: conf.image.pullPolicy,
                 command: ["/bin/touch", sessionFile],
                 resources: {
                   requests: { cpu: "5m", memory: "8Mi" },
@@ -190,7 +190,7 @@ export function createMariastew(
               {
                 name: "mariastew",
                 image,
-                imagePullPolicy: conf.image.pullPolicy ?? "Always",
+                imagePullPolicy: conf.image.pullPolicy,
                 ports: [{ name: "http", containerPort: 8080 }],
                 env: [
                   { name: "BIND_ADDR", value: "0.0.0.0:8080" },
@@ -239,7 +239,7 @@ export function createMariastew(
               {
                 name: "aria2",
                 image,
-                imagePullPolicy: conf.image.pullPolicy ?? "Always",
+                imagePullPolicy: conf.image.pullPolicy,
                 command: [
                   "/usr/bin/aria2c",
                   "--enable-rpc",

--- a/packages/mcp-gateway/src/mcp-gateway.ts
+++ b/packages/mcp-gateway/src/mcp-gateway.ts
@@ -456,7 +456,7 @@ export function createMcpGateway(
               {
                 name: "mcp-gateway",
                 image: `${conf.image.repository}:${conf.image.tag}`,
-                imagePullPolicy: conf.image.pullPolicy ?? "Always",
+                imagePullPolicy: conf.image.pullPolicy,
                 ports: [{ name: "http", containerPort: 8080 }],
                 env: [
                   { name: "BIND_ADDR", value: "0.0.0.0:8080" },

--- a/schemas/infra.json
+++ b/schemas/infra.json
@@ -1767,6 +1767,7 @@
       "type": "object",
       "properties": {
         "pullPolicy": {
+          "default": "IfNotPresent",
           "anyOf": [
             {
               "type": "string",


### PR DESCRIPTION
Drops `imagePullPolicy: Always` as the default. Every image pin in this stack is a version, and a version is immutable — a change to an image is a new number, published by that container's own workflow and moved by `update-apps`. So `Always` bought a registry round-trip on every container start to re-confirm a digest that cannot have moved.

It made sense when the pins were `main`. Nothing pins a moving tag now.

## Where the default lives

In `ImageSchema`, not spelled out at each of the six call sites. That is what lets the six `pullPolicy: "Always"` lines come out of `Pulumi.main.yaml` — they were config repeating what the code already did, which is the shape that makes a default impossible to change in one place.

A service that *does* pin a moving tag now has to say `Always` for itself. That is the point: it becomes a visible decision in config instead of the silent default everything inherited whether it needed it or not.

## Blast radius — read this bit

`imagePullPolicy` is part of the pod template, so **all six services roll on the next `up`**: navidrome, files, blit, mcp-gateway, mariastew, auth. Two of them (navidrome, mariastew) are `strategy: Recreate` on hostPath volumes, so those are a brief hard stop rather than a rolling one. mariastew's aria2 queue is erased by any deploy regardless, which is already true of every deploy.

Nothing re-pulls, so the rolled pods come up on the layers already on the node.

## The one real trade

If a version tag is ever *republished* — the same number pointing at new content — nodes holding the old layer will not pick it up. That is the intended consequence of treating tags as immutable, and it is exactly what happened to `auth:0.1.0` an hour ago: the package was deleted and the tag republished from CI. Anything doing that deliberately in future needs a new version number, not a re-push.

Checked with `mise run check` — 159 tests, lint, format, typecheck. The `pulumi preview` on this PR is the thing to read for the actual resource diff.