### PR TITLE
340 feat(mariastew): typecheck and bundle the browser script (#357)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
     paths:
       - .github/workflows/ci.yml
       - "packages/**"
+      # Apps hold their own build tooling (aube-workspace.yaml), so this is
+      # where mariastew's own tsconfig/lint/fmt actually get checked.
+      - "apps/**"
       - "*.config.*"
       - package.json
   workflow_call:

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -16,8 +16,8 @@
     "**/*.yml",
     "**/*.yaml",
     "**/*.toml",
-    "apps/*/assets/datastar.js",
     "apps/*/assets/*.css",
+    "apps/*/assets/*.js",
     "apps/*/target",
     "apps/*/templates"
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -32,8 +32,8 @@
   "ignorePatterns": [
     "schemas/**",
     "node_modules/**",
-    "apps/*/assets/datastar.js",
     "apps/*/assets/*.css",
+    "apps/*/assets/*.js",
     "apps/*/target/**"
   ]
 }

--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.22] - 2026-08-08
+
+### Added
+
+- `web/app.ts` is now typechecked and bundled with rolldown into a content-hashed `assets/app-<hash>.js`, so a deploy's new script can no longer be served from a browser cache still holding the old one ([#340](https://github.com/radiosilence/jaritanet/issues/340))
+- `mise run mariastew:icons` adds a macro to `templates/icons.html` for any `icons::<name>` a template calls that isn't defined yet, sourced from the `lucide-static` package ([#357](https://github.com/radiosilence/jaritanet/issues/357))
+
 ## [0.1.21] - 2026-08-08
 
 ### Changed

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -15,14 +15,15 @@ Datastar evaluates a `data-on:*` attribute as a function body, so an attribute
 will hold anything JavaScript can express — which is how a click handler becomes
 a program written in HTML. Signal writes and one `@action` stay in the
 attribute, where they read as markup; anything with control flow in it is a
-helper on `ms` in `assets/app.js`, and the attribute calls it. Elements are
+helper on `ms` in `web/app.ts`, and the attribute calls it. Elements are
 reached through `data-ref` rather than `document.getElementById`, so a template
 holds one definition of what an id is.
 
