### PR TITLE
325 refactor(mariastew): JS in a file the linter reads, not an attribute

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -16,7 +16,8 @@
     "**/*.yml",
     "**/*.yaml",
     "**/*.toml",
-    "apps/*/assets",
+    "apps/*/assets/datastar.js",
+    "apps/*/assets/*.css",
     "apps/*/target",
     "apps/*/templates"
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -32,7 +32,8 @@
   "ignorePatterns": [
     "schemas/**",
     "node_modules/**",
-    "apps/*/assets/**",
+    "apps/*/assets/datastar.js",
+    "apps/*/assets/*.css",
     "apps/*/target/**"
   ]
 }

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -9,6 +9,26 @@ memory, so a deploy signs everyone out. The frontend is server-rendered HTML
 patched over SSE ([Datastar](https://data-star.dev), vendored at
 `assets/datastar.js`), not a client-side app.
 
+## Where the JavaScript lives
+
+Datastar evaluates a `data-on:*` attribute as a function body, so an attribute
+will hold anything JavaScript can express — which is how a click handler becomes
+a program written in HTML. Signal writes and one `@action` stay in the
+attribute, where they read as markup; anything with control flow in it is a
+helper on `ms` in `assets/app.js`, and the attribute calls it. Elements are
+reached through `data-ref` rather than `document.getElementById`, so a template
+holds one definition of what an id is.
+
+That boundary is a lint boundary, not a taste one. `assets/app.js` is the only
+file under `assets/` that oxlint and oxfmt see (the stylesheet and the vendored
+bundle are build outputs and ignored by name), and JavaScript written inside an
+attribute is seen by nothing at all until a browser runs it.
+
+Nothing checks the two halves against each other at build time, so a test does:
+`every_ms_helper_a_template_calls_is_defined` renders the page, collects every
+`ms.*` it names, and fails if `app.js` does not define one. A rename is
+otherwise silent until someone presses the button.
+
 ## Adding one
 
 Tapping Add reads the clipboard and fills the field if what is there is a
@@ -403,7 +423,7 @@ rather than by remembering to decorate it.
 
 ## Routes
 
-Everything below `/` requires a session; `/healthz`, the two `/assets/*`
+Everything below `/` requires a session; `/healthz`, the three `/assets/*`
 files, and `/auth/*` are the only routes outside that layer (`src/main.rs`).
 
 | Route | Method | What |

--- a/apps/mariastew/assets/app.js
+++ b/apps/mariastew/assets/app.js
@@ -1,0 +1,64 @@
+/**
+ * The behaviours that do not belong in an attribute.
+ *
+ * Datastar evaluates `data-on:*` as a function body, so an attribute holds
+ * anything JavaScript can express — which is how a click handler becomes a
+ * program written in HTML, invisible to oxlint and oxfmt and unreadable at the
+ * width a template gives it. Signal work and one `@action` stay inline, where
+ * they read as markup; everything with control flow in it lives here.
+ *
+ * A global rather than an export, because a Datastar expression sees only
+ * globals, `el`, `evt` and the signals.
+ */
+globalThis.ms = {
+  /**
+   * Offer a magnet from the clipboard to a field that is still empty.
+   *
+   * Has to be called from the click that opens the dialog: every browser gates
+   * `readText()` on transient user activation and `showModal()` does not spend
+   * it. Whether a prompt appears is the browser's call — Safari draws its own
+   * Paste button, Chrome grants it silently on the gesture, an insecure origin
+   * has no `navigator.clipboard` at all — and none of those are an error, they
+   * leave a field to type into. Only a magnet is offered, since that is all
+   * `/add` accepts, and only into an empty field, because the prompt can
+   * outlast the moment someone gives up waiting and starts typing.
+   */
+  pasteMagnet(field) {
+    navigator.clipboard?.readText().then(
+      (text) => {
+        const magnet = text.trim();
+        if (!field.value && magnet.startsWith("magnet:?")) field.value = magnet;
+      },
+      () => {},
+    );
+  },
+
+  /**
+   * Wire Enter to a button that sits outside the field's own form.
+   *
+   * Both submit buttons here are pinned outside the form they submit, so there
+   * is no implicit submission to inherit and the keyboard's Go key did nothing
+   * at all — on a phone, at the moment the paste just happened. Clicking the
+   * real button keeps one definition of what it does.
+   */
+  clickOnEnter(evt, button) {
+    if (evt.key !== "Enter") return;
+    evt.preventDefault();
+    button.click();
+  },
+
+  /**
+   * The listing to fetch for a click inside the picker, or null if it hit no
+   * folder — the empty space around the buttons, or the path line above them.
+   *
+   * One delegated handler serves the whole listing: a root with a hundred-plus
+   * children is one level of browsing, and a `@get` per row was that many
+   * expressions to compile on every morph and that many URLs inlined into the
+   * response. A path arriving as a plain attribute value is also never parsed
+   * as an expression, so a folder named with a quote cannot break out of it.
+   */
+  browseUrl(evt) {
+    const dir = evt.target.closest("[data-dir]")?.dataset.dir;
+    return dir === undefined ? null : `/browse?path=${encodeURIComponent(dir)}`;
+  },
+};

--- a/apps/mariastew/scripts/seed-dev-fixtures.ts
+++ b/apps/mariastew/scripts/seed-dev-fixtures.ts
@@ -200,4 +200,4 @@ async function main() {
   );
 }
 
