### PR TITLE
fix(ci): let a dispatched build cut its release too

### DIFF
--- a/.github/workflows/build-auth-container.yml
+++ b/.github/workflows/build-auth-container.yml
@@ -137,7 +137,7 @@ jobs:
   release:
     name: Release
     needs: [version, publish]
-    if: needs.version.outputs.release == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: needs.version.outputs.release == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build-files-container.yml
+++ b/.github/workflows/build-files-container.yml
@@ -65,7 +65,7 @@ jobs:
   release:
     name: Release
     needs: [version, publish]
-    if: needs.version.outputs.release == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: needs.version.outputs.release == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build-mariastew-container.yml
+++ b/.github/workflows/build-mariastew-container.yml
@@ -138,7 +138,7 @@ jobs:
   release:
     name: Release
     needs: [version, publish]
-    if: needs.version.outputs.release == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: needs.version.outputs.release == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build-serve-from-env-container.yml
+++ b/.github/workflows/build-serve-from-env-container.yml
@@ -73,7 +73,7 @@ jobs:
   release:
     name: Release
     needs: [version, publish]
-    if: needs.version.outputs.release == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: needs.version.outputs.release == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The `release` job in all four container workflows was gated on `github.event_name == 'push'`. What that guard needs to exclude is a **pull request** — which builds without publishing — and `workflow_dispatch` is not one.

So a dispatched run published an image and then declined to record it. That is not hypothetical: it is why `auth` currently has a published `ghcr.io/radiosilence/auth:0.1.0` and no `auth-v0.1.0` release, and why `update-apps` has been failing daily with:

```
::warning::auth — no readable release on radiosilence/jaritanet
::error::needs attention: auth
```

The guard is now `github.event_name != 'pull_request'`, which is the same predicate `blit-workflows` uses for `PUBLISH`. Publish and release can no longer disagree about whether a run counts.

## What merging this does

It touches all four workflow files, and each is in its own `paths:` trigger, so all four run on merge:

- **auth** — `auth-v0.1.0` does not exist, so it publishes and cuts it. That is the fix; `update-apps` goes green.
- **files / serve-from-env / mariastew** — their releases already exist, so `release=false`, the `version` input is empty, and the merge job moves only `latest`/`main`/`sha-*`. **No existing version tag is republished**, which matters because `main` has moved past mariastew's 0.1.9 and repointing that tag would be a lie.

Nothing is deployed by any of it — Pulumi pins versions, and none of those moved.

## Why the release job is where the breakage surfaced

`release` is `needs: [version, publish]`. auth's publish had been failing on a GHCR permission (#332), so the release job never ran, so no release existed, so the updater errored. One broken package ACL, three hops downstream. The ACL is fixed; this closes the last hop.