-That boundary is a lint boundary, not a taste one. `assets/app.js` is the only
-file under `assets/` that oxlint and oxfmt see (the stylesheet and the vendored
-bundle are build outputs and ignored by name), and JavaScript written inside an
-attribute is seen by nothing at all until a browser runs it.
+That boundary is a lint and typecheck boundary, not a taste one. `web/app.ts`
+is source; `assets/app.js` is its compiled, committed output (see "Rebuilding
+the browser script" below) and, like the stylesheet and the vendored bundle, is
+a build artefact oxlint, oxfmt and `tsc` all ignore by name. JavaScript written
+inside an attribute is seen by nothing at all until a browser runs it.
 
 Nothing checks the two halves against each other at build time, so a test does:
 `every_ms_helper_a_template_calls_is_defined` renders the page, collects every
@@ -678,7 +679,7 @@ device's emoji font at its own weight, colour and baseline rather than the
 text's, and `⌂` is missing from enough fonts to have arrived as a tofu box on
 the one control that had nothing else in it.
 
-Nothing is fetched or generated — they weigh less than the request that would
+Nothing is fetched at runtime — they weigh less than the request that would
 fetch them, and there is no JavaScript on this page to draw them with.
 The shared presentation attributes live on `.icon` in `styles/app.css`, sized
 in `em` so an icon is the size of the text it sits beside; a macro takes a
@@ -690,15 +691,27 @@ arriving through a different door. `.disclosure` takes it off and turns the
 chevron inside instead; a disclosure written later gets that by using the same
 two class names.
 
-Adding one: take the shapes from
-`https://unpkg.com/lucide-static/icons/<name>.svg` into a new macro — the
-`<path>`/`<polyline>`/`<circle>` children and nothing else, since everything
-on the `<svg>` itself is on `.icon` already — then
-rebuild the stylesheet if the call site introduced a class. Every icon names
-itself with `data-icon`, which is what tests assert on — a count of `<svg>`s
-only says the number changed, which every new call site does.
-`views::tests::nothing_is_drawn_with_a_unicode_glyph` fails the build if a
-character is used instead.
+Adding one: call `icons::<name>(class="")` from a template, run
+
+```sh
+mise run mariastew:icons
+```
+
+and it adds a macro for any name a template calls that `icons.html` doesn't
+define yet, sourced from `lucide-static`'s `<name>.svg` (kebab-cased) —
+the `<path>`/`<polyline>`/`<circle>` children and nothing else, since
+everything on the `<svg>` itself is on `.icon` already. It never touches a
+macro that already exists: `trash`'s shape is actually `trash-2.svg`'s under
+a plainer name, and nothing records that on purpose, so a name-guessed
+overwrite would have silently dropped two of its paths. It warns instead, if
+an existing macro's content no longer matches its name-guessed source — worth
+a look, not necessarily wrong. Rebuild the stylesheet too if the call site
+introduced a class.
+
+Every icon names itself with `data-icon`, which is what tests assert on — a
+count of `<svg>`s only says the number changed, which every new call site
+does. `views::tests::nothing_is_drawn_with_a_unicode_glyph` fails the build if
+a character is used instead.
 
 ## Rebuilding the stylesheet
 
@@ -714,3 +727,24 @@ This runs `tailwindcss` from `apps/mariastew/node_modules/.bin` (the app's
 own devDependencies — `package.json` here declares `@jaritanet/mariastew-styles`,
 separate from the Rust crate) against `styles/app.css`, minified, into
 `assets/app.css`.
+
+## Rebuilding the browser script
+
+Same deal as the stylesheet: `web/app.ts` is source, `assets/app.js` is the
+committed output, and only editing the source needs Node:
+
+```sh
+mise run js
+```
+
+This runs `tsc` from `apps/mariastew/node_modules/.bin` against
+`tsconfig.web.json` — a browser config (DOM lib, real emit), which is what
+`mise run typecheck` picks up. It does not extend the monorepo root:
+mariastew is slated to move to its own repo (#299), and a path two
+directories up is one more thing to unpick when it does.
+
+There is no bundler. `app.ts` imports nothing, so there is no module graph to
+build — and the one thing worth bundling in, Datastar, cannot come from npm at
+the version this app runs (`@starfederation/datastar` publishes a
+`1.0.0-beta`, against the v1.0.2 release vendored at `assets/datastar.js`), so
+it stays a `<script>` tag rather than an import.

--- a/apps/mariastew/assets/app-BDRw_qHx.js
+++ b/apps/mariastew/assets/app-BDRw_qHx.js
@@ -1,0 +1,101 @@
+//#region web/app.ts
+/**
+* The behaviours that do not belong in an attribute.
+*
+* Datastar evaluates `data-on:*` as a function body, so an attribute holds
+* anything JavaScript can express — which is how a click handler becomes a
+* program written in HTML, invisible to oxlint and oxfmt and unreadable at the
+* width a template gives it. Signal work and one `@action` stay inline, where
+* they read as markup; everything with control flow in it lives here.
+*
+* A global rather than an export, because a Datastar expression sees only
+* globals, `el`, `evt` and the signals.
+*/
+globalThis.ms = {
+	/**
+	* Put the clipboard into a field, from that field's own Paste button.
+	*
+	* `readText()` is gated on transient user activation everywhere and, on iOS,
+	* on a Paste bubble Safari draws itself and no page can suppress. That gate
+	* is why this hangs off a button beside the field rather than the tap that
+	* opens the sheet: Safari anchors its bubble to the touch that asked, so
+	* asking from the header put a Paste button at the top of the screen for a
+	* field at the bottom of it, and asked on every open whether or not there
+	* was anything anyone wanted pasted (#353).
+	*
+	* Whatever is on the clipboard goes in, magnet or not. Filtering to magnets
+	* made sense while the read was automatic, since nothing unasked-for should
+	* land in a field — but a button that answers an explicit tap by doing
+	* nothing reads as broken, where a wrong value is visible and `/add` says
+	* what is wrong with it.
+	*
+	* A refused prompt and a browser with no clipboard API are both no-ops
+	* rather than errors: either way there is a field to type into.
+	*/
+	pasteInto(field) {
+		navigator.clipboard?.readText().then((text) => {
+			field.value = text.trim();
+		}, () => {});
+	},
+	/**
+	* Wire Enter to a button that sits outside the field's own form.
+	*
+	* Both submit buttons here are pinned outside the form they submit, so there
+	* is no implicit submission to inherit and the keyboard's Go key did nothing
+	* at all — on a phone, at the moment the paste just happened. Clicking the
+	* real button keeps one definition of what it does.
+	*/
+	clickOnEnter(evt, button) {
+		if (evt.key !== "Enter") return;
+		evt.preventDefault();
+		button.click();
+	},
+	/**
+	* The listing to fetch for a click inside the picker, or null if it hit no
+	* folder — the empty space around the buttons, or the path line above them.
+	*
+	* One delegated handler serves the whole listing: a root with a hundred-plus
+	* children is one level of browsing, and a `@get` per row was that many
+	* expressions to compile on every morph and that many URLs inlined into the
+	* response. A path arriving as a plain attribute value is also never parsed
+	* as an expression, so a folder named with a quote cannot break out of it.
+	*/
+	browseUrl(evt) {
+		const dir = evt.target.closest("[data-dir]")?.dataset.dir;
+		return dir === void 0 ? null : `/browse?path=${encodeURIComponent(dir)}`;
+	}
+};
+/**
+* Publish how much of the viewport the on-screen keyboard is covering, as
+* `--keyboard-inset` on the root element.
+*
+* iOS Safari shrinks the visual viewport for its keyboard and leaves the
+* layout viewport alone. Fixed positioning resolves against the layout one, so
+* the bottom sheet opened underneath the keyboard and Safari scrolled the page
+* chasing the focused field — the invisible dialog and the stray vertical
+* scroll of #353, one cause. Nothing in CSS exposes the gap between the two
+* viewports; this is the only place it can be measured.
+*
+* `offsetTop` is part of it: the visual viewport also pans, and what is
+* covered is whatever sits below its bottom edge in layout coordinates.
+*
+* A browser that resizes its layout viewport for its own keyboard measures
+* zero here, which is the fallback in the stylesheet too, so it is left alone.
+* The guard is for the same reason `visualViewport` is read defensively
+* anywhere: it is absent in older WebViews, and a missing keyboard offset is a
+* sheet that behaves exactly as it did before this existed.
+*/
+const viewport = globalThis.visualViewport;
+if (viewport) {
+	let published = -1;
+	const publish = () => {
+		const covered = Math.round(Math.max(0, document.documentElement.clientHeight - viewport.height - viewport.offsetTop));
+		if (covered === published) return;
+		published = covered;
+		document.documentElement.style.setProperty("--keyboard-inset", `${covered}px`);
+	};
+	viewport.addEventListener("resize", publish);
+	viewport.addEventListener("scroll", publish);
+	publish();
+}
+//#endregion

--- a/apps/mariastew/build.rs
+++ b/apps/mariastew/build.rs
@@ -1,0 +1,32 @@
+//! Finds `assets/app-<hash>.js`, the output of `mise run js`, and hands its
+//! name to `main.rs` as `APP_JS_FILENAME` — `include_str!` needs a literal
+//! path, and rolldown decides the hash, so nothing in the Rust source can
+//! spell the filename itself.
+//!
+//! Exactly one match is the point: it is what catches a stale second file
+//! left by a `mise run js` that forgot to clean the last hash, same as it
+//! catches forgetting to run `mise run js` at all.
+
+use std::fs;
+
+fn main() {
+    println!("cargo:rerun-if-changed=assets");
+
+    let matches: Vec<_> = fs::read_dir("assets")
+        .expect("apps/mariastew/assets should exist")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("app-") && name.ends_with(".js"))
+        .collect();
+
+    let filename = match matches.as_slice() {
+        [one] => one,
+        [] => panic!("no assets/app-*.js found — run `mise run js` before building mariastew"),
+        many => panic!(
+            "found {} assets/app-*.js files ({many:?}) — `mise run js` should have removed the old hash before writing the new one",
+            many.len()
+        ),
+    };
+
+    println!("cargo:rustc-env=APP_JS_FILENAME={filename}");
+}

--- a/apps/mariastew/package.json
+++ b/apps/mariastew/package.json
@@ -5,6 +5,9 @@
   "devDependencies": {
     "@tailwindcss/cli": "4.3.3",
     "daisyui": "5.7.16",
-    "tailwindcss": "4.3.3"
+    "lucide-static": "1.30.0",
+    "rolldown": "1.2.3",
+    "tailwindcss": "4.3.3",
+    "typescript": "6.0.3"
   }
 }