-main();
+await main();

--- a/apps/mariastew/src/main.rs
+++ b/apps/mariastew/src/main.rs
@@ -27,10 +27,27 @@ use axum::routing::get;
 use crate::config::Config;
 use crate::state::AppState;
 
-/// Served from the binary rather than a volume: they are build outputs, so a
-/// mount would be a second thing to keep in step with the image.
-const DATASTAR: &str = include_str!("../assets/datastar.js");
-const STYLESHEET: &str = include_str!("../assets/app.css");
+/// Served from the binary rather than a volume: the stylesheet and the vendored
+/// bundle are build outputs, so a mount would be a second thing to keep in step
+/// with the image, and `app.js` travels with them because it is the same thing
+/// to the browser.
+const ASSETS: [(&str, &str, &str); 3] = [
+    (
+        "/assets/app.js",
+        "text/javascript; charset=utf-8",
+        include_str!("../assets/app.js"),
+    ),
+    (
+        "/assets/datastar.js",
+        "text/javascript; charset=utf-8",
+        include_str!("../assets/datastar.js"),
+    ),
+    (
+        "/assets/app.css",
+        "text/css; charset=utf-8",
+        include_str!("../assets/app.css"),
+    ),
+];
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -71,35 +88,25 @@ async fn main() -> anyhow::Result<()> {
 
     // Only what is genuinely public sits outside the auth layer: the probe the
     // kubelet calls, the login round-trip that cannot require a session to
-    // establish one, and two static assets. Everything else is inside
+    // establish one, and the static assets. Everything else is inside
     // `routes::router`, which the layer wraps whole.
-    let app = Router::new()
+    let mut app = Router::new()
         .merge(routes::router().layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::extract::require_session,
         )))
         .merge(auth::routes::router())
