### PR TITLE
362 fix(mariastew): let aria2 stop the download, and actually adopt the stranded ones

### DIFF
--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.24] - 2026-08-08
+
+### Fixed
+
+- An add interrupted by a restart is picked up again. 0.1.23 claimed this and did not do it: `--bt-load-saved-metadata` resolves a restored magnet off the disk before aria2 answers a single RPC, so it comes back named after its file rather than `[METADATA]…` and the rule that looked for one matched nothing. The two fixes cancelled each other out ([#362](https://github.com/radiosilence/jaritanet/issues/362))
+- An unfinished add is now recognised by what aria2 holds — paused, with no `select-file` — and reconciled continuously rather than once at startup, so a magnet that resolves long after boot is picked up too. A download somebody paused on purpose already carries a selection, and is left alone ([#362](https://github.com/radiosilence/jaritanet/issues/362))
+- An adopted add is narrowed in place when its metadata pass is already over, rather than waiting ten minutes for a `followedBy` that will never appear while the download runs unfiltered ([#362](https://github.com/radiosilence/jaritanet/issues/362))
+
+### Changed
+
+- aria2 creates the followed download stopped (`--pause-metadata`), so the filter's selection lands before any content is fetched. The add no longer pauses it — that raced with aria2's own stop, fetched the whole torrent meanwhile, and stranded the download outright if the process died in the window ([#362](https://github.com/radiosilence/jaritanet/issues/362))
+
 ## [0.1.23] - 2026-08-08
 
 ### Fixed

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -170,18 +170,27 @@ magnet resolves under its own gid first, `follow-torrent` spawns the real
 download from the resolved metadata, `filter::is_garbage` picks the indices
 worth keeping from *that* download's own file list — not the resolving gid's,
 which always has exactly one entry, itself — and `aria2.changeOption` applies
-the selection to it. `finish_add_inner` pauses the download the moment it
-exists and unpauses it only after `changeOption` has taken, which closes most
-(not all — see below) of the window a full, unfiltered selection would
-otherwise fetch in.
+the selection to it.
 
-There is no `bt-metadata-only` pass ahead of this that stops before any
-content flows: it stops `follow-torrent` from ever spawning the real download
-at all, so `finish_add_inner` would poll for a `followedBy` that never
-arrives (see the commit that removed it for the production incident this
-caused). Selection is applied to a download that is already running, not one
-that hasn't started yet — the pause above is what limits the exposure, not
-a delay before it exists.
+`--pause-metadata` is what makes that safe. aria2 creates the followed download
+already stopped, with its full file list readable, so the selection is in place
+before a single content byte arrives — measured against a real swarm, nothing
+reaches the disk in that window but the saved `.torrent`. `finish_add_inner`
+only has to release it at the end.
+
+Two earlier shapes were worse, and both are worth remembering. `bt-metadata-only`
+stops `follow-torrent` from ever spawning the real download at all, so
+`finish_add_inner` polls for a `followedBy` that never arrives — see the commit
+that removed it for the production incident. Pausing the download from here
+instead lost a race with itself: aria2 refuses to unpause a group until it has
+finished stopping, the download fetched every file in the torrent meanwhile,
+and a process that died in that window left one aria2 serialised as paused with
+nothing that would ever start it.
+
+The option lives on the aria2 process, so the add does not assume it: the
+child's own status decides whether there is a pause to release, and an aria2
+started without it still works — with the old exposure, which is the sweep
+below's problem.
 
 aria2 also downloads whole pieces regardless of selection, so a small
 deselected file sharing a piece boundary with a selected one can land anyway
@@ -361,13 +370,35 @@ aria2 serialises `pause=true` alongside the magnet, and a restored paused
 magnet does not even ask for metadata. The download sat there permanently,
 with the selection never applied and nothing left that would ever apply it.
 
-`resume` adopts them. A metadata download still in aria2's queues when this
-process starts is by definition an add nobody is finishing — a resolved
-magnet's own gid moves to the stopped list, which the download list already
-sweeps — so each one is released and run through the same finish the request
-would have. Only at startup: a metadata row on screen carries a pause button
-like any other, and overruling someone who pressed it a second ago is a
-different bug.
+**An unfinished add is a paused download with no `select-file`.** aria2 holds
+that mark, `finish_add_inner` writes it exactly once at the end of the
+sequence, and nothing else writes it at all — so `getOption` answers "is
+anybody finishing this" without inferring anything from names or byte counts,
+and a download somebody deliberately paused is left alone because it already
+carries one.
+
+`resume` reconciles on that rule, off the snapshots the poller already
+publishes, and it costs one `getOption` per *paused* download per tick — a
+running queue asks aria2 nothing extra. An `Adding` claim keeps it from
+adopting the add running beside it, which is the same state for the second or
+two it lasts.
+
+Two earlier rules for this were wrong, and both failed silently:
+
+- **A `[METADATA]` row at startup.** `--bt-load-saved-metadata` reads the
+  torrent off the disk before aria2 answers a single RPC, so a restored magnet
+  comes back named after its file and never matches. The two fixes cancelled
+  each other out and the stranding stayed exactly as it was.
+- **Only at startup.** A magnet that resolves a minute after boot produces its
+  paused download a minute after boot, and a one-shot has long since run.
+
+The same restore is why `routes::follow` exists. An adopted add is usually
+*already* the download it would have been followed to — the metadata pass is
+over, `followedBy` will never appear — so waiting for one is ten minutes of
+polling and a timeout with the download running unnarrowed throughout. aria2
+tells the two apart: an unresolved magnet has no `bittorrent.info.name` and one
+file called `[METADATA]<dn>`, a real download has the torrent's own name and
+its real file list.
 
 Nothing the interface cleared comes back. `routes::clear` follows `remove` with
 `removeDownloadResult` and keeps asking until the gid is gone from every list

--- a/apps/mariastew/docker-compose.yml
+++ b/apps/mariastew/docker-compose.yml
@@ -77,6 +77,13 @@ services:
       - --dir=/tv
       - --continue=true
       - --check-integrity=true
+      # Production sets this (see packages/mariastew/src/mariastew.ts) and the
+      # add path is shaped around it: the followed download is created stopped
+      # so the filter's selection lands before anything is fetched. Without it
+      # here, local dev would exercise a different sequence from the one that
+      # ships — and the one case that only shows up in the combination is the
+      # kind this file exists to make visible.
+      - --pause-metadata=true
       # Nothing is preallocated, so a file the filter rejected never touches
       # disk — see "Why files land straight in the library" in the README.
       - --file-allocation=none

--- a/apps/mariastew/src/aria2.rs
+++ b/apps/mariastew/src/aria2.rs
@@ -656,6 +656,26 @@ impl Aria2 {
             .await?;
         Ok(())
     }
+
+    /// Whether `select-file` has been set on this download.
+    ///
+    /// The one durable mark that an add finished. aria2 holds it — nothing on
+    /// this side does — and it is written exactly once, by
+    /// `routes::finish_add_inner`, at the end of the sequence that narrows a
+    /// download to the files worth keeping. So its absence says the add did
+    /// not get that far, and `resume` reads it to tell a download waiting to
+    /// be finished from one somebody deliberately paused.
+    ///
+    /// Absent rather than empty when unset: aria2 omits the key from
+    /// `getOption` entirely, which is why this answers a bool rather than
+    /// handing back a string nobody would know how to read.
+    pub async fn has_selection(&self, gid: &str) -> AppResult<bool> {
+        let options = self.call("getOption", serde_json::json!([gid])).await?;
+        Ok(options
+            .get("select-file")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| !v.is_empty()))
+    }
 }
 
 #[cfg(test)]

--- a/apps/mariastew/src/auth/routes.rs
+++ b/apps/mariastew/src/auth/routes.rs
@@ -168,6 +168,7 @@ mod tests {
             config: std::sync::Arc::new(Config::fixture()),
             activity: crate::activity::Activity::new(),
             clearing: crate::state::Clearing::default(),
+            adding: Default::default(),
             aria2: Aria2::new(String::new(), reqwest::Client::new()),
             sessions: crate::auth::session::Sessions::new(),
             poll: crate::poll::Poll::new(),

--- a/apps/mariastew/src/main.rs
+++ b/apps/mariastew/src/main.rs
@@ -88,6 +88,7 @@ async fn main() -> anyhow::Result<()> {
         activity: activity::Activity::new(),
         poll: poll::Poll::new(),
         clearing: state::Clearing::default(),
+        adding: state::Adding::default(),
         http,
     };
 

--- a/apps/mariastew/src/notify.rs
+++ b/apps/mariastew/src/notify.rs
@@ -332,6 +332,7 @@ mod tests {
             activity: crate::activity::Activity::new(),
             poll: crate::poll::Poll::new(),
             clearing: crate::state::Clearing::default(),
+            adding: Default::default(),
             http: reqwest::Client::new(),
         }
     }

--- a/apps/mariastew/src/poll.rs
+++ b/apps/mariastew/src/poll.rs
@@ -212,6 +212,7 @@ mod tests {
             sessions: crate::auth::session::Sessions::new(),
             activity: crate::activity::Activity::new(),
             clearing: crate::state::Clearing::default(),
+            adding: Default::default(),
             poll: Poll::new(),
             http: reqwest::Client::new(),
         }

--- a/apps/mariastew/src/resume.rs
+++ b/apps/mariastew/src/resume.rs
@@ -1,72 +1,104 @@
-//! The adds a restart interrupted, picked up again.
+//! The adds nobody is finishing, finished.
 //!
 //! Adding a magnet is two steps with a gap in the middle: aria2 resolves the
-//! metadata, and `routes::finish_add` — detached from the request that asked
-//! for it — waits for the download that comes out of that, narrows it to the
-//! files worth keeping, and starts it. A pod replaced inside the gap loses the
-//! second step alone, because aria2's session restores the first.
+//! metadata and creates the real download paused (`--pause-metadata`), and
+//! `routes::finish_add` — detached from the request that asked for it — reads
+//! the file list, narrows it to what is worth keeping, and releases it. The
+//! second step lives in one process's memory and nothing restores it, so a pod
+//! replaced inside the gap leaves a download aria2 will hold, paused, forever.
 //!
-//! What comes back is worse than nothing. The narrowing is done under a pause,
-//! aria2 serialises `pause=true` alongside the magnet, and a restored paused
-//! magnet does not even ask for metadata — so the row says "finding peers"
-//! over data that may already be complete, and says it forever. That is the
-//! shape of "the queue came back but nothing in it moves".
+//! That is not a rare window. It is every add, for as long as a magnet takes
+//! to resolve, and a resolve is minutes on a sparse swarm.
 //!
-//! A metadata download still in aria2's active or waiting queues when this
-//! process starts is exactly one of those: an add with nobody finishing it.
-//! Nothing else leaves one there — once a magnet resolves, its own gid moves
-//! to the stopped list, which `routes::all_downloads` already sweeps. So they
-//! are adopted, once, and put through the same finish the request would have.
+//! **An unfinished add is a paused download with no `select-file`.** aria2
+//! holds that mark, `routes::finish_add_inner` writes it exactly once at the
+//! end of the sequence, and nothing else writes it at all — so its absence is
+//! the difference between a download waiting to be finished and one somebody
+//! deliberately paused, without inferring anything from names or byte counts.
 //!
-//! Deliberately only at startup. A metadata row on screen carries a pause
-//! button like any other, so unpausing one on sight would be overruling
-//! someone who pressed it a second ago; one that was already paused before
-//! this process existed is not that.
+//! Two earlier rules for this were wrong, and both failed the same way:
+//!
+//! - *A `[METADATA]` row at startup.* `--bt-load-saved-metadata` means a
+//!   restored magnet has its torrent read off the disk before aria2 answers a
+//!   single RPC, so what comes back is named after the file rather than
+//!   `[METADATA]…` and the rule matched nothing. The two fixes cancelled out.
+//! - *Only the first poll.* A magnet that resolves a minute after start-up
+//!   produces its paused child a minute after start-up, and a one-shot at
+//!   boot has long since run.
+//!
+//! So this reconciles continuously, off the snapshots the poller already
+//! publishes. It costs one `getOption` per paused download per tick, and only
+//! paused ones — a queue that is running asks aria2 nothing extra.
 
-use crate::aria2::Status;
+use std::sync::Arc;
+
+use crate::aria2::{Download, Status};
 use crate::routes::finish_add_inner;
 use crate::state::AppState;
 
-/// Whatever the first poll finds. Waiting on the poller rather than asking
-/// aria2 directly is also how this waits for the sidecar: only a successful
-/// sample is ever published, and aria2 loads its session before it answers RPC
-/// at all, so a first answer is a complete one.
+/// Watches the poll for downloads with nobody finishing them.
+///
+/// Reading the poller rather than aria2 directly is also how this waits for
+/// the sidecar — only a successful sample is ever published — and it means an
+/// aria2 that restarts under a still-running mariastew is reconciled too,
+/// which a start-up hook could never see.
 pub fn spawn(state: AppState) {
     tokio::spawn(async move {
         let mut poll = state.poll.subscribe();
-        if poll.changed().await.is_err() {
-            return;
-        }
-        let downloads = poll.borrow_and_update().downloads.clone();
-        for d in downloads.iter().filter(|d| d.is_metadata()) {
-            tokio::spawn(adopt(
-                state.clone(),
-                d.gid.clone(),
-                d.dir.clone(),
-                d.status == Status::Paused,
-            ));
+        while poll.changed().await.is_ok() {
+            let downloads = poll.borrow_and_update().downloads.clone();
+            reconcile(&state, &downloads).await;
         }
     });
 }
 
-/// One interrupted add, carried the rest of the way.
+async fn reconcile(state: &AppState, downloads: &Arc<Vec<Download>>) {
+    for d in downloads.iter() {
+        if d.status != Status::Paused || state.adding.contains(&d.gid) {
+            continue;
+        }
+        match state.aria2.has_selection(&d.gid).await {
+            // Someone pressed pause. Theirs to undo.
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(gid = %d.gid, error = %e, "resume: could not read the selection");
+                continue;
+            }
+        }
+        tokio::spawn(adopt(state.clone(), d.gid.clone(), d.dir.clone()));
+    }
+}
+
+/// One unfinished add, carried the rest of the way.
 ///
-/// The unpause comes first and is fatal to this attempt if it fails: the whole
-/// point is that a paused magnet fetches no metadata, so there is nothing for
-/// the finish below to wait for and it would only spend ten minutes proving
-/// it. `sub` is the audit field on the "starting download" line, and nobody
-/// asked for this one — the restart did.
-async fn adopt(state: AppState, gid: String, dir: String, paused: bool) {
-    tracing::info!(%gid, %dir, paused, "resume: finishing an add a restart interrupted");
+/// The claim is taken here rather than left to `finish_add_inner`, because the
+/// gap between spawning this and that function reaching its own claim is a gap
+/// the next tick can arrive in — and two tasks narrowing one download would
+/// race to release it.
+///
+/// The release comes first and is fatal to this attempt if it fails: a paused
+/// magnet fetches no metadata, so there would be nothing for the finish below
+/// to wait for and it would spend ten minutes proving it. `sub` is the audit
+/// field on the "starting download" line, and nobody asked for this one — the
+/// restart did.
+async fn adopt(state: AppState, gid: String, dir: String) {
+    let claim = state.adding.claim(&gid);
+    tracing::info!(%gid, %dir, "resume: finishing an add nobody was finishing");
     state
         .activity
         .record(&gid, "picked up again after a restart");
 
-    if paused && let Err(e) = state.aria2.unpause(&gid).await {
-        tracing::error!(%gid, error = %e, "resume: could not restart a paused add");
+    if let Err(e) = state.aria2.unpause(&gid).await {
+        tracing::error!(%gid, error = %e, "resume: could not release a stalled add");
         state.activity.record(&gid, format!("failed — {e}"));
         return;
     }
+
+    // Dropped before the finish rather than held across it: `finish_add_inner`
+    // takes its own claim on the same gid, and this one has done its job the
+    // moment that exists.
+    drop(claim);
 
     if let Err(e) = finish_add_inner(&state, "restart", &dir, &gid).await {
         tracing::error!(%gid, error = %e, "resume: could not finish an interrupted add");
@@ -86,51 +118,81 @@ mod tests {
     use super::*;
     use crate::config::Config;
 
-    #[derive(Clone, Default)]
-    struct Calls {
+    #[derive(Clone)]
+    struct Mock {
         unpaused: Arc<Mutex<Vec<String>>>,
         selected: Arc<Mutex<Vec<String>>>,
+        /// Whether the paused download in the queue already carries a
+        /// selection — the difference between an abandoned add and one
+        /// somebody paused on purpose.
+        has_selection: bool,
+        /// Whether the adopted gid still has a metadata pass to be followed to
+        /// its download, or *is* that download already — see `routes::follow`.
+        resolves_to_child: bool,
     }
 
-    /// A restored add exactly as aria2 hands one back: the magnet's own gid,
-    /// paused, in the waiting queue, with the download it resolved to already
-    /// attached. The child's file list is the one the filter has to see —
-    /// reading the metadata gid's own would find a single `[METADATA]` entry
-    /// and select by position (see `finish_add_inner`).
-    async fn mock_aria2(calls: Calls) -> String {
+    /// A download paused with no selection, exactly as a restart leaves one.
+    /// Named after its file rather than `[METADATA]…`, because
+    /// `--bt-load-saved-metadata` resolves it off the disk before aria2 answers
+    /// anything — which is the shape the old rule missed.
+    async fn mock_aria2(mock: Mock) -> String {
         async fn rpc(
-            AxumState(calls): AxumState<Calls>,
+            AxumState(mock): AxumState<Mock>,
             Json(body): Json<serde_json::Value>,
         ) -> Json<serde_json::Value> {
             let gid = body["params"][0].as_str().unwrap_or_default().to_string();
+            // aria2 reports a released download as running, so the mock has to
+            // as well: `finish_add_inner` reads the status back to decide
+            // whether there is a pause left to undo, and a mock frozen at
+            // "paused" would let a double release through unnoticed.
+            let released = |g: &str| mock.unpaused.lock().unwrap().iter().any(|u| u == g);
+            let live = |g: &str| if released(g) { "active" } else { "paused" };
             let result = match body["method"].as_str().unwrap_or_default() {
                 "aria2.tellActive" | "aria2.tellStopped" => serde_json::json!([]),
                 "aria2.tellWaiting" => serde_json::json!([download(
-                    "metadata-gid",
-                    "paused",
-                    serde_json::json!([{"index": "1", "path": "[METADATA]Show.S01", "length": "0", "selected": "true"}]),
+                    "stranded-gid",
+                    live("stranded-gid"),
+                    serde_json::json!([{"index": "1", "path": "/tv/Show.S01/ep01.mkv", "length": "90", "selected": "true"}]),
                 )]),
+                "aria2.getOption" => {
+                    if mock.has_selection {
+                        serde_json::json!({"select-file": "1"})
+                    } else {
+                        serde_json::json!({"dir": "/tv"})
+                    }
+                }
                 "aria2.tellStatus" if gid == "child-gid" => download(
                     "child-gid",
-                    "active",
+                    live("child-gid"),
                     serde_json::json!([
                         {"index": "1", "path": "/tv/Show.S01/poster.jpg", "length": "10", "selected": "true"},
                         {"index": "2", "path": "/tv/Show.S01/ep01.mkv", "length": "90", "selected": "true"},
                     ]),
                 ),
-                "aria2.tellStatus" => {
-                    let mut d = download("metadata-gid", "complete", serde_json::json!([]));
+                "aria2.tellStatus" if mock.resolves_to_child => {
+                    let mut d = download("stranded-gid", "active", serde_json::json!([]));
                     d["followedBy"] = serde_json::json!(["child-gid"]);
                     d
                 }
+                // No `followedBy`, and not a `[METADATA]` row: the torrent was
+                // read off the disk during aria2's start-up, so this gid is
+                // the download itself.
+                "aria2.tellStatus" => download(
+                    "stranded-gid",
+                    live("stranded-gid"),
+                    serde_json::json!([
+                        {"index": "1", "path": "/tv/Show.S01/poster.jpg", "length": "10", "selected": "true"},
+                        {"index": "2", "path": "/tv/Show.S01/ep01.mkv", "length": "90", "selected": "true"},
+                    ]),
+                ),
                 "aria2.unpause" => {
-                    calls.unpaused.lock().unwrap().push(gid.clone());
+                    mock.unpaused.lock().unwrap().push(gid.clone());
                     serde_json::json!(gid)
                 }
-                "aria2.pause" => serde_json::json!(gid),
+                "aria2.pause" => panic!("the add must not pause anything itself any more"),
                 "aria2.changeOption" => {
                     if let Some(files) = body["params"][1]["select-file"].as_str() {
-                        calls.selected.lock().unwrap().push(files.to_string());
+                        mock.selected.lock().unwrap().push(files.to_string());
                     }
                     serde_json::json!("OK")
                 }
@@ -153,24 +215,16 @@ mod tests {
             })
         }
 
-        let app = Router::new().route("/", post(rpc)).with_state(calls);
+        let app = Router::new().route("/", post(rpc)).with_state(mock);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
         format!("http://{addr}/")
     }
 
-    /// The whole bug, end to end: a deploy that lands mid-add leaves a paused
-    /// magnet in the session, and nothing in aria2 will ever start it again.
-    /// Adopting it has to both release the pause and apply the selection the
-    /// interrupted add never got to — coming back downloading everything is a
-    /// different failure, not a fix.
-    #[tokio::test]
-    async fn a_paused_add_left_by_a_restart_is_released_and_narrowed() {
-        let calls = Calls::default();
-        let url = mock_aria2(calls.clone()).await;
+    fn state_for(url: String) -> AppState {
         let http = reqwest::Client::new();
-        let state = AppState {
+        AppState {
             config: Arc::new(Config {
                 aria2_rpc_url: url.clone(),
                 // The poller samples on the idle schedule with nobody
@@ -183,37 +237,132 @@ mod tests {
             poll: crate::poll::Poll::new(),
             activity: crate::activity::Activity::new(),
             clearing: crate::state::Clearing::default(),
+            adding: crate::state::Adding::default(),
             http,
+        }
+    }
+
+    async fn settle(f: impl Fn() -> bool) -> bool {
+        for _ in 0..200 {
+            if f() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        false
+    }
+
+    /// The whole bug, end to end — and the one the first version of this
+    /// missed. A restart leaves a paused download that nothing in aria2 will
+    /// ever start, and because `--bt-load-saved-metadata` resolves it off the
+    /// disk it does *not* come back looking like a metadata row. Adopting it
+    /// has to both release it and apply the selection the interrupted add
+    /// never got to: coming back downloading everything is a different
+    /// failure, not a fix.
+    #[tokio::test]
+    async fn a_paused_add_with_no_selection_is_released_and_narrowed() {
+        let mock = Mock {
+            unpaused: Arc::new(Mutex::new(Vec::new())),
+            selected: Arc::new(Mutex::new(Vec::new())),
+            has_selection: false,
+            resolves_to_child: true,
         };
+        let state = state_for(mock_aria2(mock.clone()).await);
 
         crate::poll::spawn(state.clone());
         spawn(state.clone());
 
-        for _ in 0..200 {
-            if !calls.selected.lock().unwrap().is_empty() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-
-        assert_eq!(
-            *calls.unpaused.lock().unwrap(),
-            ["metadata-gid", "child-gid"],
-            "the restored magnet has to be released before it fetches anything, \
-             and the download it resolves to released again after being narrowed"
+        assert!(
+            settle(|| !mock.selected.lock().unwrap().is_empty()).await,
+            "the stranded add was never picked up"
         );
         assert_eq!(
-            *calls.selected.lock().unwrap(),
+            *mock.unpaused.lock().unwrap(),
+            ["stranded-gid", "child-gid"],
+            "the stalled add has to be released before it resolves, and the \
+             download it resolves to released again after being narrowed"
+        );
+        assert_eq!(
+            *mock.selected.lock().unwrap(),
             ["2"],
             "the poster is what the filter exists to leave behind"
         );
+    }
+
+    /// The other half of the rule, and the reason it is `select-file` rather
+    /// than "is it paused". Someone pressing pause and then a deploy landing
+    /// must not read as an abandoned add — a queue that quietly restarts
+    /// itself on every deploy is its own bug.
+    #[tokio::test]
+    async fn a_download_somebody_paused_on_purpose_is_left_alone() {
+        let mock = Mock {
+            unpaused: Arc::new(Mutex::new(Vec::new())),
+            selected: Arc::new(Mutex::new(Vec::new())),
+            has_selection: true,
+            resolves_to_child: false,
+        };
+        let state = state_for(mock_aria2(mock.clone()).await);
+
+        crate::poll::spawn(state.clone());
+        spawn(state.clone());
+
         assert!(
-            state
-                .activity
-                .entries("child-gid")
-                .iter()
-                .any(|e| e.message.contains("picked up again after a restart")),
-            "the row has to say why it moved on its own"
+            !settle(|| !mock.unpaused.lock().unwrap().is_empty()).await,
+            "a deliberate pause was overruled"
+        );
+    }
+
+    /// The shape production actually restores, and the one the first version
+    /// of this got wrong twice over. `--bt-load-saved-metadata` reads the
+    /// torrent off the disk during aria2's start-up, so the adopted gid has no
+    /// metadata pass left to follow and no `followedBy` that will ever appear
+    /// — waiting for one is ten minutes of polling and a timeout, with the
+    /// download running unnarrowed throughout.
+    #[tokio::test]
+    async fn an_add_restored_past_its_metadata_pass_is_narrowed_in_place() {
+        let mock = Mock {
+            unpaused: Arc::new(Mutex::new(Vec::new())),
+            selected: Arc::new(Mutex::new(Vec::new())),
+            has_selection: false,
+            resolves_to_child: false,
+        };
+        let state = state_for(mock_aria2(mock.clone()).await);
+
+        crate::poll::spawn(state.clone());
+        spawn(state.clone());
+
+        assert!(
+            settle(|| !mock.selected.lock().unwrap().is_empty()).await,
+            "an add with no metadata pass left to follow was never narrowed"
+        );
+        assert_eq!(*mock.selected.lock().unwrap(), ["2"]);
+        assert_eq!(
+            *mock.unpaused.lock().unwrap(),
+            ["stranded-gid"],
+            "there is one download here, so there is one release"
+        );
+    }
+
+    /// The reconciler runs every tick and an add takes seconds, so the state
+    /// it recognises is one a live add stands in the middle of. Without the
+    /// claim it would adopt the add already running beside it.
+    #[tokio::test]
+    async fn an_add_this_process_is_already_running_is_not_adopted() {
+        let mock = Mock {
+            unpaused: Arc::new(Mutex::new(Vec::new())),
+            selected: Arc::new(Mutex::new(Vec::new())),
+            has_selection: false,
+            resolves_to_child: true,
+        };
+        let state = state_for(mock_aria2(mock.clone()).await);
+        let _claim = state.adding.claim("stranded-gid");
+
+        crate::poll::spawn(state.clone());
+        spawn(state.clone());
+
+        assert!(
+            !settle(|| !mock.unpaused.lock().unwrap().is_empty()).await,
+            "the reconciler raced the add that was already in flight"
         );
     }
 }

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -419,63 +419,64 @@ const RESOLVE_TIMEOUT: Duration = Duration::from_secs(600);
 /// `addUri` also means there is no infohash collision to resolve: one
 /// download exists for this magnet from start to finish, under one gid.
 ///
-/// `bt-metadata-only` used to stop aria2 right at that boundary, so the
-/// selection was in place before a single content byte arrived. Without it
-/// (see `add` for why it had to go — it also stops `followedBy` from ever
-/// appearing), the child starts downloading everything the instant it
-/// exists. That is what the pause/change/unpause sequence below is for.
+/// `--pause-metadata` is what makes the narrowing safe, and it is set on the
+/// aria2 process rather than here. aria2 creates the followed download already
+/// paused, so the selection is in place before a single content byte arrives
+/// and this only has to release it at the end.
+///
+/// Two earlier shapes are worth remembering, because both are worse. Asking
+/// for `bt-metadata-only` stops aria2 *before* it spawns the followed download
+/// at all, so `followedBy` never appears and every add runs out the clock —
+/// see `add`. Pausing the child from here instead lost a race with itself:
+/// aria2 refuses to unpause a group until it has finished stopping, the child
+/// fetched every file in the torrent in the meantime, and a process that died
+/// in that window left a download aria2 serialised as paused with nothing that
+/// would ever start it.
+///
+/// So the pause is not made here and its absence is not assumed either — the
+/// child's own status decides whether there is anything to release, which is
+/// also what keeps this working against an aria2 started without the option.
 pub(crate) async fn finish_add_inner(
     state: &AppState,
     sub: &str,
     dir: &str,
     metadata_gid: &str,
 ) -> AppResult<()> {
-    let deadline = tokio::time::Instant::now() + RESOLVE_TIMEOUT;
-    let child_gid = loop {
-        let status = state.aria2.tell_status(metadata_gid).await?;
-        if status.status == Status::Error {
-            return Err(AppError::Upstream(
-                status
-                    .error_message
-                    .unwrap_or_else(|| "metadata fetch failed".to_string()),
-            ));
-        }
-        if let Some(gid) = status.followed_by.into_iter().next() {
-            break gid;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            // Not the caller's mistake — a sparse swarm, or one that never
-            // shows up at all, is an upstream condition and reads as one.
-            return Err(AppError::Upstream(format!(
-                "the magnet did not resolve within {}s",
-                RESOLVE_TIMEOUT.as_secs()
-            )));
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    };
+    // Held for the whole sequence, so the reconciler in `resume` — which
+    // recognises an unfinished add by exactly the state this is standing in
+    // the middle of — leaves this one alone. Dropped on every exit, `?`
+    // included.
+    let _adding = state.adding.claim(metadata_gid);
 
-    // Before anything else: the history so far was written under the gid that
-    // resolved the magnet, and that gid is about to leave every list this UI
-    // reads. From here both names reach one log.
-    state.activity.link(metadata_gid, &child_gid);
+    let child_gid = follow(state, metadata_gid).await?;
+
+    // An adopted add is already the download it would have been followed to
+    // (see `follow`), so there is no second gid to link a history to and no
+    // second claim to take — both were done under this one.
+    let followed = child_gid != metadata_gid;
+
+    // The history so far was written under the gid that resolved the magnet,
+    // and that gid is about to leave every list this UI reads. From here both
+    // names reach one log.
+    let _adding_child = followed.then(|| {
+        // Claimed before the first await that could let the reconciler see it:
+        // a child born paused with no selection is exactly what `resume`
+        // adopts, and this is the task already doing that.
+        state.activity.link(metadata_gid, &child_gid);
+        state.adding.claim(&child_gid)
+    });
     state
         .activity
         .record(&child_gid, "torrent file arrived — choosing files");
 
-    // Freshly created and, without `bt-metadata-only`, already fetching
-    // aria2's default selection — every file. Pausing closes most of that
-    // window before `changeOption` narrows it; best-effort, because a
-    // download that will not pause just keeps fetching everything for the
-    // few seconds this takes, which `notify::sweep_garbage` already exists
-    // to clean up after. Unpausing back out is not best-effort: if the pause
-    // took, it must be undone, or the download sits paused forever with
-    // nothing left to tell anyone it is stuck.
-    let paused = state.aria2.pause(&child_gid).await.is_ok();
-
     // The child's file list is already known the moment it is queryable —
     // aria2 only creates it once it has parsed a complete torrent out of the
-    // resolved metadata, so there is nothing left to wait for here.
-    let files = state.aria2.tell_status(&child_gid).await?.files;
+    // resolved metadata, so a paused child still answers with every file in
+    // it, which is the whole reason the selection can be applied before
+    // anything is fetched.
+    let child = state.aria2.tell_status(&child_gid).await?;
+    let paused = child.status == Status::Paused;
+    let files = child.files;
     if files.is_empty() {
         return Err(AppError::Upstream(
             "aria2 followed the metadata pass but the download it created has no files".to_string(),
@@ -535,6 +536,51 @@ pub(crate) async fn finish_add_inner(
     state.activity.record(&child_gid, "downloading");
 
     Ok(())
+}
+
+/// The download a selection has to be applied to, given the gid an add is
+/// known by.
+///
+/// Normally that is not the same gid: a magnet resolves under its own, and
+/// `follow-torrent` spawns the real download beside it. But `resume` adopts an
+/// add by whatever aria2 is holding, and after a restart that is often the
+/// spawned download itself — `--bt-load-saved-metadata` reads the torrent off
+/// the disk during start-up, so there is no metadata pass left to wait for and
+/// no `followedBy` that will ever appear. Waiting for one anyway is ten
+/// minutes of polling followed by a timeout, with the download running
+/// unnarrowed the whole time. That is what this exists to tell apart.
+///
+/// The two are distinguishable and not by their gids: aria2 gives an
+/// unresolved magnet no `bittorrent.info.name` and a single file called
+/// `[METADATA]<dn>`, which is what `is_metadata` reads, while a real download
+/// carries the torrent's own name and its real file list.
+async fn follow(state: &AppState, gid: &str) -> AppResult<String> {
+    let deadline = tokio::time::Instant::now() + RESOLVE_TIMEOUT;
+    loop {
+        let status = state.aria2.tell_status(gid).await?;
+        if status.status == Status::Error {
+            return Err(AppError::Upstream(
+                status
+                    .error_message
+                    .unwrap_or_else(|| "metadata fetch failed".to_string()),
+            ));
+        }
+        if let Some(child) = status.followed_by.first() {
+            return Ok(child.clone());
+        }
+        if !status.is_metadata() && !status.files.is_empty() {
+            return Ok(gid.to_string());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            // Not the caller's mistake — a sparse swarm, or one that never
+            // shows up at all, is an upstream condition and reads as one.
+            return Err(AppError::Upstream(format!(
+                "the magnet did not resolve within {}s",
+                RESOLVE_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }
 
 /// How long to keep offering aria2 the chance to accept the unpause above.
@@ -914,6 +960,7 @@ mod tests {
             activity: crate::activity::Activity::new(),
             poll: crate::poll::Poll::new(),
             clearing: crate::state::Clearing::default(),
+            adding: Default::default(),
             http: reqwest::Client::new(),
         }
     }
@@ -1078,9 +1125,10 @@ mod tests {
             change_option_calls: Arc<Mutex<Vec<serde_json::Value>>>,
             metadata_add_result: Arc<serde_json::Value>,
             metadata_outcome: MetadataOutcome,
-            /// Lets a test exercise the case where the child will not pause —
-            /// `finish_add_inner` treats that as tolerable and best-effort.
-            pause_should_succeed: bool,
+            /// How aria2 hands the followed download over. `--pause-metadata`
+            /// makes that "paused" in production; "active" is an aria2 started
+            /// without it, which must not then be unpaused.
+            child_status: &'static str,
             /// How many `unpause` calls are refused before one is accepted,
             /// standing in for the window a real pause takes to settle. See
             /// [`unpause_settled`].
@@ -1120,13 +1168,11 @@ mod tests {
                 "aria2.addUri" => {
                     panic!("a second addUri means the duplicate-infohash bug is back")
                 }
-                "aria2.pause" => {
-                    if mock.pause_should_succeed {
-                        serde_json::json!({"result": "OK"})
-                    } else {
-                        serde_json::json!({"error": {"code": 1, "message": "not pausable"}})
-                    }
-                }
+                // The add pauses nothing any more: `--pause-metadata` hands
+                // the child over already stopped, which is what closed both
+                // the race with our own pause and the window where aria2 was
+                // fetching every file in the torrent.
+                "aria2.pause" => panic!("finish_add must not pause anything itself"),
                 "aria2.unpause" => {
                     let mut refusals = mock.unpause_refusals.lock().unwrap();
                     if *refusals > 0 {
@@ -1152,7 +1198,7 @@ mod tests {
                             },
                             g,
                         ) if g == child_gid => {
-                            download_result(child_gid, "active", child_files.clone())
+                            download_result(child_gid, mock.child_status, child_files.clone())
                         }
                         (MetadataOutcome::ResolvesWithChild { child_gid, .. }, _) => {
                             let mut result =
@@ -1186,16 +1232,16 @@ mod tests {
             metadata_add_result: serde_json::Value,
             metadata_outcome: MetadataOutcome,
         ) -> Mock {
-            mock_server_with(metadata_add_result, metadata_outcome, true, 0).await
+            mock_server_with(metadata_add_result, metadata_outcome, "paused", 0).await
         }
 
-        /// The two ways aria2 declines to be driven across the metadata
-        /// boundary: a group it will not pause, and one it will not unpause
-        /// *yet*.
+        /// `child_status` is how aria2 hands the followed download over, and
+        /// `unpause_refusals` is it declining to take it back — the two ends
+        /// of the only thing `finish_add_inner` still does to a pause.
         async fn mock_server_with(
             metadata_add_result: serde_json::Value,
             metadata_outcome: MetadataOutcome,
-            pause_should_succeed: bool,
+            child_status: &'static str,
             unpause_refusals: u32,
         ) -> Mock {
             let calls = Arc::new(Mutex::new(Vec::new()));
@@ -1205,7 +1251,7 @@ mod tests {
                 change_option_calls: change_option_calls.clone(),
                 metadata_add_result: Arc::new(metadata_add_result),
                 metadata_outcome,
-                pause_should_succeed,
+                child_status,
                 unpause_refusals: Arc::new(Mutex::new(unpause_refusals)),
             };
             let app = axum::Router::new().route("/", post(rpc)).with_state(mock);
@@ -1325,13 +1371,12 @@ mod tests {
 
             add(State(state), CurrentSession(session()), Form(add_form())).await;
 
-            wait_for_calls(&mock.calls, 6).await;
+            wait_for_calls(&mock.calls, 5).await;
             assert_eq!(
                 mock.calls.lock().unwrap().as_slice(),
                 [
                     "aria2.addUri",
                     "aria2.tellStatus",
-                    "aria2.pause",
                     "aria2.tellStatus",
                     "aria2.changeOption",
                     "aria2.unpause",
@@ -1369,7 +1414,7 @@ mod tests {
             let activity = state.activity.clone();
 
             add(State(state), CurrentSession(session()), Form(add_form())).await;
-            wait_for_calls(&mock.calls, 6).await;
+            wait_for_calls(&mock.calls, 5).await;
 
             let messages: Vec<String> = activity
                 .entries("child-gid")
@@ -1390,14 +1435,13 @@ mod tests {
             );
         }
 
-        /// The pause is best-effort — a child that will not pause must not
-        /// stop the add, since `notify::sweep_garbage` is the backstop for
-        /// whatever it fetches in the meantime. What must not happen is an
-        /// `unpause` call for a pause that never took: that would either
-        /// error against a gid aria2 never actually paused, or (worse, if
-        /// aria2 tolerated it) mask a real pause/unpause mismatch elsewhere.
+        /// `--pause-metadata` lives on the aria2 process, so the add cannot
+        /// assume it: an aria2 started without it hands the child over already
+        /// running. Unpausing that is not harmless — aria2 answers
+        /// `cannot be unpaused now` for a group it never paused — so the
+        /// child's own status is what decides, not what this hoped for.
         #[tokio::test]
-        async fn finish_add_tolerates_a_child_that_will_not_pause() {
+        async fn a_child_aria2_handed_over_running_is_not_unpaused() {
             let child_files = serde_json::json!([
                 {"index": "1", "path": "/mnt/kontent/movies/movie.mkv", "length": "100", "selected": "true"},
             ]);
@@ -1407,7 +1451,7 @@ mod tests {
                     child_gid: "child-gid".to_string(),
                     child_files,
                 },
-                false,
+                "active",
                 0,
             )
             .await;
@@ -1415,17 +1459,16 @@ mod tests {
 
             add(State(state), CurrentSession(session()), Form(add_form())).await;
 
-            wait_for_calls(&mock.calls, 5).await;
+            wait_for_calls(&mock.calls, 4).await;
             assert_eq!(
                 mock.calls.lock().unwrap().as_slice(),
                 [
                     "aria2.addUri",
                     "aria2.tellStatus",
-                    "aria2.pause",
                     "aria2.tellStatus",
                     "aria2.changeOption",
                 ],
-                "a failed pause must not be followed by an unpause"
+                "a child that was never paused must not be unpaused"
             );
         }
 
@@ -1445,7 +1488,7 @@ mod tests {
                     child_gid: "child-gid".to_string(),
                     child_files,
                 },
-                true,
+                "paused",
                 2,
             )
             .await;
@@ -1453,7 +1496,7 @@ mod tests {
 
             add(State(state), CurrentSession(session()), Form(add_form())).await;
 
-            wait_for_calls(&mock.calls, 8).await;
+            wait_for_calls(&mock.calls, 7).await;
             assert_eq!(
                 mock.calls
                     .lock()

--- a/apps/mariastew/src/state.rs
+++ b/apps/mariastew/src/state.rs
@@ -46,6 +46,53 @@ impl Clearing {
     }
 }
 
+/// Downloads this process is part-way through adding.
+///
+/// An unfinished add is identified by what aria2 holds — paused, with no
+/// `select-file` — and that description fits a *live* add just as exactly as
+/// an abandoned one, for the whole second or two it takes. Without this the
+/// reconciler in `resume` would adopt the add already running beside it, and
+/// the two would race to pause, narrow and start the same download.
+///
+/// Held rather than inferred because there is nothing to infer from: aria2
+/// cannot say which of two processes asked, and the answer is only ever
+/// interesting to the one that did.
+#[derive(Clone, Default)]
+pub struct Adding(Arc<Mutex<HashSet<String>>>);
+
+impl Adding {
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashSet<String>> {
+        self.0.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Claims `gid` until the returned guard drops, which is what makes the
+    /// error paths safe: a finish that fails half way still has to let the
+    /// reconciler have another go, and there is no `?` that can skip a drop.
+    pub fn claim(&self, gid: &str) -> Claim {
+        self.lock().insert(gid.to_string());
+        Claim {
+            set: self.clone(),
+            gid: gid.to_string(),
+        }
+    }
+
+    pub fn contains(&self, gid: &str) -> bool {
+        self.lock().contains(gid)
+    }
+}
+
+/// One claimed gid, released on drop. See [`Adding::claim`].
+pub struct Claim {
+    set: Adding,
+    gid: String,
+}
+
+impl Drop for Claim {
+    fn drop(&mut self) {
+        self.set.lock().remove(&self.gid);
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub config: Arc<Config>,
@@ -59,6 +106,8 @@ pub struct AppState {
     pub activity: Activity,
     /// Removals in flight — see [`Clearing`].
     pub clearing: Clearing,
+    /// Adds in flight — see [`Adding`].
+    pub adding: Adding,
     /// Hydra and Telegram. One client, so the connection pool and the TLS
     /// session cache are shared.
     pub http: reqwest::Client,

--- a/packages/mariastew/src/mariastew.ts
+++ b/packages/mariastew/src/mariastew.ts
@@ -301,6 +301,19 @@ export function createMariastew(
                   // entries and never a sibling, so it survives to be read.
                   "--bt-save-metadata=true",
                   "--bt-load-saved-metadata=true",
+                  // The download a magnet resolves into is created stopped, so
+                  // `finish_add_inner` can narrow it to the files worth keeping
+                  // before a single content byte arrives. It used to pause the
+                  // child itself, which lost a race with its own request —
+                  // aria2 refuses to unpause a group until it has finished
+                  // stopping — while the child fetched the whole torrent in the
+                  // meantime.
+                  //
+                  // Not `bt-metadata-only`, which stops aria2 *before* it
+                  // spawns the followed download at all: `followedBy` never
+                  // appears and every add runs out the clock. This one still
+                  // spawns it, just stopped, with its full file list readable.
+                  "--pause-metadata=true",
                   // Nothing is preallocated, so a file the metadata pass chose
                   // not to download never appears on disk at all — which is
                   // what makes downloading straight into the library safe.


### PR DESCRIPTION
Closes #362. **Also fixes a bug #361 shipped** — see the second section.

## The add pauses nothing now

`finish_add` narrows a download to the files worth keeping, and it was doing that under a pause it issued itself. That pause caused all three of the problems around it:

- **It leaked.** The download fetched every file in the torrent, garbage included, between existing and the pause landing.
- **It raced with itself.** aria2 refuses to unpause a group until it has finished stopping (`GID#… cannot be unpaused now`), and the pause two calls earlier is what put it there. #361 papered over that with a retry.
- **It stranded the download outright** if the process died in the window — aria2 serialises `pause=true` and nothing would ever start it again. That is half of #359.

`--pause-metadata=true` removes the cause: aria2 creates the followed download **already stopped**, with its **full file list readable**, so the selection lands before a single content byte arrives. Measured against a real swarm — nothing on disk in that window but the saved `.torrent`.

Not `--bt-metadata-only`, which is the option that was tried and removed: that stops aria2 *before* it spawns the followed download at all, so `followedBy` never appears and every add runs out the clock. This one still spawns it, just stopped.

The option lives on the aria2 process, so the add does not assume it — the child's own status decides whether there is a pause to release. An aria2 started without it still works, with the old exposure.

## #361's `resume` never fired

The two halves of #359 cancelled each other out, and I did not catch it because I tested them separately and never in combination — which is the only configuration production runs.

`--bt-load-saved-metadata` reads the torrent off the disk **before aria2 answers a single RPC**, so a restored magnet comes back named after its file, not `[METADATA]…`. `is_metadata()` is false, `resume`'s filter skips it, and the stranded download sits there exactly as it did before. Confirmed by running main's own flags against a real aria2:

```
=== what MAIN brings back after a restart ===
e6fa960e952ecc34 paused   name=/dl/debian-13.6.0-amd64-netinst.iso  is_metadata=False
```

The rule is now what aria2 actually holds. **An unfinished add is a paused download with no `select-file`** — `finish_add_inner` writes that mark exactly once, at the end of the sequence, and nothing else writes it at all:

```
restored, never-finished add:  select-file = None
after finish_add applied it:   select-file = '1'
```

So a download somebody paused on purpose already carries one and is left alone, with no inference from names or byte counts. Reconciled **every tick** rather than once at startup, because a magnet that resolves a minute after boot strands a minute after boot — and an `Adding` claim keeps the reconciler off the add running beside it, which is in the same state for the second or two it lasts. Costs one `getOption` per *paused* download per tick; a running queue asks aria2 nothing extra.

## And an adopted add has no metadata pass left to follow

Same root cause, separate failure. `finish_add_inner` waits for `followedBy`, but an add restored past its metadata pass **is** the download it would have been followed to — `followedBy` will never appear. It polled for ten minutes and timed out with the download running unnarrowed the whole time. Caught by watching the real binary do it:

```
resume: finishing an add nobody was finishing gid=b33bba479e1af784
...
child select-file: None      <- released, never narrowed
```

`routes::follow` tells the two apart on what aria2 reports, verified both ways:

| | `followedBy` | `bittorrent.info.name` | `files[0]` |
|---|---|---|---|
| unresolved magnet | none | `None` | `[METADATA]Big+Buck+Bunny` |
| restored download | none | `debian-…iso` | real path |

## How this was verified

Real aria2 1.37, real magnet, and the real `mariastew` binary — not just unit tests, because unit tests are what missed this last time.

Full pod restart, both processes, which is the combination that was broken:

```
1. add interrupted: parent=4bacaf6f… child=d2b5895b… (paused, unselected)
2. POD RESTART — aria2 dies and comes back from its session
   restored: 4bacaf6f… paused debian-13.6.0-amd64-netinst.iso
3. mariastew starts
   resume: finishing an add nobody was finishing gid=4bacaf6f…
   starting download sub=restart magnet_files=1 wanted=1
   select-file: 1
   status active, completedLength 602554368, connections 44
```

And the other half of the rule, live: pausing a download that already carries a selection, then leaving the reconciler running for 25s — still `paused`, `resume:` logged exactly once (the earlier adoption). A deliberate pause is not overruled.

## What to look at

- `apps/mariastew/src/resume.rs` — the reconciler, with tests for both restored shapes, for a deliberate pause being left alone, and for not racing an in-flight add
- `routes::follow` — the metadata-pass-or-not decision
- `state::Adding` — the RAII claim; the guard is why a `?` mid-finish still hands the download back to the reconciler
- `packages/mariastew/src/mariastew.ts` and `docker-compose.yml` — the flag, in both places, so local dev exercises the sequence that ships

`cargo test` 174 passed, `cargo clippy` clean, `mise run check` green.