--- a/apps/mariastew/scripts/gen-icons.ts
+++ b/apps/mariastew/scripts/gen-icons.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env -S node --experimental-strip-types
+
+/**
+ * Adds a macro to templates/icons.html for any `icons::<name>` a template
+ * calls that icons.html does not yet define, sourced from lucide-static by
+ * kebab-casing the name.
+ *
+ * Existing macros are never overwritten — only warned about if their content
+ * no longer matches the name-guessed lucide-static icon, since the guess is
+ * not always right. `trash`'s macro is actually `trash-2.svg`'s paths under
+ * the name `trash`, kept for the plainer icon it names; nothing records that
+ * on purpose, so regenerating it from the name would have silently dropped
+ * two paths from a shipped icon. A mismatch here means "look before
+ * touching this one", not "overwrite it".
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const templatesDir = join(root, "templates");
+const iconsPath = join(templatesDir, "icons.html");
+const lucideIconsDir = join(root, "node_modules/lucide-static/icons");
+
+const kebab = (name: string) => name.replaceAll("_", "-");
+
+function lucideInner(name: string): string | undefined {
+  let svg: string;
+  try {
+    svg = readFileSync(join(lucideIconsDir, `${kebab(name)}.svg`), "utf8");
+  } catch {
+    return undefined;
+  }
+  return svg
+    .slice(svg.indexOf(">", svg.indexOf("<svg")) + 1, svg.lastIndexOf("</svg>"))
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("")
+    .replaceAll(" />", "/>");
+}
+
+const referenced = new Set<string>();
+for (const file of readdirSync(templatesDir)) {
+  if (!file.endsWith(".html")) continue;
+  const text = readFileSync(join(templatesDir, file), "utf8");
+  for (const m of text.matchAll(/icons::([a-z_]+)\(/g)) referenced.add(m[1]);
+}
+
+const icons = readFileSync(iconsPath, "utf8");
+const macroRe =
+  /\{% macro (\w+)\(class="[^"]*"\) %\}<svg[^>]*>([\s\S]*?)<\/svg>\{% endmacro %\}/g;
+
+const defined = new Map<string, string>();
+for (const m of icons.matchAll(macroRe)) defined.set(m[1], m[2]);
+
+const stale: string[] = [];
+for (const [name, currentInner] of defined) {
+  const lucide = lucideInner(name);
+  if (lucide !== undefined && lucide !== currentInner) stale.push(name);
+}
+
+const missing = [...referenced].filter((name) => !defined.has(name));
+const additions = missing.map((name) => {
+  const inner = lucideInner(name);
+  if (inner === undefined) {
+    throw new Error(
+      `templates call icons::${name}(), but it has no macro and no lucide-static icon named "${kebab(name)}.svg" exists — add the macro by hand, or fix the name`,
+    );
+  }
+  return `\n{% macro ${name}(class="") %}<svg class="icon {{ class }}" data-icon="${kebab(name)}" viewBox="0 0 24 24" aria-hidden="true">${inner}</svg>{% endmacro %}\n`;
+});
+
+if (additions.length > 0) {
+  writeFileSync(iconsPath, `${icons.trimEnd()}\n${additions.join("")}`);
+  console.log(`added: ${missing.join(", ")}`);
+} else {
+  console.log("nothing missing");
+}
+
+if (stale.length > 0) {
+  console.warn(
+    `content differs from lucide-static's name-guessed source, not touched: ${stale.join(", ")} — check by hand before assuming this is just an upstream shape change`,
+  );
+}

--- a/apps/mariastew/src/main.rs
+++ b/apps/mariastew/src/main.rs
@@ -27,15 +27,23 @@ use axum::routing::get;
 use crate::config::Config;
 use crate::state::AppState;
 
+/// `build.rs` finds the one `assets/app-<hash>.js` rolldown wrote and hands
+/// its name over as an env var — the hash is how a deploy's new script stops
+/// being served from a browser cache still holding the old one, and it is not
+/// something the source can spell on its own since rolldown chooses it.
+/// `views::Page::app_js_path` renders the same constant into the `<script>`
+/// tag that requests it.
+pub const APP_JS_PATH: &str = concat!("/assets/", env!("APP_JS_FILENAME"));
+
 /// Served from the binary rather than a volume: the stylesheet and the vendored
 /// bundle are build outputs, so a mount would be a second thing to keep in step
 /// with the image, and `app.js` travels with them because it is the same thing
 /// to the browser.
 const ASSETS: [(&str, &str, &str); 3] = [
     (
-        "/assets/app.js",
+        APP_JS_PATH,
         "text/javascript; charset=utf-8",
-        include_str!("../assets/app.js"),
+        include_str!(concat!("../assets/", env!("APP_JS_FILENAME"))),
     ),
     (
         "/assets/datastar.js",

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -282,6 +282,13 @@ impl Page {
     fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
+
+    /// Same reasoning as `version`: fixed at compile time, so a method rather
+    /// than a field every construction site would have to repeat. See
+    /// `crate::APP_JS_PATH`, which this and the route it names both read.
+    fn app_js_path(&self) -> &'static str {
+        crate::APP_JS_PATH
+    }
 }
 
 /// The list on its own. Its root element carries the same id as the one in the
@@ -1357,7 +1364,7 @@ mod tests {
     /// side of it is otherwise silent until someone presses the button.
     #[test]
     fn every_ms_helper_a_template_calls_is_defined() {
-        const SCRIPT: &str = include_str!("../assets/app.js");
+        const SCRIPT: &str = include_str!(concat!("../assets/", env!("APP_JS_FILENAME")));
         let page = Page {
             roots: vec![],
             rows: vec![],

--- a/apps/mariastew/templates/icons.html
+++ b/apps/mariastew/templates/icons.html
@@ -18,9 +18,12 @@
      the number changed, which every future call site will do, while a name
      says whether the tick is still on the finished badge.
 
-     Adding one: take the `<path>` elements from
-     https://unpkg.com/lucide-static/icons/<name>.svg — nothing else from
-     that file is needed. #}
+     Adding one: call `icons::<name>()` from a template and run
+     `mise run mariastew:icons` — it adds a macro sourced from
+     `lucide-static`'s `<name>.svg` (kebab-cased), the `<path>` elements and
+     nothing else from that file. It never overwrites a macro that already
+     exists (see `scripts/gen-icons.ts`), so a shape that diverged from its
+     name on purpose, like `trash`'s, stays put. #}
 
 {% macro check(class="") %}<svg class="icon {{ class }}" data-icon="check" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>{% endmacro %}
 

--- a/apps/mariastew/templates/page.html
+++ b/apps/mariastew/templates/page.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="/assets/app.css">
 {# Before Datastar: both are modules, so they run in document order and `ms.*`
      is defined by the time an expression names one. #}
-<script type="module" src="/assets/app.js"></script>
+<script type="module" src="{{ self.app_js_path() }}"></script>
 <script type="module" src="/assets/datastar.js"></script>
 </head>
 {# `$addStatus` and `$addMessage` are the whole contract with the server for

--- a/apps/mariastew/tsconfig.web.json
+++ b/apps/mariastew/tsconfig.web.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [],
+    "noEmit": true
+  },
+  "include": ["web/**/*.ts"]
+}