-        .route("/healthz", get(|| async { "ok" }))
-        .route(
-            "/assets/datastar.js",
-            get(|| async {
-                (
-                    [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-                    DATASTAR,
-                )
-                    .into_response()
-            }),
-        )
-        .route(
-            "/assets/app.css",
-            get(|| async {
-                (
-                    [(header::CONTENT_TYPE, "text/css; charset=utf-8")],
-                    STYLESHEET,
-                )
-                    .into_response()
-            }),
-        )
+        .route("/healthz", get(|| async { "ok" }));
+    for (path, content_type, body) in ASSETS {
+        app =
+            app.route(
+                path,
+                get(move || async move {
+                    ([(header::CONTENT_TYPE, content_type)], body).into_response()
+                }),
+            );
+    }
+    let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .with_state(state);
 

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -297,9 +297,12 @@ fn magnet_infohash(magnet: &str) -> Option<&str> {
 /// still a warning here, so this is a change to what the browser is told, not
 /// to what we can see.
 fn add_outcome(message: Option<&str>) -> Response {
+    // Flat signal names, not one nested `add` object — see the note on
+    // `data-signals__ifmissing` in page.html for why the client cannot read a
+    // nested one reliably.
     let body = match message {
-        None => serde_json::json!({ "add": { "status": "ok" } }),
-        Some(m) => serde_json::json!({ "add": { "status": "error", "message": m } }),
+        None => serde_json::json!({ "addStatus": "ok" }),
+        Some(m) => serde_json::json!({ "addStatus": "error", "addMessage": m }),
     };
     (StatusCode::OK, axum::Json(body)).into_response()
 }
@@ -1368,11 +1371,9 @@ mod tests {
                 .expect("a small json body");
             let body: serde_json::Value =
                 serde_json::from_slice(&body).expect("add answers with json");
-            assert_eq!(body["add"]["status"], "error");
+            assert_eq!(body["addStatus"], "error");
             assert!(
-                body["add"]["message"]
-                    .as_str()
-                    .is_some_and(|m| !m.is_empty()),
+                body["addMessage"].as_str().is_some_and(|m| !m.is_empty()),
                 "the rejection has to say something, got {body}"
             );
         }

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -613,8 +613,7 @@ mod tests {
         .render()
         .unwrap();
         assert!(
-            page.contains("document.getElementById('add-dialog').showModal()")
-                && page.contains(r#"data-on:click=""#),
+            page.contains("$addDialog.showModal()") && page.contains(r#"data-on:click=""#),
             "add-dialog button markup: {page}"
         );
         // The generic "on" plugin needs the colon (data-on:click) — see the
@@ -1224,13 +1223,8 @@ mod tests {
         }
         .render()
         .unwrap();
-        // The JSON.stringify($add) prefix is not decorative — see the
-        // comment on this element in page.html. A narrower assertion here
-        // (checking only for `$add.status === 'error'`) would pass with the
-        // prefix silently deleted, which is exactly the change that breaks
-        // this at runtime with no error anywhere.
-        assert!(page.contains(r#"data-show="JSON.stringify($add) && $add.status === 'error'""#));
-        assert!(page.contains(r#"data-text="JSON.stringify($add) && $add.message""#));
+        assert!(page.contains(r#"data-show="$addStatus === 'error'""#));
+        assert!(page.contains(r#"data-text="$addMessage""#));
     }
 
     /// A successful add needs to be seen, not inferred later from a row
@@ -1245,20 +1239,18 @@ mod tests {
         }
         .render()
         .unwrap();
-        assert!(page.contains("JSON.stringify($add); if ($add.status === 'ok')"));
-        assert!(page.contains("add-dialog').close()"));
-        assert!(page.contains(r#"[name=magnet]').value = ''"#));
-        assert!(page.contains(r#"data-show="JSON.stringify($add) && $add.status === 'ok'""#));
+        assert!(page.contains(r#"data-effect="if ($addStatus === 'ok') el.close()""#));
+        assert!(page.contains(r#"$magnet.value = ''"#));
+        assert!(page.contains(r#"data-show="$addStatus === 'ok'""#));
         assert!(page.contains("Added"));
     }
 
-    /// The toast's own dismiss timer: a plain `setTimeout` writing a signal
-    /// was tried and rejected — the write happens outside Datastar's own
-    /// batch, and data-show never picked it up, so the toast stayed on
-    /// screen forever with no error anywhere. `on-interval` wraps its
-    /// callback in that batch and is what actually clears it.
+    /// The toast clears the signal it reads, from a trigger Datastar owns. A
+    /// plain `setTimeout` writing a signal was tried and rejected: the write
+    /// happens outside Datastar's batch, `data-show` never picks it up, and the
+    /// toast stays on screen forever with no error anywhere.
     #[test]
-    fn the_toast_reset_uses_on_interval_not_a_bare_settimeout() {
+    fn the_toast_clears_itself_from_a_trigger_datastar_owns() {
         let page = Page {
             roots: vec![],
             rows: vec![],
@@ -1266,14 +1258,79 @@ mod tests {
         }
         .render()
         .unwrap();
-        assert!(page.contains("data-on-interval__duration.3s="));
-        // "setTimeout" still appears in the explanatory HTML comment above
-        // the interval element — checking for the actual call form, not the
-        // bare word, is what keeps this test honest about what regressed.
+        assert!(page.contains("data-on-signal-patch__delay.3s="));
+        // Guarded on the value it clears, so the clear's own patch fires this
+        // once more and finds nothing to do. Unguarded, it writes every three
+        // seconds for the life of the page.
+        assert!(page.contains("if ($addStatus === 'ok') { $addStatus = ''"));
         assert!(
             !page.contains("setTimeout(() =>"),
             "a bare setTimeout call writing a signal does not get picked up by data-show: {page}"
         );
+    }
+
+    /// Two flat signals, never one `$add` object. A nested signal is tracked
+    /// only through its parent, so a reader of `$add.status` alone does not
+    /// re-run when the server patches it — the dialog, the toast and the error
+    /// each stop working with no error anywhere, which is why every reader of
+    /// the nested shape needed a `JSON.stringify($add)` prefix beside it.
+    #[test]
+    fn the_add_contract_is_flat_signals() {
+        let page = Page {
+            roots: vec![],
+            rows: vec![],
+            aria2_unreachable: false,
+        }
+        .render()
+        .unwrap();
+        assert!(page.contains(r#"data-signals__ifmissing="{addStatus: '', addMessage: ''}""#));
+        assert!(
+            !page.contains("$add."),
+            "a nested add signal is back: {page}"
+        );
+        assert!(
+            !page.contains("JSON.stringify($add"),
+            "the prefix a nested signal needs is back, so the shape is too: {page}"
+        );
+    }
+
+    /// A template naming a helper the module does not define throws at click
+    /// time and nowhere else: no build step sees the split, so a rename on one
+    /// side of it is otherwise silent until someone presses the button.
+    #[test]
+    fn every_ms_helper_a_template_calls_is_defined() {
+        const SCRIPT: &str = include_str!("../assets/app.js");
+        let page = Page {
+            roots: vec![],
+            rows: vec![],
+            aria2_unreachable: false,
+        }
+        .render()
+        .unwrap();
+        // `Page` renders the picker inline, so this covers browse.html too.
+        let mut called: Vec<&str> = page
+            .match_indices("ms.")
+            .filter(|(i, _)| {
+                page[..*i]
+                    .chars()
+                    .next_back()
+                    .is_none_or(|c| !c.is_alphanumeric() && c != '_' && c != '$' && c != '.')
+            })
+            .filter_map(|(i, _)| page[i + 3..].split_once('('))
+            .map(|(name, _)| name)
+            .collect();
+        called.sort_unstable();
+        called.dedup();
+        assert!(
+            !called.is_empty(),
+            "no ms.* helper calls found at all: {page}"
+        );
+        for name in called {
+            assert!(
+                SCRIPT.contains(&format!("{name}(")),
+                "a template calls ms.{name}() but assets/app.js does not define it"
+            );
+        }
     }
 
     /// A finished row used to look exactly like every other row except for

--- a/apps/mariastew/templates/browse.html
+++ b/apps/mariastew/templates/browse.html
@@ -1,20 +1,13 @@
-{# One delegated handler for the whole picker rather than a `@get` per row.
-     Two reasons, and the second is the one that mattered. A hundred-plus
-     folders meant a hundred-plus expressions for Datastar to compile on
-     every morph, and the same number of URLs inlined into the HTML — a
-     real library sent 205KB of which the overwhelming majority was
-     repeated per-row markup. And a path reaching the browser as a plain
-     attribute value is never parsed as an expression, so a folder named
-     with a quote cannot break out into the handler the way it could when
-     each URL was interpolated into one.
+{# One delegated handler for the whole picker rather than a `@get` per row —
+     see `ms.browseUrl` for why.
 
-     It lives on `#picker` because that is the element the response
-     patches: Datastar morphs by id rather than replacing, so the handler
-     and its in-flight `$browsing` signal survive the swap they trigger.
-     Anything below it is free to be replaced wholesale. #}
+     It lives on `#picker` because that is the element the response patches:
+     Datastar morphs by id rather than replacing, so the handler and its
+     in-flight `$browsing` signal survive the swap they trigger. Anything below
+     it is free to be replaced wholesale. #}
 {% import "icons.html" as icons %}
 <div id="picker" class="flex flex-col gap-2" data-indicator="browsing"
-  data-on:click="const t = evt.target.closest('[data-dir]'); if (t) @get('/browse?path=' + encodeURIComponent(t.dataset.dir))">
+  data-on:click="const url = ms.browseUrl(evt); if (url) @get(url)">
   {# Centred, not top-aligned: the buttons are 44px touch targets and the
        path is a 20px line, so aligning their tops leaves the home icon
        sitting 12px below the text it belongs to. A path long enough to wrap past 44px
@@ -153,11 +146,11 @@
   <div class="flex gap-2">
     <input type="hidden" name="parent" value="{{ path }}">
     {# Enter creates the folder, for the same reason it adds the magnet — see
-         the note on that field. A text field whose button is right beside it
-         and whose Enter key does nothing is the one place a keyboard is
-         guaranteed to be open. #}
+         `ms.clickOnEnter`. A text field whose button is right beside it and
+         whose Enter key does nothing is the one place a keyboard is guaranteed
+         to be open. #}
     <input name="name" placeholder="New folder name" enterkeyhint="done"
-      data-on:keydown="if (evt.key === 'Enter') { evt.preventDefault(); document.getElementById('mkdir-submit').click() }"
+      data-on:keydown="ms.clickOnEnter(evt, $mkdirSubmit)"
       class="input input-bordered input-sm flex-1 min-h-11">
     {# Icon-only, like the home button above: this row is a text field and
          its button on a phone, and the word took the width a folder name
@@ -168,7 +161,8 @@
          nothing else. Creating a folder answers with the same picker after
          the same readdir, and showed nothing at all while it did. #}
     <button type="button" id="mkdir-submit" class="btn btn-sm min-h-11 min-w-11"
-      aria-label="Create folder" title="Create folder" data-indicator="browsing"
+      aria-label="Create folder" title="Create folder"
+      data-ref="mkdirSubmit" data-indicator="browsing"
       data-on:click="@post('/mkdir', {contentType: 'form'})">{% call icons::folder_plus(class="text-lg") %}{% endcall %}</button>
   </div>
 

--- a/apps/mariastew/templates/page.html
+++ b/apps/mariastew/templates/page.html
@@ -9,18 +9,26 @@
 <title>mariastew</title>
 {% import "icons.html" as icons %}
 <link rel="stylesheet" href="/assets/app.css">
+{# Before Datastar: both are modules, so they run in document order and `ms.*`
+     is defined by the time an expression names one. #}
+<script type="module" src="/assets/app.js"></script>
 <script type="module" src="/assets/datastar.js"></script>
 </head>
-{# `$add` is the whole contract with the server for this form: one signal,
-     patched by POST /add's response (Content-Type: application/json is all
-     it takes — Datastar treats a JSON body as a signal patch on its own,
-     no SSE framing required, confirmed against the vendored bundle rather
-     than assumed). `{status: "ok"}` closes the dialog and confirms;
-     `{status: "error", message: "..."}` keeps it open and shows why.
-     `__ifmissing` seeds the shape once without ever stomping a patch that
-     arrived before this ran. #}
+{# `$addStatus` and `$addMessage` are the whole contract with the server for
+     this form: POST /add answers with a JSON body, which Datastar treats as a
+     signal patch on its own (Content-Type: application/json is all it takes, no
+     SSE framing required). `ok` closes the dialog and confirms; `error` keeps it
+     open and says why.
+
+     Two flat signals rather than one `$add` object: a nested signal is tracked
+     only through its parent, so a reader of `$add.status` alone does not re-run
+     when the server patches it, and fails silently when it does not. A
+     top-level signal has no parent. `''` rather than `null` because a null in a
+     `data-signals` patch deletes the key rather than setting it.
+
+     `__ifmissing` seeds them without stomping a patch that arrived first. #}
 <body data-init="@get('/stream')"
-  data-signals__ifmissing="{add: {status: null, message: null}}"
+  data-signals__ifmissing="{addStatus: '', addMessage: ''}"
   class="min-h-screen bg-base-200">
 
 {# The header is the primary action, not a name plus an action — the person
@@ -29,63 +37,33 @@
      the same reason it did: the only control in the header of an app for
      adding downloads does not need saying twice. It keeps its accessible
      name in `aria-label` — the icon is `aria-hidden`, so without it the
-     button would announce as nothing at all. #}
-{# The clipboard read happens here, in the click handler, because that is the
-     only place it can: every browser gates `readText()` on transient user
-     activation, and `showModal()` does not spend it. Whether a prompt appears
-     is the browser's call — Safari draws its own Paste button, Chrome grants
-     it silently on the gesture, an insecure origin has no `navigator.clipboard`
-     at all — so both arms are handled and none of them are an error: a refusal
-     or a clipboard holding something else just leaves an empty field to type
-     into. Only a magnet is pasted, since that is the only thing `/add` accepts,
-     and only into a field still empty, because the prompt can outlast the
-     moment someone gives up waiting and starts typing. #}
+     button would announce as nothing at all.
+
+     Nothing is reset here: closing is what clears an abandoned attempt, and
+     that is the one event every dismissal raises. #}
 <header class="bg-base-100 shadow-sm p-4">
   <button type="button" class="btn btn-primary btn-lg min-h-14 w-full"
     aria-label="Add download" title="Add download"
-    data-on:click="$add = {status: null, message: null}; document.getElementById('add-dialog').showModal(); navigator.clipboard?.readText().then((text) => { const field = document.querySelector('#add-form [name=magnet]'); if (!field.value && text.trim().startsWith('magnet:?')) field.value = text.trim() }, () => {})">{% call icons::plus(class="text-3xl") %}{% endcall %}</button>
+    data-on:click="$addDialog.showModal(); ms.pasteMagnet($magnet)">{% call icons::plus(class="text-3xl") %}{% endcall %}</button>
 </header>
 
-{# Reacts to $add rather than to the fetch itself, so it does not care
-     whether the response was a plain JSON body or an SSE patch — either
-     lands here the same way. Closes the dialog and clears the field the
-     moment $add says ok; the toast below confirms and dismisses itself.
+{# The confirmation the owner asked for: something to actually see once the
+     dialog goes, not just a row that shows up later.
 
-     `JSON.stringify($add);` on its own line is load-bearing, not decorative
-     — confirmed by direct testing, not assumed. A nested signal
-     (`$add.status`) read only through a chained property access
-     (`$add.status === 'ok'` as the very first thing evaluated) does not
-     reliably re-run this effect when the server patches `$add`; forcing a
-     full read of the parent object first does, on every test run, with or
-     without other statements around it. Do not remove this line — the
-     failure mode if you do is silent: no error, no console output, the
-     effect just never fires and the dialog never closes. #}
-<div data-effect="JSON.stringify($add); if ($add.status === 'ok') { document.getElementById('add-dialog').close(); document.querySelector('#add-form [name=magnet]').value = '' }"></div>
+     Bottom, not top: the header is a single full-width Add button and a top
+     toast lands squarely on it — so the confirmation covered the control that
+     produced it, at the one moment someone might want to add a second magnet.
+     The dialog is already closed by the time this shows, so the bottom edge it
+     used to occupy is free.
 
-{# The reset that clears the toast lives in its own on-interval instead of
-     a plain window.setTimeout — confirmed by direct testing, not assumed.
-     A raw timer callback that writes $add writes the signal outside
-     Datastar's own batch (`beginBatch`/`endBatch`, which every native
-     trigger — `on-interval` included — wraps its callback in), and that
-     write was never picked up by data-show: the toast stayed on screen
-     indefinitely with no error anywhere. `on-interval` wraps correctly, at
-     the cost of
-     firing every three seconds for the life of the page rather than once —
-     harmless, since resetting an already-null $add is a no-op — and the
-     toast disappears within one interval period of $add going ok, not at
-     exactly three seconds. #}
-<div data-on-interval__duration.3s="$add = {status: null, message: null}"></div>
-
-{# The confirmation the owner asked for: something to actually see once
-     the dialog goes, not just a row that shows up later. Same
-     JSON.stringify($add) prefix as the effect above, same reason — see
-     that comment. #}
-{# Bottom, not top: the header became a single full-width Add button, and a
-     top toast lands squarely on it — so the confirmation covered the control
-     that produced it, at the one moment someone might want to add a second
-     magnet. The dialog is already closed by the time this shows, so the
-     bottom edge it used to occupy is free. #}
-<div class="toast toast-bottom toast-center z-10 mb-[env(safe-area-inset-bottom)]" data-show="JSON.stringify($add) && $add.status === 'ok'">
+     It clears the signal it reads, three seconds after the patch that set it,
+     so nothing else has to own its lifetime. A bare `setTimeout` cannot: it
+     writes outside Datastar's batch and the write is never picked up, with no
+     error anywhere. The clear is itself a patch, so this fires once more and
+     then stops — an idle page has no timer running. #}
+<div class="toast toast-bottom toast-center z-10 mb-[env(safe-area-inset-bottom)]"
+  data-show="$addStatus === 'ok'"
+  data-on-signal-patch__delay.3s="if ($addStatus === 'ok') { $addStatus = ''; $addMessage = '' }">
   <div role="alert" class="alert alert-success">
     {% call icons::circle_check() %}{% endcall %}
     <span>Added — it will show up in the list shortly.</span>
@@ -102,27 +80,25 @@
      directory tree in front of someone who has not pasted anything yet.
      `dvh` rather than `vh` because mobile Safari's collapsing toolbar makes
      `vh` wrong the moment the address bar shows or hides. #}
-{# Reset on close rather than on open. A chosen destination and a half-typed
+{# It closes itself off `$addStatus` rather than off the fetch, so it does not
+     care whether the answer came back as a plain JSON body or an SSE patch.
+
+     Reset on close rather than on open. A chosen destination and a half-typed
      magnet survived Cancel and every tap-outside dismiss, because nothing ever
      put the dialog back — reopening showed the previous attempt and the only
      way out was reloading the page. Closing is the moment an attempt is
      abandoned, and it is the one event every dismissal raises: Cancel's
      `method="dialog"`, `closedby="any"`, and Escape alike. Re-fetching the
-     picker with no path returns it to the roots. #}
-<dialog id="add-dialog" closedby="any"
-  data-on:close="$add = {status: null, message: null}; document.querySelector('#add-form [name=magnet]').value = ''; @get('/browse')"
+     picker with no path returns it to the roots. Only an error is cleared — the
+     success that closed this is what the toast is still showing. #}
+<dialog id="add-dialog" closedby="any" data-ref="addDialog"
+  data-effect="if ($addStatus === 'ok') el.close()"
+  data-on:close="if ($addStatus === 'error') $addStatus = ''; $addMessage = ''; $magnet.value = ''; @get('/browse')"
   class="open:flex flex-col mx-0 mt-auto mb-0 w-full sm:mx-auto sm:mb-auto sm:max-w-sm max-h-[85dvh] rounded-t-2xl sm:rounded-box bg-base-100 shadow-xl backdrop:bg-black/50">
   <div class="mx-auto mt-3 h-1.5 w-10 shrink-0 rounded-full bg-base-300 sm:hidden"></div>
   <form id="add-form" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
-    {# Enter has to be wired by hand. The button that adds is pinned in the
-         footer outside this form, so there is no submit button in it to do
-         implicit submission, and the picker's own text field means the
-         single-field exception does not apply either — the keyboard's Go key
-         did nothing at all, which on a phone is where the paste just
-         happened. Clicking the real button rather than repeating its
-         expression keeps one definition of what Add does. #}
-    <input name="magnet" required placeholder="Paste a magnet link" enterkeyhint="go"
-      data-on:keydown="if (evt.key === 'Enter') { evt.preventDefault(); document.getElementById('add-submit').click() }"
+    <input name="magnet" data-ref="magnet" required placeholder="Paste a magnet link" enterkeyhint="go"
+      data-on:keydown="ms.clickOnEnter(evt, $addSubmit)"
       class="input input-bordered input-lg min-h-14 w-full text-base" autofocus>
     <details class="disclosure rounded-box border border-base-300">
       <summary class="min-h-11 flex items-center gap-2 p-3 cursor-pointer text-sm">
@@ -136,19 +112,18 @@
     </details>
   </form>
 
-  {# A 400 (magnets only, destination outside a root, magnet never
-       resolved) used to do nothing visible at all — indistinguishable from
-       the dialog just not working. Same $add contract as success, so it
-       needs nothing from the server beyond the message it already computed
-       for the plain-text body today. Same JSON.stringify($add) prefix as
-       the effect above and for the same reason. #}
-  {# The icon is a sibling of the message, not inside it: `data-text`
-       replaces the element's whole content, so anything nested in the same
-       element is gone the first time an error arrives. #}
+  {# A 400 (magnets only, destination outside a root, magnet never resolved)
+       used to do nothing visible at all — indistinguishable from the dialog
+       just not working. Same contract as success, so it needs nothing from the
+       server beyond the message it already computed for the plain-text body.
+
+       The icon is a sibling of the message, not inside it: `data-text` replaces
+       the element's whole content, so anything nested in the same element is
+       gone the first time an error arrives. #}
   <p class="flex items-start gap-1.5 px-4 text-sm text-error"
-    data-show="JSON.stringify($add) && $add.status === 'error'">
+    data-show="$addStatus === 'error'">
     {% call icons::triangle_alert() %}{% endcall %}
-    <span data-text="JSON.stringify($add) && $add.message"></span>
+    <span data-text="$addMessage"></span>
   </p>
 
   {# The one row that has to clear the home indicator: a bottom sheet ends at
@@ -164,16 +139,15 @@
          explicitly which form to serialize instead of walking up from here
          and finding none.
 
-         data-indicator sets $adding for exactly the request's duration —
-         confirmed against the vendored plugin, not assumed — which is what
-         drives both the disabled state (a second tap while the first is
-         still in flight is how the owner's retries piled up duplicate
-         "already registered" errors) and the label. $add is cleared before
-         firing so a stale error from a previous attempt does not linger
-         through a fresh one. #}
+         data-indicator sets $adding for exactly the request's duration, which
+         is what drives both the disabled state (a second tap while the first is
+         still in flight is how the owner's retries piled up duplicate "already
+         registered" errors) and the label. The signals are cleared before
+         firing so a stale error from a previous attempt does not linger through
+         a fresh one. #}
     <button type="button" id="add-submit" class="btn btn-primary min-h-12 flex-[2]"
-      data-indicator="adding" data-attr:disabled="$adding"
-      data-on:click="$add = {status: null, message: null}; @post('/add', {contentType: 'form', selector: '#add-form'})">
+      data-ref="addSubmit" data-indicator="adding" data-attr:disabled="$adding"
+      data-on:click="$addStatus = ''; $addMessage = ''; @post('/add', {contentType: 'form', selector: '#add-form'})">
       <span data-show="$adding" class="loading loading-spinner loading-sm"></span>
       <span data-text="$adding ? 'Adding…' : 'Add'"></span>
     </button>

--- a/packages/k8s/src/service.test.ts
+++ b/packages/k8s/src/service.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout as sleep } from "node:timers/promises";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -173,7 +174,7 @@ describe("service template", () => {
         if (found) return found;
         // Sequential is the point — polling for something to appear.
         // oxlint-disable-next-line no-await-in-loop
-        await new Promise((r) => setTimeout(r, 5));
+        await sleep(5);
       }
       throw new Error(`${name} was never registered`);
     };

--- a/packages/vpn/src/profiles.ts
+++ b/packages/vpn/src/profiles.ts
@@ -1,4 +1,5 @@
 import * as crypto from "node:crypto";
+import { sha256hex } from "@jaritanet/k8s";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import type { VpnUser } from "./users.ts";
@@ -6,6 +7,8 @@ import {
   buildProfile,
   type Exit,
   notifyProfileUrls,
+  type ResolvedExit,
+  type ResolvedNode,
   type SingboxNode,
 } from "./singbox.ts";
 
@@ -70,11 +73,9 @@ export function createProfileServer(
             JSON.stringify(
               buildProfile(
                 user,
-                // biome-ignore lint/suspicious/noExplicitAny: resolved Outputs
-                resolved as any,
+                resolved as ResolvedNode[],
                 opts.magicdnsSuffix,
-                // biome-ignore lint/suspicious/noExplicitAny: resolved Outputs
-                resolvedExits as any,
+                resolvedExits as ResolvedExit[],
               ),
               null,
               2,
@@ -84,11 +85,9 @@ export function createProfileServer(
       ),
     );
 
-  const routesHash = pulumi
-    .secret(routes)
-    .apply((r) =>
-      crypto.createHash("sha256").update(r).digest("hex").slice(0, 16),
-    );
+  const routesHash = sha256hex(pulumi.secret(routes)).apply((h) =>
+    h.slice(0, 16),
+  );
 
   const secret = new k8s.core.v1.Secret(
     "singbox-profiles",

--- a/packages/vpn/src/singbox.ts
+++ b/packages/vpn/src/singbox.ts
@@ -29,7 +29,7 @@ export type SingboxNode = {
 };
 
 /** The same shape with Outputs resolved to plain strings (for JSON.stringify). */
-type ResolvedNode = {
+export type ResolvedNode = {
   name: string;
   server: string;
   hysteria: {
@@ -56,7 +56,7 @@ export type Exit = {
   server: pulumi.Input<string>;
 };
 
-type ResolvedExit = {
+export type ResolvedExit = {
   name: string;
   port: number;
   method: string;


### PR DESCRIPTION
Closes #325.

## The question the ticket asked

No, Alpine would not have helped. `x-on:click="…"` is the same inline JavaScript
with a different prefix, and Datastar is load-bearing here for reasons Alpine has
no answer to: `datastar-patch-elements` morphs by element id, which is what keeps
a row's `<details>` open while the SSE stream rewrites it once a second, and
`data-indicator` is what drives every in-flight state. Replacing one library
would have meant adding two.

The problem was never the attribute. It was that we had written *programs* in
attributes — the Add button was a 300-character clipboard read, promise chain and
two DOM queries — and `apps/*/assets` was ignored wholesale by oxlint and oxfmt
for the vendored bundle's sake, so no gate in the repo had ever parsed a line of
it.

## What changed

**The split.** Anything with control flow is a helper on `ms` in
`assets/app.js`; signal writes and one `@action` stay inline, where they read as
markup. Elements come from `data-ref`, not `document.getElementById`. The ignore
patterns now name the build outputs (`datastar.js`, `*.css`) rather than the
directory, so the hand-written file is linted and formatted like everything else.

**Three hacks, each of which failed silently.** These are the reason the ticket
exists, and all three were consequences of the same thing — reaching for a
workaround where a Datastar primitive already existed:

| Was | Is | Why the old one was wrong |
|---|---|---|
| `JSON.stringify($add)` beside every reader of `$add.status` | `$addStatus` / `$addMessage` | A nested signal is tracked only through its parent, so a reader of `$add.status` alone never re-runs. Two flat signals have no parent. The seed also moved `null` → `''`: a null in a `data-signals` patch **deletes** the key rather than setting it, so the shape it claimed to seed was never created. |
| `document.getElementById('add-dialog')`, `querySelector('#add-form [name=magnet]')` | `data-ref` + `el` | Every id was written twice, and once per reader. |
| `data-on-interval__duration.3s` writing signals for the life of the page | `data-on-signal-patch__delay.3s`, guarded | It fired 20 times a minute forever to dismiss a toast. The new one fires from the patch that set the toast, and since the clear is itself a patch, it fires once more and stops. An idle page has no timer. |

`POST /add` answers with the flat names to match (`src/routes.rs`).

Roughly 90 lines of comment went with them — the essays existed to explain the
hacks, and CLAUDE.md's rule is that comments are timeless. The reasoning that
outlives the hack stayed.

**Also, from a sweep of the TypeScript** (small, unrelated to the templates):
`buildProfile`'s two `as any` casts now name the resolved types that already
existed unexported for exactly them; `routesHash` uses the `sha256hex` helper
three of its neighbours already use, producing a byte-identical value; a poll
loop sleeps with `node:timers/promises`; `seed-dev-fixtures` awaits its own
`main`, so a failure is a failed script rather than an unhandled rejection.

## How to confirm it works

Everything here is behavioural in a browser, so the checks are tests over the
rendered markup — `mise run check` is green (159 vitest), as is `cargo test` in
`apps/mariastew` (162).

Four template tests pinned the old shapes and now pin the new ones. Two are new,
and they are the ones worth reading:

- `the_add_contract_is_flat_signals` — fails if `$add.` or a
  `JSON.stringify($add)` prefix comes back. That regression is invisible at
  runtime: no error, the dialog just never closes.
- `every_ms_helper_a_template_calls_is_defined` — renders the page, collects
  every `ms.*` it names, and fails if `app.js` does not define one. Nothing else
  sees across that split, so a rename would otherwise be silent until someone
  pressed the button.

Also worth a manual pass on the compose stack (`docker compose up --build`, then
`/auth/dev-login`), since signal reactivity is the part a test can only
approximate: add a magnet and check the dialog closes and the toast appears and
goes; add a non-magnet and check the error shows and survives until Cancel; open
the picker and check both Enter keys and the spinner still work.

**No CSS change** — `assets/app.css` is byte-identical, confirming no class names
moved.

## Left out deliberately

The same 16-line cloud-init-wait shell block is copy-pasted verbatim seven times
across `packages/vpn`, `packages/hetzner` and `packages/infra`. It is a real
rule-of-three violation, but it is deployed shell in six files and has nothing to
do with this diff — filed separately as #337.
