### PR TITLE
354 fix(mariastew): controls that say what they do and that the press landed

### DIFF
--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.20] - 2026-08-08
+
+### Changed
+
+- "Done" is "Clear" and "Delete download" is "Cancel & delete" — both now say what they do to the list, and a completed download reads "downloaded" rather than "ready" ([#354](https://github.com/radiosilence/jaritanet/issues/354))
+- Every control that changes something on the server spins and disables itself for its own request, rather than waiting for the next snapshot to show the press landed ([#354](https://github.com/radiosilence/jaritanet/issues/354))
+
 ## [0.1.19] - 2026-08-08
 
 ### Added

--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - "Done" is "Clear" and "Delete download" is "Cancel & delete" — both now say what they do to the list, and a completed download reads "downloaded" rather than "ready" ([#354](https://github.com/radiosilence/jaritanet/issues/354))
 - Every control that changes something on the server spins and disables itself for its own request, rather than waiting for the next snapshot to show the press landed ([#354](https://github.com/radiosilence/jaritanet/issues/354))
+- Clearing holds the response open until aria2 has actually let go, and stops the download with `forceRemove` rather than waiting for the swarm to be told. A removal that does not take answers with a status instead of a silent 204 ([#354](https://github.com/radiosilence/jaritanet/issues/354))
+- Every mutation is now bounded: 10s on any aria2 call, 10s on `mkdir`, and one second of retries on a removal ([#354](https://github.com/radiosilence/jaritanet/issues/354))
 
 ## [0.1.19] - 2026-08-08
 

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/src/aria2.rs
+++ b/apps/mariastew/src/aria2.rs
@@ -10,10 +10,21 @@
 
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde::Deserialize;
 
 use crate::error::{AppError, AppResult};
+
+/// How long any one call gets before it is a failure rather than a wait.
+///
+/// Every mutation the page can ask for is held open until aria2 answers it, so
+/// an unbounded call is a button that spins forever — and there is nothing here
+/// that aria2 answers slowly. A `tellStatus` or a `forceRemove` is a hash
+/// lookup over a loopback socket in the same pod; anything near this ceiling is
+/// a sidecar that has stopped answering, which is worth saying rather than
+/// waiting out.
+const RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub struct Aria2 {
@@ -523,6 +534,7 @@ impl Aria2 {
         let response = self
             .http
             .post(self.url.as_str())
+            .timeout(RPC_TIMEOUT)
             .json(&body)
             .send()
             .await
@@ -583,12 +595,17 @@ impl Aria2 {
         Ok(())
     }
 
-    /// Stop it, forcibly if it will not stop cleanly — the reason to press the
-    /// button is usually that something is misbehaving.
+    /// Stop it now. `forceRemove`, not `remove`: the graceful one announces the
+    /// stop to every tracker and waits for the peers to go before the download
+    /// leaves the active list, and the press that reaches here is someone who
+    /// has already decided — held open while it happens. Trying `remove` first
+    /// and falling back bought the polite version at the cost of that wait plus
+    /// a failed call on every download aria2 had already stopped.
+    ///
+    /// aria2 refuses this for a download that is already stopped, which is what
+    /// `remove_download_result` is for.
     pub async fn remove(&self, gid: &str) -> AppResult<()> {
-        if self.call("remove", serde_json::json!([gid])).await.is_err() {
-            self.call("forceRemove", serde_json::json!([gid])).await?;
-        }
+        self.call("forceRemove", serde_json::json!([gid])).await?;
         Ok(())
     }
 

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -588,11 +588,14 @@ async fn delete_partial(state: &AppState, status: &Download) {
 }
 
 /// How long to keep asking aria2 whether it has actually let go, and how often.
-/// A removal is usually done inside one poll; a torrent with peers to
-/// disconnect takes a moment longer. Giving up hands the row its controls back,
-/// which is the honest outcome — the download really is still there.
-const CLEAR_ATTEMPTS: u32 = 12;
-const CLEAR_POLL: Duration = Duration::from_millis(250);
+/// `forceRemove` stops the download outright, but it arrives in the stopped
+/// list a moment after the call returns and `removeDownloadResult` refuses it
+/// until it does — so one attempt is not enough and a second usually is. The
+/// request is held open for this, which is what keeps the budget to a second:
+/// giving up hands the row its controls back and answers with a status, which
+/// is the honest outcome — the download really is still there.
+const CLEAR_ATTEMPTS: u32 = 10;
+const CLEAR_POLL: Duration = Duration::from_millis(100);
 
 /// Make aria2 forget a download, then delete whatever it should not have left
 /// behind.
@@ -609,8 +612,8 @@ const CLEAR_POLL: Duration = Duration::from_millis(250);
 /// to the stopped list first, and `removeDownloadResult` refuses it until it
 /// arrives. So what decides the outcome here is not whether a call succeeded
 /// but whether the gid is still in a list the page reads — the same question
-/// the row on screen is asking.
-async fn clear(state: &AppState, gid: &str, status: &Download) {
+/// the row on screen is asking, and the answer this returns.
+async fn clear(state: &AppState, gid: &str, status: &Download) -> bool {
     if !status.is_stopped()
         && let Err(e) = state.aria2.remove(gid).await
     {
@@ -645,6 +648,7 @@ async fn clear(state: &AppState, gid: &str, status: &Download) {
         state.activity.record(gid, "aria2 would not let go of it");
     }
     state.clearing.end(gid);
+    gone
 }
 
 /// Two behaviours behind one button, decided by whether the download completed.
@@ -653,10 +657,17 @@ async fn clear(state: &AppState, gid: &str, status: &Download) {
 /// seeding, the files stay: that is stopping an upload, not undoing a download,
 /// and deleting the episode would be astonishing.
 ///
-/// The request only starts it. What aria2 takes to let go is not something a
-/// browser holds a `POST` open for (see `finish_add` for the same shape and the
-/// production abort that motivated it), so the row is marked `clearing` and the
-/// stream reports the outcome.
+/// The response is held until aria2 has actually let go, so the button's own
+/// loading state is the wait rather than a guess at it, and a removal that does
+/// not take answers with a status instead of a silent 204 over a row that is
+/// still there. That is affordable now only because the stop is `forceRemove`:
+/// the graceful one waited on the swarm, which is the open-ended wait
+/// `finish_add` is detached for.
+///
+/// `clear` runs in a task that is then awaited rather than inline. A browser
+/// that gives up on the response drops this future, and the removal has to
+/// outlive that — aria2 has already been told to stop by then, and abandoning
+/// the rest would leave the gid marked `clearing` with nothing left to lift it.
 pub async fn remove(
     State(state): State<AppState>,
     CurrentSession(session): CurrentSession,
@@ -672,11 +683,33 @@ pub async fn remove(
         finished = status.is_finished(),
         "removing download"
     );
-    if state.clearing.begin(&gid) {
-        state.activity.record(&gid, "clearing");
-        tokio::spawn(async move { clear(&state, &gid, &status).await });
+    // A second press while the first removal is still in flight waits on
+    // nothing: the row it would report on is already rendering as `clearing`
+    // from the request that owns it.
+    if !state.clearing.begin(&gid) {
+        return Ok(StatusCode::NO_CONTENT.into_response());
     }
-    Ok(StatusCode::NO_CONTENT.into_response())
+    state.activity.record(&gid, "clearing");
+    let task = tokio::spawn({
+        let state = state.clone();
+        let gid = gid.clone();
+        async move { clear(&state, &gid, &status).await }
+    });
+    match task.await {
+        Ok(true) => Ok(StatusCode::NO_CONTENT.into_response()),
+        Ok(false) => Err(AppError::Upstream(format!(
+            "aria2 still lists {gid} after being told to drop it"
+        ))),
+        // Only a panic reaches here, and `clear` lifts the mark on every path
+        // it returns from — so this is the one place left that can strand a row
+        // as permanently clearing.
+        Err(e) => {
+            state.clearing.end(&gid);
+            Err(AppError::Internal(anyhow::anyhow!(
+                "clearing {gid} panicked: {e}"
+            )))
+        }
+    }
 }
 
 #[derive(serde::Deserialize)]
@@ -780,6 +813,9 @@ pub struct MkdirForm {
     pub name: String,
 }
 
+/// How long the filesystem gets — see the call site in `mkdir`.
+const FS_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Rejects anything empty, a bare `.`/`..`, or containing a path separator —
 /// `mkdir` makes one directory, not a path of them.
 fn is_valid_dir_name(name: &str) -> bool {
@@ -806,8 +842,14 @@ pub async fn mkdir(
     let target = parent.join(&form.name);
     let target_str = target.to_string_lossy().into_owned();
 
-    tokio::fs::create_dir_all(&target)
+    // The one mutation here that is not an aria2 call, and so not covered by
+    // that client's own ceiling. A `mkdir` against the library's spinning disks
+    // takes a moment; taking this long is a mount that has gone away, and the
+    // request is held open for it — an uninterruptible `create_dir_all` on a
+    // dead NFS handle would otherwise be a spinner with no end.
+    tokio::time::timeout(FS_TIMEOUT, tokio::fs::create_dir_all(&target))
         .await
+        .map_err(|_| AppError::Internal(anyhow::anyhow!("mkdir timed out: {target_str}")))?
         .map_err(|e| AppError::Internal(e.into()))?;
 
     // `resolve` only ever answered for names; `target` exists now, so
@@ -1631,6 +1673,9 @@ mod tests {
         /// aria2 is not done when `remove` returns: the download has to reach
         /// the stopped list before `removeDownloadResult` will take it. One
         /// attempt left the corpse behind, where it rendered as a live row.
+        ///
+        /// The response is the end of the whole thing now, so nothing here has
+        /// to wait for a detached task to catch up.
         #[tokio::test]
         async fn a_removal_keeps_asking_until_aria2_has_actually_let_go() {
             let mock = mock_server("active", 3).await;
@@ -1645,13 +1690,10 @@ mod tests {
             .await
             .expect("removing an active download must not fail");
 
-            assert!(wait_until_gone(&mock).await, "aria2 still lists it");
-            for _ in 0..100 {
-                if !state.clearing.contains("g1") {
-                    break;
-                }
-                tokio::time::sleep(StdDuration::from_millis(10)).await;
-            }
+            assert!(
+                mock.status.lock().unwrap().is_none(),
+                "the response came back before aria2 had let go"
+            );
             assert!(!state.clearing.contains("g1"), "the mark was never lifted");
             assert!(
                 state.activity.entries("g1").is_empty(),
@@ -1668,13 +1710,12 @@ mod tests {
             );
         }
 
-        /// The press has to be visible before aria2 answers, or it reads as
-        /// nothing having happened — which is the whole complaint. The mark is
-        /// set by the request, not by whatever finishes later.
+        /// Stopping is `forceRemove` — the graceful `remove` announces to every
+        /// tracker and waits for the peers to go, which is the wait the held
+        /// response cannot afford and the press has already decided against.
         #[tokio::test]
-        async fn the_row_is_marked_clearing_before_the_removal_completes() {
-            // Refuses long enough that the mark is still up when this asserts.
-            let mock = mock_server("active", u32::MAX).await;
+        async fn stopping_a_running_download_does_not_wait_for_the_swarm() {
+            let mock = mock_server("active", 0).await;
             let state = state(mock.url.clone());
             remove(
                 State(state.clone()),
@@ -1682,8 +1723,63 @@ mod tests {
                 Path("g1".to_string()),
             )
             .await
-            .expect("removal must be accepted");
-            assert!(state.clearing.contains("g1"));
+            .expect("removing an active download must not fail");
+
+            let calls = mock.calls.lock().unwrap();
+            assert!(
+                calls.iter().any(|m| m == "aria2.forceRemove"),
+                "nothing forced the stop: {calls:?}"
+            );
+            assert!(
+                !calls.iter().any(|m| m == "aria2.remove"),
+                "the graceful call is the wait this avoids: {calls:?}"
+            );
+        }
+
+        /// A removal that does not take is a row that is still there, and
+        /// answering 204 over it is the silence #354 was about. The mark comes
+        /// off either way — the controls it hid have to come back.
+        #[tokio::test]
+        async fn a_removal_aria2_refuses_answers_with_an_error_and_hands_the_row_back() {
+            let mock = mock_server("active", u32::MAX).await;
+            let state = state(mock.url.clone());
+            let err = remove(
+                State(state.clone()),
+                CurrentSession(session()),
+                Path("g1".to_string()),
+            )
+            .await
+            .expect_err("a removal that never took must not answer 204");
+            assert!(matches!(err, AppError::Upstream(_)), "{err:?}");
+            assert!(!state.clearing.contains("g1"), "the mark was never lifted");
+        }
+
+        /// The press has to be visible before aria2 answers, or it reads as
+        /// nothing having happened — which is the whole complaint. Every other
+        /// page open on the same download reads the mark, not this request's
+        /// response, so it is set for the whole time the request is in flight.
+        #[tokio::test]
+        async fn the_row_is_marked_clearing_while_the_removal_is_still_in_flight() {
+            // Refuses for the whole attempt budget, so the request is still
+            // open while this asserts against it.
+            let mock = mock_server("active", u32::MAX).await;
+            let state = state(mock.url.clone());
+            let in_flight = tokio::spawn({
+                let state = state.clone();
+                async move {
+                    remove(State(state), CurrentSession(session()), Path("g1".to_string())).await
+                }
+            });
+
+            let mut marked = false;
+            for _ in 0..200 {
+                if state.clearing.contains("g1") {
+                    marked = true;
+                    break;
+                }
+                tokio::time::sleep(StdDuration::from_millis(5)).await;
+            }
+            assert!(marked, "the press was invisible until the removal finished");
 
             let downloads = all_downloads(&state).await.expect("aria2 answers");
             let row = rows(&state, &downloads)
@@ -1692,6 +1788,8 @@ mod tests {
                 .expect("the row is still there while aria2 holds on");
             assert_eq!(row.state, "clearing");
             assert!(row.clearing);
+
+            in_flight.await.expect("the handler ran to completion").ok();
         }
     }
 }

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -87,7 +87,7 @@ pub struct Row {
     pub paused: bool,
     /// Removal asked for and not yet confirmed — see `state::Clearing`. It
     /// replaces `state` above rather than sitting beside it: a row on its way
-    /// out is not "ready", whatever aria2 still says about the swarm.
+    /// out is not "downloaded", whatever aria2 still says about the swarm.
     pub clearing: bool,
 }
 
@@ -99,6 +99,10 @@ pub struct Row {
 /// screen was the giveaway: it is precise about traffic and meaningless to
 /// whoever is waiting for a film. Each state now says either what is
 /// happening or what is wrong, in the terms of the thing being waited for.
+///
+/// `Complete` says "downloaded" rather than "ready" for that reason. "Ready"
+/// names a state of the app — something prepared, waiting to be started — when
+/// what it is reporting is that the file has arrived.
 ///
 /// "starting" used to answer for everything between pasting a magnet and the
 /// first byte, which is where a download spends the time someone actually
@@ -112,7 +116,7 @@ pub struct Row {
 fn bar_class_and_state(health: Health) -> (&'static str, &'static str) {
     match health {
         Health::Moving => ("progress-success", "downloading"),
-        Health::Complete => ("progress-success", "ready"),
+        Health::Complete => ("progress-success", "downloaded"),
         Health::Choked => ("progress-warning", "stalled"),
         Health::Blocked => ("progress-error", "can't connect"),
         Health::Errored => ("progress-error", "failed"),
@@ -145,7 +149,8 @@ impl Row {
         // Not a `Health`: nothing has been asked of the swarm and aria2's
         // reading has not changed, so this is a fact about a request in flight
         // rather than about the download. It still outranks the reading —
-        // "ready" beside a spinner is the confusion the mark exists to remove.
+        // "downloaded" beside a spinner is the confusion the mark exists to
+        // remove.
         let (bar_class, state) = if clearing {
             ("progress-info", "clearing")
         } else {
@@ -512,7 +517,7 @@ mod tests {
     fn state_complete() {
         assert_eq!(
             bar_class_and_state(Health::Complete),
-            ("progress-success", "ready")
+            ("progress-success", "downloaded")
         );
     }
 
@@ -1351,22 +1356,54 @@ mod tests {
         assert!(!render(&moving()).contains("badge-success"));
     }
 
-    /// A finished torrent is one press from being done with, and the press
-    /// keeps every file — so the button says so and is coloured like the badge
-    /// beside it, rather than reading as the quiet sibling of the destructive
-    /// one it shares a slot with.
+    /// A finished torrent is one press from being out of the list, and the
+    /// press keeps every file — so the button says so and is coloured like the
+    /// badge beside it, rather than reading as the quiet sibling of the
+    /// destructive one it shares a slot with. #354: "Done" said neither which
+    /// of those two it was nor that it did anything to the list at all.
     #[test]
-    fn a_finished_row_offers_done_and_an_unfinished_one_offers_the_destructive_button() {
+    fn a_finished_row_offers_clear_and_an_unfinished_one_offers_the_destructive_button() {
         let finished = render(&Download {
             completed_length: 1_073_741_824,
             download_speed: 0,
             ..moving()
         });
-        assert!(finished.contains("Done"), "{finished}");
+        assert!(finished.contains("Clear"), "{finished}");
         assert!(!finished.contains("btn-error"));
 
         let unfinished = render(&moving());
-        assert!(unfinished.contains("Delete download"), "{unfinished}");
+        assert!(unfinished.contains("Cancel &amp; delete"), "{unfinished}");
+    }
+
+    /// #354: every control that changes something on the server says the press
+    /// landed, without waiting for a snapshot to come back and say it. The
+    /// signal is per row and per slot — one shared name would have a press on
+    /// one row spinning a button on another.
+    #[test]
+    fn each_control_spins_for_its_own_request() {
+        for html in [
+            render(&Download {
+                completed_length: 1_073_741_824,
+                download_speed: 0,
+                ..moving()
+            }),
+            render(&moving()),
+            render(&Download {
+                status: Status::Paused,
+                ..moving()
+            }),
+        ] {
+            for signal in ["pausingabc", "removingabc"] {
+                assert!(
+                    html.contains(&format!(r#"data-indicator="{signal}""#)),
+                    "no indicator for {signal}: {html}"
+                );
+                assert!(
+                    html.contains(&format!(r#"data-attr:disabled="${signal}""#)),
+                    "{signal} does not disable its own button: {html}"
+                );
+            }
+        }
     }
 
     /// A row offers exactly two controls, and every existing assertion here
@@ -1411,7 +1448,7 @@ mod tests {
 
     /// #316: the press had nothing to show for itself. aria2 takes a moment to
     /// let go and the list is redrawn from aria2 once a second, so a row being
-    /// removed kept reading "ready" beside a button that could be pressed
+    /// removed kept reading "downloaded" beside a button that could be pressed
     /// again — which is what "it does nothing" was. Every control goes and the
     /// state says what is happening.
     #[test]
@@ -1457,7 +1494,7 @@ mod tests {
 
     /// Nothing is moving, so there is no rate to show and no rate to divide
     /// the remaining bytes by — a "0 B/s · 0s left" on a finished row is two
-    /// measurements nobody took. The badge already says "ready".
+    /// measurements nobody took. The badge already says "downloaded".
     #[test]
     fn an_idle_row_shows_neither_and_keeps_the_dash_in_the_readings() {
         let page = render(&Download {

--- a/apps/mariastew/templates/row.html
+++ b/apps/mariastew/templates/row.html
@@ -211,25 +211,52 @@
           <span class="loading loading-spinner loading-xs"></span>Clearing…
         </button>
         {% else %}
+        {# Each control spins for exactly its own request. `data-indicator`
+             counts only requests raised by the element carrying it, so the
+             signal is named for the row as well as the slot — two rows pressed
+             at once must not spin each other, and the pause slot must not
+             answer for the clear slot beside it.
+
+             Server state arrives a poll behind at best, and for pause that is
+             the whole feedback there is: a button that looks untouched until
+             the next snapshot is the button people press again. #}
         {% if row.paused %}
         <button type="button" class="btn btn-sm min-h-11 flex-1"
-          data-on:click="@post('/downloads/{{ row.gid }}/resume')">{% call icons::play() %}{% endcall %} Resume</button>
+          data-indicator="pausing{{ row.gid }}" data-attr:disabled="$pausing{{ row.gid }}"
+          data-on:click="@post('/downloads/{{ row.gid }}/resume')">
+          <span data-show="$pausing{{ row.gid }}" class="loading loading-spinner loading-xs"></span>
+          <span data-show="!$pausing{{ row.gid }}" class="contents">{% call icons::play() %}{% endcall %}</span> Resume</button>
         {% else %}
         <button type="button" class="btn btn-sm min-h-11 flex-1"
-          data-on:click="@post('/downloads/{{ row.gid }}/pause')">{% call icons::pause() %}{% endcall %} Pause</button>
+          data-indicator="pausing{{ row.gid }}" data-attr:disabled="$pausing{{ row.gid }}"
+          data-on:click="@post('/downloads/{{ row.gid }}/pause')">
+          <span data-show="$pausing{{ row.gid }}" class="loading loading-spinner loading-xs"></span>
+          <span data-show="!$pausing{{ row.gid }}" class="contents">{% call icons::pause() %}{% endcall %}</span> Pause</button>
         {% endif %}
-        {# Done rather than "stop seeding", and affirmative rather than ghost:
-             on a finished row this is the ordinary end of a download and keeps
-             every file, which is the opposite of what the destructive button
-             beside it on an unfinished row does. The tick is the same one the
-             badge carries, for the same reason — this button is the one that
-             agrees with it. #}
+        {# Clear rather than "done" or "stop seeding", and affirmative rather
+             than ghost: on a finished row this takes the download out of the
+             list and keeps every file, which is the opposite of what the
+             destructive button beside it on an unfinished row does. "Done" was
+             read as marking something rather than removing it — the word for a
+             list is what it does to the list. The tick is the same one the
+             badge carries, for the same reason: this button is the one that
+             agrees with it.
+
+             The unfinished one names both halves, because it is the only
+             control here that destroys anything and "delete download" read as
+             deleting the entry. #}
         {% if row.finished %}
         <button type="button" class="btn btn-sm btn-success min-h-11 flex-1"
-          data-on:click="@post('/downloads/{{ row.gid }}/remove')">{% call icons::check() %}{% endcall %} Done</button>
+          data-indicator="removing{{ row.gid }}" data-attr:disabled="$removing{{ row.gid }}"
+          data-on:click="@post('/downloads/{{ row.gid }}/remove')">
+          <span data-show="$removing{{ row.gid }}" class="loading loading-spinner loading-xs"></span>
+          <span data-show="!$removing{{ row.gid }}" class="contents">{% call icons::check() %}{% endcall %}</span> Clear</button>
         {% else %}
         <button type="button" class="btn btn-sm btn-error min-h-11 flex-1"
-          data-on:click="@post('/downloads/{{ row.gid }}/remove')">{% call icons::trash() %}{% endcall %} Delete download</button>
+          data-indicator="removing{{ row.gid }}" data-attr:disabled="$removing{{ row.gid }}"
+          data-on:click="@post('/downloads/{{ row.gid }}/remove')">
+          <span data-show="$removing{{ row.gid }}" class="loading loading-spinner loading-xs"></span>
+          <span data-show="!$removing{{ row.gid }}" class="contents">{% call icons::trash() %}{% endcall %}</span> Cancel &amp; delete</button>
         {% endif %}
         {% endif %}
       </div>


### PR DESCRIPTION
Closes #354.

## What it does

**The words.** "Done" is `Clear` and "Delete download" is `Cancel & delete` — both now name what they do to the list rather than describing a state. A completed download reads `downloaded` rather than `ready`, which named a state of the app when what it reports is that the file arrived. The finished row keeps its green button and its tick; only the label moved.

**The feedback.** Every mutation is now held open until it has actually resolved, and every control carries its own `data-indicator` — so the spinner on a button is the server working, not a guess that it might be. Previously `remove` answered 204 the moment it had spawned the work, so the only acknowledgement of a press was the next snapshot.

**The stop is forced.** `forceRemove`, not `remove`. The graceful call announces the stop to every tracker and waits for peers to disconnect before the download leaves the active list — that is the open-ended wait a held response cannot carry, and someone pressing Clear has already decided. The retry budget drops from 3s to 1s with it.

**Nothing is unbounded.** 10s on any aria2 RPC (per-request, so it covers add/pause/resume/remove alike), 10s on `mkdir`'s `create_dir_all` — the only mutation not behind that client — and 1s of retries on a removal. A removal that still does not take answers 502 and hands the row its controls back, rather than 204 over a row that is still there.

## Load-bearing decisions

- **`clear` runs in a spawned task that is then awaited.** Awaiting the handle is what holds the response open; the task owning the work is what makes a client disconnect harmless. A handler future dropped mid-`clear` would leave the gid marked `clearing` with aria2 already told to stop, and nothing left to lift the mark.
- **The indicator signal is named per row *and* per slot** (`pausing<gid>`, `removing<gid>`). `data-indicator` counts only requests raised by its own element, so a single shared name would have a press on one row spinning a button on another. Same reason `#picker` and the mkdir button already carry their own.
- **`add` stays detached** past the `addUri`. The mutation — registering the magnet — is held open and bounded like the rest; what follows is a magnet resolve with a 600s ceiling, which is a download lifecycle rather than a request anyone is waiting on. Holding it was the production `NS_BINDING_ABORTED` that `finish_add` exists to avoid.
- **The `clearing` mark stays server-side** even though the request is now held. It is what every *other* open page reads, and what renders this row during the wait.

## Verifying

`cargo test` in `apps/mariastew` — 166 pass. The ones that matter here:

- `stopping_a_running_download_does_not_wait_for_the_swarm` — asserts `forceRemove` and the absence of the graceful call
- `a_removal_keeps_asking_until_aria2_has_actually_let_go` — aria2 has let go by the time the response returns, no waiting on a detached task
- `a_removal_aria2_refuses_answers_with_an_error_and_hands_the_row_back` — 502 rather than 204, mark lifted
- `the_row_is_marked_clearing_while_the_removal_is_still_in_flight` — the press is visible to every other page for the whole request
- `each_control_spins_for_its_own_request` — indicator and disable, per slot, across finished/unfinished/paused rows
- `a_finished_row_offers_clear_and_an_unfinished_one_offers_the_destructive_button`, `state_complete`, `the_word_the_log_uses_for_a_state_is_the_word_the_badge_uses`

Version bumped to 0.1.20, which is what cuts the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTDnRyQuuu68n51UofQrYs