### PR TITLE
341 feat(mariastew): show the running version under the list

### DIFF
--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.19] - 2026-08-08
+
+### Added
+
+- Show the running version under the list ([#341](https://github.com/radiosilence/jaritanet/issues/341), [#344](https://github.com/radiosilence/jaritanet/pull/344))
+
 ## [0.1.18] - 2026-08-08
 
 ### Added

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -291,6 +291,17 @@ impl Page {
         }
         .render()
     }
+
+    /// The build serving this page. `Cargo.toml`'s version is what a release
+    /// is here, so it is the same string the image tag and the GitHub release
+    /// carry — which is the point: neither of those is visible from a phone,
+    /// and "which build am I looking at" is the first question a download
+    /// behaving oddly raises. A method rather than a field because it is
+    /// fixed at compile time and every construction site, tests included,
+    /// would otherwise have to repeat it.
+    fn version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
 }
 
 /// The list on its own. Its root element carries the same id as the one in the
@@ -624,6 +635,24 @@ mod tests {
         assert!(
             !page.contains("data-on-click") && !page.contains("data-on-submit"),
             "a dash-form data-on- attribute survived and will be silently ignored: {page}"
+        );
+    }
+
+    /// The version is only worth showing if it is the one that shipped. A
+    /// hardcoded string in the template would render fine and be wrong from
+    /// the next release onward, silently.
+    #[test]
+    fn the_page_shows_the_build_it_was_compiled_from() {
+        let page = Page {
+            roots: vec![],
+            rows: vec![],
+            aria2_unreachable: false,
+        }
+        .render()
+        .unwrap();
+        assert!(
+            page.contains(&format!("v{}", env!("CARGO_PKG_VERSION"))),
+            "no version on the page: {page}"
         );
     }
 

--- a/apps/mariastew/templates/page.html
+++ b/apps/mariastew/templates/page.html
@@ -158,5 +158,14 @@
 {% include "downloads.html" %}
 </main>
 
+{# Below the list, which is the one place on this page that costs nothing:
+     the header is a single control by design and the bottom edge is where a
+     version is looked for. It clears the home indicator for the same reason
+     the dialog's footer does — it is the last element on the page, so on a
+     phone with a gesture bar it would otherwise sit under it. #}
+<footer class="pb-[max(1rem,env(safe-area-inset-bottom))] text-center text-xs opacity-40">
+  v{{ self.version() }}
+</footer>
+
 </body>
 </html>


### PR DESCRIPTION
Closes #341.

A `<footer>` after the download list, `text-xs opacity-40`, reading `v0.1.19` from `env!("CARGO_PKG_VERSION")` through a `Page::version()` method.

**Why a method, not a field.** `Page` is constructed at one route and a dozen tests; a field would make every one of them repeat a string that is fixed at compile time. `picker()` is already the precedent.

**Why the bottom.** The header is deliberately a single full-width Add button — anything else in it spends the vertical space a phone in portrait can least afford. The footer carries the same `pb-[max(1rem,env(safe-area-inset-bottom))]` the dialog's button row does, because it is now the last element on the page and would otherwise sit under the gesture bar.

`Cargo.toml`'s version is what a release is here, so what the page shows is the same string as the image tag and the GitHub release — neither of which is visible from a phone.

## Verifying

- `views::tests::the_page_shows_the_build_it_was_compiled_from` renders `Page` and asserts the compiled-in version is in the output, so a hardcoded string in the template fails rather than quietly going stale at the next bump.
- `mise run css` reported no change to `assets/app.css` — every class used was already emitted.
- Version bumped to 0.1.19 with a changelog entry, per the release convention.