### PR TITLE
345 fix(infra): sort tags by version instead of trusting API order

### DIFF
--- a/packages/infra/src/versions.test.ts
+++ b/packages/infra/src/versions.test.ts
@@ -70,6 +70,20 @@ describe("pickLatestTag", () => {
       normaliseVersion(pickLatestTag(tags, "serve-from-env-v") ?? ""),
     ).toBe("0.2.0");
   });
+
+  // The releases API returned mariastew's history with 0.1.9 ahead of 0.1.19,
+  // and comparing the tags as whole strings agreed: "9" > "1". Reported as
+  // #345 — the workflow called 0.1.9 up to date while 0.1.19 was live.
+  it("sorts by version rather than trusting the order it is given", () => {
+    const outOfOrder = [
+      "mariastew-v0.1.9",
+      "mariastew-v0.1.8",
+      "mariastew-v0.1.19",
+      "mariastew-v0.1.10",
+      "mariastew-v0.1.0",
+    ];
+    expect(pickLatestTag(outOfOrder, "mariastew-v")).toBe("mariastew-v0.1.19");
+  });
 });
 
 describe("parseImageRef", () => {

--- a/packages/infra/src/versions.ts
+++ b/packages/infra/src/versions.ts
@@ -57,7 +57,37 @@ export type Decision =
 export const normaliseVersion = (tag: string) => tag.replace(/^\D*/, "");
 
 /**
- * The newest release belonging to one component, given tags newest first.
+ * Numeric segment by segment, so `0.1.19` sorts above `0.1.9` — comparing the
+ * whole string the ordinary way puts it below, because `1` < `9`.
+ */
+function compareVersions(a: string, b: string) {
+  const partsA = normaliseVersion(a).split(/[.-]/);
+  const partsB = normaliseVersion(b).split(/[.-]/);
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const partA = partsA[i] ?? "";
+    const partB = partsB[i] ?? "";
+    const numA = Number(partA);
+    const numB = Number(partB);
+    if (
+      partA !== "" &&
+      partB !== "" &&
+      !Number.isNaN(numA) &&
+      !Number.isNaN(numB)
+    ) {
+      if (numA !== numB) return numA - numB;
+      continue;
+    }
+    if (partA !== partB) return partA < partB ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * The newest release belonging to one component.
+ *
+ * The releases API is not reliably newest-first — this repo's own release
+ * history for `mariastew` came back with `0.1.9` ahead of `0.1.19` — so this
+ * has to sort rather than trust the order it is handed.
  *
  * A repo publishing several things cuts prefixed releases — this one releases
  * `serve-from-env-v1.2.0` and `files-v1.0.0` — and "the latest release" is then
@@ -65,7 +95,9 @@ export const normaliseVersion = (tag: string) => tag.replace(/^\D*/, "");
  * released most recently and pin itself to an image that was never built.
  */
 export const pickLatestTag = (tags: string[], prefix?: string) =>
-  (prefix ? tags.filter((tag) => tag.startsWith(prefix)) : tags)[0];
+  (prefix ? tags.filter((tag) => tag.startsWith(prefix)) : tags)
+    .toSorted(compareVersions)
+    .at(-1);
 
 export const applyTemplate = (template: string, version: string) =>
   template.replaceAll("{version}", version);


### PR DESCRIPTION
## Summary

`pickLatestTag` (`packages/infra/src/versions.ts`) took the first element of the tag list returned by the GitHub releases API, on the assumption it comes back newest-first. It doesn't for this repo — `mariastew`'s release history came back with `0.1.9` ahead of `0.1.19` — and comparing the tags as whole strings agreed with that order, since `"9" > "1"` lexicographically. The updater locked onto `0.1.9` and reported mariastew up to date indefinitely, even though `0.1.19` had been live for a while (fixes #345).

`pickLatestTag` now sorts the filtered tags by version, comparing each `.`-separated segment numerically, and returns the maximum rather than the first.

## How to confirm

- `packages/infra/src/versions.test.ts` has a new case reproducing the exact reported symptom: an out-of-order tag list (`0.1.9`, `0.1.8`, `0.1.19`, `0.1.10`, `0.1.0`) now correctly picks `0.1.19`.
- Existing `pickLatestTag` tests still pass unchanged — the ordering they assert on happens to already be sorted, so the new sort is a no-op there.
- `mise run check` (lint, fmt, typecheck, test) is green.

## Dependency

Once merged, dispatching `update-apps.yml` manually should bump mariastew's pin from `0.1.9` straight to `0.1.19` — worth watching that run to confirm the fix holds against the live registry, not just the test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQ2JfysAMmtdZ3Msvp3CAk