--- a/apps/mariastew/web/app.ts
+++ b/apps/mariastew/web/app.ts
@@ -1,3 +1,11 @@
+declare global {
+  var ms: {
+    pasteInto(field: HTMLInputElement): void;
+    clickOnEnter(evt: KeyboardEvent, button: HTMLButtonElement): void;
+    browseUrl(evt: Event): string | null;
+  };
+}
+
 /**
  * The behaviours that do not belong in an attribute.
  *
@@ -65,7 +73,8 @@ globalThis.ms = {
    * as an expression, so a folder named with a quote cannot break out of it.
    */
   browseUrl(evt) {
-    const dir = evt.target.closest("[data-dir]")?.dataset.dir;
+    const dir = (evt.target as HTMLElement).closest<HTMLElement>("[data-dir]")
+      ?.dataset.dir;
     return dir === undefined ? null : `/browse?path=${encodeURIComponent(dir)}`;
   },
 };

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -54,9 +54,18 @@ importers:
       daisyui:
         specifier: 5.7.16
         version: 5.7.16
+      lucide-static:
+        specifier: 1.30.0
+        version: 1.30.0
+      rolldown:
+        specifier: 1.2.3
+        version: 1.2.3
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/auth:
     dependencies:
@@ -538,6 +547,9 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
   '@oxfmt/binding-android-arm-eabi@0.49.0':
     resolution: {integrity: sha512-HbifJ84prIh9+55CTPAU35JdRQrwg47y16cGerCC+iejSKOuHXYo2WDql6l7cQlzrYVtc3f4UWY+dBj2lRmOeA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -939,8 +951,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.1.5':
     resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -951,8 +975,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.1.5':
     resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -963,8 +999,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
     resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -977,8 +1026,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -991,8 +1054,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1005,8 +1082,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1022,8 +1112,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.1.5':
     resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1773,6 +1875,9 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
+  lucide-static@1.30.0:
+    resolution: {integrity: sha512-lgG5XTlCPG9OQABEVbhhvcG3N0T8SDFg8NFw34j71+VK8TSP6xMlfXLsuwXiHZvL+bDoA5J2gOebqRocl4WvTw==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2020,6 +2125,11 @@ packages:
 
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2666,6 +2776,8 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@oxc-project/types@0.143.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.49.0':
     optional: true
 
@@ -2949,37 +3061,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.5':
@@ -2992,7 +3140,13 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -3635,6 +3789,8 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
+  lucide-static@1.30.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3963,6 +4119,26 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   safer-buffer@2.1.2:
     optional: true

--- a/mise.toml
+++ b/mise.toml
@@ -35,7 +35,7 @@ run = "oxfmt --check"
 
 [tasks.typecheck]
 description = "Type check every package"
-run = 'for p in packages/*/tsconfig.json; do echo "→ $p" && tsc -p "$p" || exit 1; done'
+run = 'for p in packages/*/tsconfig.json apps/*/tsconfig*.json; do echo "→ $p" && tsc -p "$p" || exit 1; done'
 
 [tasks.test]
 description = "Run the test suite (vitest on Node — Pulumi needs Node's v8)"
@@ -61,6 +61,26 @@ dir = "apps/mariastew"
 run = "./node_modules/.bin/tailwindcss -i styles/app.css -o assets/app.css --minify"
 # The output is committed, so cargo build needs no node toolchain and the
 # container build has one artefact rather than two.
+
+[tasks."js"]
+description = "Rebuild mariastew's browser script after changing web/app.ts"
+dir = "apps/mariastew"
+# Typechecking is `mise run typecheck`'s job (tsconfig.web.json is noEmit);
+# this only bundles. app.ts still imports nothing, so rolldown has no module
+# graph to speak of here — it exists to fingerprint the output filename, so a
+# deploy's new script can't be served from a browser cache holding the old
+# one. Sequential: the old hash's file has to be gone before build.rs globs
+# for the new one, or it finds two and refuses to guess.
+run = [
+  "rm -f assets/app-*.js",
+  "./node_modules/.bin/rolldown web/app.ts --platform browser --format esm --dir assets --entryFileNames app-[hash].js",
+]
+# The output is committed, same deal as app.css.
+
+[tasks."mariastew:icons"]
+description = "Add a macro for any icons::<name> a template calls that templates/icons.html doesn't define yet"
+dir = "apps/mariastew"
+run = "./scripts/gen-icons.ts"
 
 [tasks."check:profiles"]
 description = "Validate every profile shape against the real sing-box binary (needs docker)"


### PR DESCRIPTION
## Summary

- `web/app.ts` replaces the hand-written `assets/app.js`: typechecked against a self-contained, DOM-only `tsconfig.web.json` (no reaching into the monorepo root — mariastew is slated to move to its own repo per #299), and bundled by rolldown into a content-hashed `assets/app-<hash>.js` so a deploy's new script can't be served from a browser cache still holding the old one.
- `build.rs` finds that hashed file at Rust compile time and hands its name to both the served route and the `<script>` tag via one shared constant (`APP_JS_PATH`), since `include_str!` needs a literal path and rolldown chooses the hash.
- `datastar.js` stays hand-vendored — npm's `@starfederation/datastar` is still only `1.0.0-beta.11` against the v1.0.2 actually running; pulling it in would be a real downgrade.
- Closes #357 too: `mise run mariastew:icons` adds a macro to `templates/icons.html` for any `icons::<name>` a template calls that isn't defined yet, sourced from the `lucide-static` package instead of hand-copying SVGs from a CDN. It never overwrites an existing macro — `trash`'s current shape is actually `trash-2.svg`'s under a plainer name, with nothing recording that on purpose, so blind regeneration would have silently dropped two of its paths. It warns on content drift instead of touching it.
- `ci.yml`'s `pull_request` path filter gains `apps/**` — it only watched `packages/**` before, so mariastew's own TS/lint surface (including this PR's own changes) would never actually run through `mise run lint`/`typecheck`/`fmt:check` in CI.
- Cargo.toml bumped to 0.1.22 with a changelog entry, matching this repo's convention of bumping alongside the PR that ships the change.

## Why not what the ticket originally said

#340 as filed explicitly said "no bundler" (app.ts has no imports, so no module graph to bundle). That call gets revisited here because deploy cache-busting needs *something* to fingerprint the output filename, and rolldown does that cleanly without touching how datastar is loaded — it still bundles nothing but app.ts itself.

## Test plan

- [x] `mise run check` (lint, fmt:check, typecheck, test) — all green
- [x] `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` in `apps/mariastew` — all green
- [x] Manually verified `mise run js` cleans the previous hash before rolldown writes the new one, and `build.rs` panics clearly on zero or multiple `assets/app-*.js` matches
- [x] Manually verified `mise run mariastew:icons` is a no-op today (nothing missing) and correctly regenerates a deleted macro byte-for-byte when tested against `house`
- [x] Manually verified it does *not* clobber `trash`/`magnet`, whose content diverges from their name-guessed lucide-static source — warns instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3BVRJU4tVFuZsr3Pp8CTf

Closes #340
Closes #357