### PR TITLE
359 fix(mariastew): a restore that reads the torrent, and finishes the add

### DIFF
--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.22] - 2026-08-08
+
+### Fixed
+
+- A restored download resumes from the torrent on disk rather than asking the swarm for metadata it already has, so a deploy no longer leaves rows on "finding peers" over data that is already complete ([#359](https://github.com/radiosilence/jaritanet/issues/359))
+- An add interrupted by a restart is picked up and finished on startup. It came back paused — that is how aria2 serialises one — with nothing left to start it or to narrow it to the files worth keeping ([#359](https://github.com/radiosilence/jaritanet/issues/359))
+- An add no longer loses the race with its own pause. aria2 refuses to unpause a group until it has finished stopping, and a single attempt left the download stopped for good ([#359](https://github.com/radiosilence/jaritanet/issues/359))
+
 ## [0.1.21] - 2026-08-08
 
 ### Changed

--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A restored download resumes from the torrent on disk rather than asking the swarm for metadata it already has, so a deploy no longer leaves rows on "finding peers" over data that is already complete ([#359](https://github.com/radiosilence/jaritanet/issues/359))
 - An add interrupted by a restart is picked up and finished on startup. It came back paused — that is how aria2 serialises one — with nothing left to start it or to narrow it to the files worth keeping ([#359](https://github.com/radiosilence/jaritanet/issues/359))
 - An add no longer loses the race with its own pause. aria2 refuses to unpause a group until it has finished stopping, and a single attempt left the download stopped for good ([#359](https://github.com/radiosilence/jaritanet/issues/359))
+- A restored torrent being re-hashed says "checking files" rather than "downloaded". aria2 counts every piece as complete before it starts checking them, so the state that answered first was the wrong one for the longest wait a deploy has ([#359](https://github.com/radiosilence/jaritanet/issues/359))
+- The bar and the bytes beside it follow the hash check while one runs, rather than sitting at whatever the download reached ([#359](https://github.com/radiosilence/jaritanet/issues/359))
 
 ## [0.1.21] - 2026-08-08
 

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -325,8 +325,48 @@ A magnet added through `addUri` is saved as the magnet, and the options changed
 on the resolved download go with it — aria2 serialises whatever is set on the
 group — so a restored torrent keeps the `dir` it was heading for and the
 `select-file` the filter narrowed it to, rather than starting over and pulling
-down the scene garbage that was deselected. Restoring re-fetches metadata from
-the infohash, which is what the persisted DHT table now makes quick.
+down the scene garbage that was deselected.
+
+### Restoring the magnet is not restoring the torrent
+
+What the session holds is the magnet, so restoring one used to hand the
+infohash back to the swarm and wait — for metadata already held, to resume
+bytes already on the disk. A well-seeded torrent answered in seconds and a
+sparse one never did, which is a resume whose reliability is a property of
+other people. The failure looked like nothing at all: the row said "finding
+peers" over a finished download and kept saying it.
+
+`--bt-save-metadata` writes the resolved torrent out, and
+`--bt-load-saved-metadata` reads it back before asking anyone, so a restart is
+a disk read rather than a negotiation — restoring with the network unplugged
+loads the metadata and finishes verification in two seconds. aria2 names the
+file `<infohash>.torrent` and puts it beside the data, with no option to put it
+elsewhere, so ~60KB per torrent sits in the library next to what it describes.
+`notify::sweep_garbage` walks a download's own entries and never a sibling, so
+it survives to be read.
+
+Anything added before this existed has no saved torrent and falls back to the
+swarm, which is the old behaviour rather than a new failure.
+
+### An add is two steps, and a restart can land between them
+
+`routes::finish_add` runs detached from the request that started it: aria2
+resolves the metadata, and this waits for the download that comes out of it,
+narrows it to the files worth keeping, and starts it. A pod replaced inside
+that gap loses the second step alone — aria2's session restores the first.
+
+What came back was worse than nothing. The narrowing happens under a pause,
+aria2 serialises `pause=true` alongside the magnet, and a restored paused
+magnet does not even ask for metadata. The download sat there permanently,
+with the selection never applied and nothing left that would ever apply it.
+
+`resume` adopts them. A metadata download still in aria2's queues when this
+process starts is by definition an add nobody is finishing — a resolved
+magnet's own gid moves to the stopped list, which the download list already
+sweeps — so each one is released and run through the same finish the request
+would have. Only at startup: a metadata row on screen carries a pause button
+like any other, and overruling someone who pressed it a second ago is a
+different bug.
 
 Nothing the interface cleared comes back. `routes::clear` follows `remove` with
 `removeDownloadResult` and keeps asking until the gid is gone from every list

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -379,6 +379,21 @@ already on disk for each restored row, on a mechanical disk, on every deploy —
 the price of never trusting bytes nobody verified, and the reason to press
 **Done** on rows that are finished with rather than leaving them in the list.
 
+### Saying so while it happens
+
+That read is the longest wait a deploy has, and the row used to report it as
+`downloaded` with a full still bar. aria2 counts every piece in the control
+file as complete *before* it starts hashing them, so `completedLength` is
+already final for the whole check and only `verifiedLength` moves — sampled on
+a real restore, 57MB to 762MB in 1.4s on an SSD, and minutes on the disks this
+runs on.
+
+So `Health::Verifying` is decided ahead of completion rather than after it, and
+the bar is drawn from `verifiedLength` while a check is running. The row reads
+`checking files` with `230 MB of 754 MB` beside a bar that moves. Capped at the
+total, because aria2 hashes whole pieces and a selective torrent can verify
+past the size of the files it chose.
+
 ### Where it lives
 
 `statePath` (default `/var/lib/mariastew`) is a directory of its own on the

--- a/apps/mariastew/src/aria2.rs
+++ b/apps/mariastew/src/aria2.rs
@@ -256,12 +256,35 @@ impl Download {
             .unwrap_or((self.total_length, self.completed_length))
     }
 
+    /// What the bar is drawn from, and the bytes printed beside it.
+    ///
+    /// A hash check has progress of its own, and it is not the download's.
+    /// aria2 counts every piece in the control file as complete before it
+    /// starts hashing, so through the whole check `display_totals` reads full
+    /// for a restored seed and frozen for a restored partial, while
+    /// `verifiedLength` climbs from zero to the total — measured at the
+    /// poller's own rate on a real restore, 57MB to 762MB in 1.4s on an SSD,
+    /// and the same read is minutes on the disks this actually runs on. So a
+    /// bar tracking downloaded bytes is a bar that does not move for the one
+    /// wait it was most wanted for.
+    ///
+    /// Capped at the total: aria2 hashes whole pieces, so a selective torrent
+    /// can verify past the size of the files it chose, and a bar over 100% is
+    /// worse than one that saturates.
+    pub fn progress_totals(&self) -> (u64, u64) {
+        let (total, done) = self.display_totals();
+        match self.verified_length {
+            Some(verified) => (total, verified.min(total)),
+            None => (total, done),
+        }
+    }
+
     /// `None` until the magnet resolves, which a `<progress>` with no value
     /// renders as indeterminate. That is the honest rendering: with
     /// `total_length` at zero a percentage is a division by zero, and
     /// "resolving the magnet" is a different state from "downloading nothing".
     pub fn percent(&self) -> Option<f64> {
-        let (total, done) = self.display_totals();
+        let (total, done) = self.progress_totals();
         if total == 0 {
             return None;
         }
@@ -294,24 +317,29 @@ impl Download {
     pub fn health(&self) -> Health {
         // Status first: paused and errored are decisions made about the
         // download, not observations of its traffic, so they outrank
-        // whatever the speed and seeder counts happen to say. Completion
-        // comes next because a finished torrent still shows connections and
-        // zero speed while idling. Only after all of that does the question
-        // become "why is nothing moving", which is what the rest of the
-        // branches diagnose in order from most to least fixable locally.
+        // whatever the speed and seeder counts happen to say. Only after all
+        // of that does the question become "why is nothing moving", which is
+        // what the rest of the branches diagnose in order from most to least
+        // fixable locally.
         if self.status == Status::Error {
             Health::Errored
         } else if self.status == Status::Paused {
             Health::Paused
+        } else if self.verify_integrity_pending || self.verified_length.is_some() {
+            // Ahead of every traffic reading below, because a hash check runs
+            // at zero download speed with peers still connected, which those
+            // would diagnose as stalled — and ahead of `is_finished`, which
+            // otherwise answers for the case the check matters most in.
+            // aria2 counts every piece in the control file as complete before
+            // it starts hashing them, so a restored *seeding* torrent reads
+            // as fully downloaded for the entire check and said "downloaded"
+            // through the longest wait a deploy has: re-reading gigabytes off
+            // a mechanical disk.
+            Health::Verifying
         } else if self.is_finished() {
             Health::Complete
         } else if self.status == Status::Waiting {
             Health::Queued
-        } else if self.verify_integrity_pending || self.verified_length.is_some() {
-            // Ahead of every traffic reading below: a hash check runs at zero
-            // download speed with peers still connected, which the "why is
-            // nothing moving" branches would diagnose as stalled.
-            Health::Verifying
         } else if self.is_metadata() || self.total_length == 0 {
             Health::Resolving
         } else if self.download_speed > 0 {
@@ -770,6 +798,45 @@ mod tests {
         d.verified_length = None;
         d.verify_integrity_pending = true;
         assert_eq!(d.health(), Health::Verifying);
+    }
+
+    /// The case the check matters most in, and the one it used to answer for
+    /// last. aria2 counts every piece in the control file as complete before
+    /// it starts hashing them, so a restored seeding torrent reads as fully
+    /// downloaded for the whole check — and `is_finished` above said
+    /// "downloaded" through the longest wait a deploy has.
+    #[test]
+    fn health_verifying_outranks_a_completion_aria2_has_not_rechecked_yet() {
+        let mut d = download(Status::Active);
+        d.total_length = 100;
+        d.completed_length = 100;
+        d.verified_length = Some(30);
+        assert_eq!(d.health(), Health::Verifying);
+
+        d.verified_length = None;
+        assert_eq!(d.health(), Health::Complete);
+    }
+
+    /// The bar has to follow the check, because nothing else about the
+    /// download moves while one runs: the byte counters are already at their
+    /// final value and `verifiedLength` is the only thing climbing.
+    #[test]
+    fn the_bar_follows_the_hash_check_while_one_is_running() {
+        let mut d = download(Status::Active);
+        d.total_length = 100;
+        d.completed_length = 100;
+
+        d.verified_length = Some(30);
+        assert_eq!(d.progress_totals(), (100, 30));
+        assert_eq!(d.percent(), Some(30.0));
+
+        // aria2 hashes whole pieces, so a selective torrent can verify past
+        // the size of the files it chose. A saturated bar beats one at 140%.
+        d.verified_length = Some(140);
+        assert_eq!(d.progress_totals(), (100, 100));
+
+        d.verified_length = None;
+        assert_eq!(d.progress_totals(), (100, 100));
     }
 
     #[test]

--- a/apps/mariastew/src/main.rs
+++ b/apps/mariastew/src/main.rs
@@ -2,8 +2,9 @@
 //!
 //! A small service in front of aria2. aria2 does the downloading and holds all
 //! the state; this renders it and takes instructions. Nothing is persisted on
-//! this side, so there is no database, no reconciliation, and a restarted pod
-//! simply re-reads reality.
+//! this side, so there is no database and a restarted pod simply re-reads
+//! reality — except for the one thing aria2 cannot restore on its own, an add
+//! that was still in flight when the pod went away (see `resume`).
 
 mod activity;
 mod aria2;
@@ -13,6 +14,7 @@ mod error;
 mod filter;
 mod notify;
 mod poll;
+mod resume;
 mod routes;
 mod state;
 mod views;
@@ -82,9 +84,11 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // The poller before the watcher: the watcher reads its snapshots and would
-    // otherwise sit on an empty channel until the first tick anyway.
+    // otherwise sit on an empty channel until the first tick anyway. `resume`
+    // reads the same channel, and only its first snapshot.
     poll::spawn(state.clone());
     notify::spawn_watcher(state.clone());
+    resume::spawn(state.clone());
 
     // Only what is genuinely public sits outside the auth layer: the probe the
     // kubelet calls, the login round-trip that cannot require a session to

--- a/apps/mariastew/src/resume.rs
+++ b/apps/mariastew/src/resume.rs
@@ -1,0 +1,219 @@
+//! The adds a restart interrupted, picked up again.
+//!
+//! Adding a magnet is two steps with a gap in the middle: aria2 resolves the
+//! metadata, and `routes::finish_add` — detached from the request that asked
+//! for it — waits for the download that comes out of that, narrows it to the
+//! files worth keeping, and starts it. A pod replaced inside the gap loses the
+//! second step alone, because aria2's session restores the first.
+//!
+//! What comes back is worse than nothing. The narrowing is done under a pause,
+//! aria2 serialises `pause=true` alongside the magnet, and a restored paused
+//! magnet does not even ask for metadata — so the row says "finding peers"
+//! over data that may already be complete, and says it forever. That is the
+//! shape of "the queue came back but nothing in it moves".
+//!
+//! A metadata download still in aria2's active or waiting queues when this
+//! process starts is exactly one of those: an add with nobody finishing it.
+//! Nothing else leaves one there — once a magnet resolves, its own gid moves
+//! to the stopped list, which `routes::all_downloads` already sweeps. So they
+//! are adopted, once, and put through the same finish the request would have.
+//!
+//! Deliberately only at startup. A metadata row on screen carries a pause
+//! button like any other, so unpausing one on sight would be overruling
+//! someone who pressed it a second ago; one that was already paused before
+//! this process existed is not that.
+
+use crate::aria2::Status;
+use crate::routes::finish_add_inner;
+use crate::state::AppState;
+
+/// Whatever the first poll finds. Waiting on the poller rather than asking
+/// aria2 directly is also how this waits for the sidecar: only a successful
+/// sample is ever published, and aria2 loads its session before it answers RPC
+/// at all, so a first answer is a complete one.
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move {
+        let mut poll = state.poll.subscribe();
+        if poll.changed().await.is_err() {
+            return;
+        }
+        let downloads = poll.borrow_and_update().downloads.clone();
+        for d in downloads.iter().filter(|d| d.is_metadata()) {
+            tokio::spawn(adopt(
+                state.clone(),
+                d.gid.clone(),
+                d.dir.clone(),
+                d.status == Status::Paused,
+            ));
+        }
+    });
+}
+
+/// One interrupted add, carried the rest of the way.
+///
+/// The unpause comes first and is fatal to this attempt if it fails: the whole
+/// point is that a paused magnet fetches no metadata, so there is nothing for
+/// the finish below to wait for and it would only spend ten minutes proving
+/// it. `sub` is the audit field on the "starting download" line, and nobody
+/// asked for this one — the restart did.
+async fn adopt(state: AppState, gid: String, dir: String, paused: bool) {
+    tracing::info!(%gid, %dir, paused, "resume: finishing an add a restart interrupted");
+    state
+        .activity
+        .record(&gid, "picked up again after a restart");
+
+    if paused && let Err(e) = state.aria2.unpause(&gid).await {
+        tracing::error!(%gid, error = %e, "resume: could not restart a paused add");
+        state.activity.record(&gid, format!("failed — {e}"));
+        return;
+    }
+
+    if let Err(e) = finish_add_inner(&state, "restart", &dir, &gid).await {
+        tracing::error!(%gid, error = %e, "resume: could not finish an interrupted add");
+        state.activity.record(&gid, format!("failed — {e}"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use axum::extract::State as AxumState;
+    use axum::routing::post;
+    use axum::{Json, Router};
+
+    use super::*;
+    use crate::config::Config;
+
+    #[derive(Clone, Default)]
+    struct Calls {
+        unpaused: Arc<Mutex<Vec<String>>>,
+        selected: Arc<Mutex<Vec<String>>>,
+    }
+
+    /// A restored add exactly as aria2 hands one back: the magnet's own gid,
+    /// paused, in the waiting queue, with the download it resolved to already
+    /// attached. The child's file list is the one the filter has to see —
+    /// reading the metadata gid's own would find a single `[METADATA]` entry
+    /// and select by position (see `finish_add_inner`).
+    async fn mock_aria2(calls: Calls) -> String {
+        async fn rpc(
+            AxumState(calls): AxumState<Calls>,
+            Json(body): Json<serde_json::Value>,
+        ) -> Json<serde_json::Value> {
+            let gid = body["params"][0].as_str().unwrap_or_default().to_string();
+            let result = match body["method"].as_str().unwrap_or_default() {
+                "aria2.tellActive" | "aria2.tellStopped" => serde_json::json!([]),
+                "aria2.tellWaiting" => serde_json::json!([download(
+                    "metadata-gid",
+                    "paused",
+                    serde_json::json!([{"index": "1", "path": "[METADATA]Show.S01", "length": "0", "selected": "true"}]),
+                )]),
+                "aria2.tellStatus" if gid == "child-gid" => download(
+                    "child-gid",
+                    "active",
+                    serde_json::json!([
+                        {"index": "1", "path": "/tv/Show.S01/poster.jpg", "length": "10", "selected": "true"},
+                        {"index": "2", "path": "/tv/Show.S01/ep01.mkv", "length": "90", "selected": "true"},
+                    ]),
+                ),
+                "aria2.tellStatus" => {
+                    let mut d = download("metadata-gid", "complete", serde_json::json!([]));
+                    d["followedBy"] = serde_json::json!(["child-gid"]);
+                    d
+                }
+                "aria2.unpause" => {
+                    calls.unpaused.lock().unwrap().push(gid.clone());
+                    serde_json::json!(gid)
+                }
+                "aria2.pause" => serde_json::json!(gid),
+                "aria2.changeOption" => {
+                    if let Some(files) = body["params"][1]["select-file"].as_str() {
+                        calls.selected.lock().unwrap().push(files.to_string());
+                    }
+                    serde_json::json!("OK")
+                }
+                other => panic!("unexpected aria2 method in test: {other}"),
+            };
+            Json(serde_json::json!({"jsonrpc": "2.0", "id": "mariastew", "result": result}))
+        }
+
+        fn download(gid: &str, status: &str, files: serde_json::Value) -> serde_json::Value {
+            serde_json::json!({
+                "gid": gid,
+                "status": status,
+                "totalLength": "100",
+                "completedLength": "0",
+                "downloadSpeed": "0",
+                "uploadSpeed": "0",
+                "connections": "0",
+                "dir": "/tv",
+                "files": files,
+            })
+        }
+
+        let app = Router::new().route("/", post(rpc)).with_state(calls);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        format!("http://{addr}/")
+    }
+
+    /// The whole bug, end to end: a deploy that lands mid-add leaves a paused
+    /// magnet in the session, and nothing in aria2 will ever start it again.
+    /// Adopting it has to both release the pause and apply the selection the
+    /// interrupted add never got to — coming back downloading everything is a
+    /// different failure, not a fix.
+    #[tokio::test]
+    async fn a_paused_add_left_by_a_restart_is_released_and_narrowed() {
+        let calls = Calls::default();
+        let url = mock_aria2(calls.clone()).await;
+        let http = reqwest::Client::new();
+        let state = AppState {
+            config: Arc::new(Config {
+                aria2_rpc_url: url.clone(),
+                // The poller samples on the idle schedule with nobody
+                // watching, and this test is the nobody.
+                idle_poll_interval: Duration::from_millis(10),
+                ..Config::fixture()
+            }),
+            aria2: crate::aria2::Aria2::new(url, http.clone()),
+            sessions: crate::auth::session::Sessions::new(),
+            poll: crate::poll::Poll::new(),
+            activity: crate::activity::Activity::new(),
+            clearing: crate::state::Clearing::default(),
+            http,
+        };
+
+        crate::poll::spawn(state.clone());
+        spawn(state.clone());
+
+        for _ in 0..200 {
+            if !calls.selected.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            *calls.unpaused.lock().unwrap(),
+            ["metadata-gid", "child-gid"],
+            "the restored magnet has to be released before it fetches anything, \
+             and the download it resolves to released again after being narrowed"
+        );
+        assert_eq!(
+            *calls.selected.lock().unwrap(),
+            ["2"],
+            "the poster is what the filter exists to leave behind"
+        );
+        assert!(
+            state
+                .activity
+                .entries("child-gid")
+                .iter()
+                .any(|e| e.message.contains("picked up again after a restart")),
+            "the row has to say why it moved on its own"
+        );
+    }
+}

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -424,7 +424,7 @@ const RESOLVE_TIMEOUT: Duration = Duration::from_secs(600);
 /// (see `add` for why it had to go — it also stops `followedBy` from ever
 /// appearing), the child starts downloading everything the instant it
 /// exists. That is what the pause/change/unpause sequence below is for.
-async fn finish_add_inner(
+pub(crate) async fn finish_add_inner(
     state: &AppState,
     sub: &str,
     dir: &str,
@@ -530,11 +530,38 @@ async fn finish_add_inner(
         .await?;
 
     if paused {
-        state.aria2.unpause(&child_gid).await?;
+        unpause_settled(state, &child_gid).await?;
     }
     state.activity.record(&child_gid, "downloading");
 
     Ok(())
+}
+
+/// How long to keep offering aria2 the chance to accept the unpause above.
+/// Generous, because the only thing waiting on it is a download that is
+/// already stopped, and giving up early is the failure this bounds.
+const UNPAUSE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Undoes the pause above, allowing for aria2 not being ready to yet.
+///
+/// A pause is a request rather than an act: the group keeps running until it
+/// has closed what it had open, and until it reaches the reserved queue aria2
+/// answers `GID#… cannot be unpaused now`. The pause a few lines up is what
+/// puts it in that window, so the two race on every add — reproducibly, on a
+/// real swarm — and losing costs the entire download: a paused group with no
+/// task left to start it sits there with nothing to say why.
+async fn unpause_settled(state: &AppState, gid: &str) -> AppResult<()> {
+    let deadline = tokio::time::Instant::now() + UNPAUSE_TIMEOUT;
+    loop {
+        match state.aria2.unpause(gid).await {
+            Ok(()) => return Ok(()),
+            Err(e) if tokio::time::Instant::now() >= deadline => return Err(e),
+            Err(e) => {
+                tracing::debug!(%gid, error = %e, "add: aria2 will not unpause yet, retrying");
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+        }
+    }
 }
 
 pub async fn pause(State(state): State<AppState>, Path(gid): Path<String>) -> AppResult<Response> {
@@ -1054,6 +1081,10 @@ mod tests {
             /// Lets a test exercise the case where the child will not pause —
             /// `finish_add_inner` treats that as tolerable and best-effort.
             pause_should_succeed: bool,
+            /// How many `unpause` calls are refused before one is accepted,
+            /// standing in for the window a real pause takes to settle. See
+            /// [`unpause_settled`].
+            unpause_refusals: Arc<Mutex<u32>>,
         }
 
         fn download_result(gid: &str, status: &str, files: serde_json::Value) -> serde_json::Value {
@@ -1096,7 +1127,18 @@ mod tests {
                         serde_json::json!({"error": {"code": 1, "message": "not pausable"}})
                     }
                 }
-                "aria2.unpause" => serde_json::json!({"result": "OK"}),
+                "aria2.unpause" => {
+                    let mut refusals = mock.unpause_refusals.lock().unwrap();
+                    if *refusals > 0 {
+                        *refusals -= 1;
+                        serde_json::json!({"error": {
+                            "code": 1,
+                            "message": "GID#child-gid cannot be unpaused now",
+                        }})
+                    } else {
+                        serde_json::json!({"result": "OK"})
+                    }
+                }
                 "aria2.tellStatus" => {
                     let gid = body["params"][0].as_str().unwrap_or_default();
                     match (&mock.metadata_outcome, gid) {
@@ -1144,13 +1186,17 @@ mod tests {
             metadata_add_result: serde_json::Value,
             metadata_outcome: MetadataOutcome,
         ) -> Mock {
-            mock_server_with_pause(metadata_add_result, metadata_outcome, true).await
+            mock_server_with(metadata_add_result, metadata_outcome, true, 0).await
         }
 
-        async fn mock_server_with_pause(
+        /// The two ways aria2 declines to be driven across the metadata
+        /// boundary: a group it will not pause, and one it will not unpause
+        /// *yet*.
+        async fn mock_server_with(
             metadata_add_result: serde_json::Value,
             metadata_outcome: MetadataOutcome,
             pause_should_succeed: bool,
+            unpause_refusals: u32,
         ) -> Mock {
             let calls = Arc::new(Mutex::new(Vec::new()));
             let change_option_calls = Arc::new(Mutex::new(Vec::new()));
@@ -1160,6 +1206,7 @@ mod tests {
                 metadata_add_result: Arc::new(metadata_add_result),
                 metadata_outcome,
                 pause_should_succeed,
+                unpause_refusals: Arc::new(Mutex::new(unpause_refusals)),
             };
             let app = axum::Router::new().route("/", post(rpc)).with_state(mock);
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1354,13 +1401,14 @@ mod tests {
             let child_files = serde_json::json!([
                 {"index": "1", "path": "/mnt/kontent/movies/movie.mkv", "length": "100", "selected": "true"},
             ]);
-            let mock = mock_server_with_pause(
+            let mock = mock_server_with(
                 serde_json::json!({"result": "metadata-gid"}),
                 MetadataOutcome::ResolvesWithChild {
                     child_gid: "child-gid".to_string(),
                     child_files,
                 },
                 false,
+                0,
             )
             .await;
             let state = test_state(mock.url);
@@ -1378,6 +1426,43 @@ mod tests {
                     "aria2.changeOption",
                 ],
                 "a failed pause must not be followed by an unpause"
+            );
+        }
+
+        /// A pause that *did* take is the dangerous one. aria2 refuses to
+        /// unpause a group until it has finished stopping, and the pause four
+        /// lines earlier is what puts it in that state — so a single attempt
+        /// loses a race it started, and the download is left stopped with
+        /// nothing to start it again. Asking once more is the whole fix.
+        #[tokio::test]
+        async fn an_unpause_aria2_is_not_ready_for_is_asked_again() {
+            let child_files = serde_json::json!([
+                {"index": "1", "path": "/mnt/kontent/movies/movie.mkv", "length": "100", "selected": "true"},
+            ]);
+            let mock = mock_server_with(
+                serde_json::json!({"result": "metadata-gid"}),
+                MetadataOutcome::ResolvesWithChild {
+                    child_gid: "child-gid".to_string(),
+                    child_files,
+                },
+                true,
+                2,
+            )
+            .await;
+            let state = test_state(mock.url);
+
+            add(State(state), CurrentSession(session()), Form(add_form())).await;
+
+            wait_for_calls(&mock.calls, 8).await;
+            assert_eq!(
+                mock.calls
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter(|m| *m == "aria2.unpause")
+                    .count(),
+                3,
+                "the add gave up on its own pause"
             );
         }
 

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -156,7 +156,10 @@ impl Row {
         } else {
             bar_class_and_state(health)
         };
-        let (size, done) = d.display_totals();
+        // The bar's own numbers, so "230 MB of 754 MB" beside a bar at 30%
+        // is the hash check's progress and not two readings of different
+        // things — see `progress_totals`.
+        let (size, done) = d.progress_totals();
 
         let (skipped_count, skipped_bytes) = d
             .files
@@ -177,7 +180,7 @@ impl Row {
             state,
             down: rate(d.download_speed),
             up: rate(d.upload_speed),
-            // The same totals the bar is drawn from — see `display_totals`.
+            // The same totals the bar is drawn from — see `progress_totals`.
             size: bytes(size),
             done: bytes(done),
             eta: d.eta_secs().map(duration),

--- a/packages/mariastew/src/mariastew.ts
+++ b/packages/mariastew/src/mariastew.ts
@@ -279,6 +279,28 @@ export function createMariastew(
                   // the gid is gone from every list aria2 keeps, and a result
                   // aria2 no longer holds is not one it can save.
                   "--force-save=true",
+                  // What the session records is the *magnet*, not the torrent
+                  // it resolved to, so a restore handed the infohash back to
+                  // the swarm and waited — for metadata already held, to
+                  // resume bytes already on the disk. A swarm that answered
+                  // slowly made every deploy slow and one that never answered
+                  // left the row on "finding peers" over a finished download,
+                  // indefinitely, which reads as the queue having been lost
+                  // rather than stopped.
+                  //
+                  // These write the resolved torrent out and read it back
+                  // before asking anyone, so a restart is a disk read rather
+                  // than a negotiation. Restoring with the network unplugged
+                  // loads the metadata and finishes verification in two
+                  // seconds, which is the property being bought.
+                  //
+                  // aria2 names the file `<infohash>.torrent` and puts it
+                  // beside the data, with no option to put it anywhere else,
+                  // so ~60KB per torrent lands in the library next to what it
+                  // describes. `notify::sweep_garbage` walks a download's own
+                  // entries and never a sibling, so it survives to be read.
+                  "--bt-save-metadata=true",
+                  "--bt-load-saved-metadata=true",
                   // Nothing is preallocated, so a file the metadata pass chose
                   // not to download never appears on disk at all — which is
                   // what makes downloading straight into the library safe.


### PR DESCRIPTION
Closes #359.

Resuming after a pod restart failed two different ways, and both end in a row that sits there saying "finding peers" over a download that is already on the disk. A third fault meant that even when the restore worked, the row would not say what it was doing.

## The session holds the magnet, not the torrent

aria2 serialises a magnet-added download as **the magnet URI** — confirmed in `SessionSerializer.cc`, where a group with a `followedBy` is skipped and the download it produced is written out under its parent's metadata info. So a restore handed the infohash back to the swarm and waited: for metadata already held, to resume bytes already written. A well-seeded torrent answered in seconds; a sparse one never did. Whether the queue came back was a property of other people.

`--bt-save-metadata` writes the resolved torrent out and `--bt-load-saved-metadata` reads it back before asking anyone.

The cost: aria2 names the file `<infohash>.torrent`, puts it beside the data, and has no option to put it anywhere else — so ~60KB per torrent sits in the library next to what it describes. Verified `notify::sweep_garbage` walks a download's own entries and never a sibling, so it survives to be read. Torrents added before this have no saved metadata and fall back to the swarm, which is the old behaviour rather than a new failure.

## An add is two steps, and a restart can land between them

`finish_add` runs detached from the request: aria2 resolves the metadata, then this waits for the download that comes out of it, narrows it to the files worth keeping under a pause, and starts it. A pod replaced inside that gap loses the second step alone.

What came back was worse than nothing — aria2 writes `pause=true` into the session, and a restored **paused** magnet does not even ask for metadata. The download sat there permanently, with the selection never applied and nothing left that would ever apply it.

`resume` adopts them. A metadata download still in aria2's queues when the process starts is by definition an add nobody is finishing — a resolved magnet's own gid moves to the stopped list, which `all_downloads` already sweeps. Startup only: a metadata row carries a pause button like any other, and overruling someone who pressed it a second ago is a different bug.

## The add could also lose the race with its own pause

A pause is a request, not an act — aria2 answers `GID#… cannot be unpaused now` until the group has finished stopping, and the pause two calls earlier is what puts it there. One attempt was not enough, and losing meant the download stayed stopped for good. Hit reproducibly against a real swarm while diagnosing the above; fixed here because the adoption path depends on it.

## And the row would not say it was checking

A restored torrent is re-hashed on the way back in, and on the disks this runs on that read *is* the deploy. The row reported it as `downloaded` behind a full, still bar.

Sampled at the poller's own rate on a real restore:

```
t     status   verifiedLength   completedLength   file.completedLength
0.0   active         57671680         791674880             791674880
0.5   active        273940480         791674880             791674880
1.4   active        762052608         791674880             791674880
1.6   active             None         791674880             791674880
```

aria2 counts every piece in the control file as complete *before* it starts hashing them, so `completedLength` is already final for the whole check and `verifiedLength` is the only thing moving. Two consequences, both fixed:

- `is_finished` was tested ahead of `Verifying`, so the state answered "downloaded" for exactly the case the check matters most in. `Verifying` now outranks completion.
- the bar was drawn from downloaded bytes, so it did not move at all during a check. It and the bytes beside it now come from `verifiedLength` while one runs — `230 MB of 754 MB` beside a bar that moves — capped at the total, since aria2 hashes whole pieces and a selective torrent can verify past what it chose.

## How this was verified

A real aria2 1.37 (the version the image ships) against the Debian netinst magnet, driven through the exact `addUri` → `followedBy` → `pause`/`changeOption`/`unpause` sequence `finish_add_inner` uses:

- the serialised session is the magnet plus `dir`/`select-file`, as described above
- killing aria2 with the child paused restores it **paused, in the waiting queue, `[METADATA]…`, at 0 bytes, indefinitely** — the reported symptom, with 754MB sitting next to it
- with the two new flags and **the container's network removed entirely**, a restart logs `BitTorrent metadata was loaded from /dl/<infohash>.torrent` and `Verification finished successfully` within two seconds
- `--bt-save-metadata` writes to the download group's `dir`, not the global `--dir` — tested both ways, which is why the file lands in the library and this says so rather than pretending otherwise
- the verification table above is `tellActive` sampled every 100ms across a restore

## What to look at

- `apps/mariastew/src/resume.rs` — new, with an end-to-end test that a paused restored add is released *and* narrowed (coming back downloading everything would be a different failure, not a fix)
- `routes::unpause_settled` — the retry, with a test that refuses twice and asserts the add did not give up
- `aria2::health` / `aria2::progress_totals` — the ordering change and the bar, each with a test
- `packages/mariastew/src/mariastew.ts` — the two flags

`cargo test` 171 passed, `cargo clippy` clean, `mise run check` green.

Merged `main` (#363) — both sides had bumped to `0.1.22` and that tag is already cut, so this is `0.1.23` and main's `0.1.22` changelog section stands as released.

## Not in this PR

`--pause-metadata=true` would have aria2 create the followed download already paused, which removes the pause/unpause dance from the add path entirely rather than making it resilient. That is a change to how every add works, so it is #362.