### PR TITLE
349 fix(ci): stop installing git hooks on runners

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ The project uses Lefthook for pre-commit validation:
 - Runs oxfmt formatting on staged files
 - Runs type checking before commit
 
+Installed by the root `prepare` script, which no-ops when `CI` is set. Hooks
+exist for a working tree a human is about to push; a runner has none, and the
+workflows that do commit (`update-apps`, `generate-schemas`) pass `-n` so a hook
+that somehow exists cannot abort a run that already did its work.
+
 ### Package Management
 
 - Uses [aube](https://aube.en.dev) as the package manager and script runner (pnpm-style isolated `node_modules`, reads `aube-lock.yaml`)

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,9 @@ _.path = ["node_modules/.bin"]
 
 [tasks.setup]
 description = "Toolchain, dependencies and git hooks, from a fresh clone"
-# `prepare` installs lefthook, so the hooks come with the dependencies.
+# `prepare` installs lefthook, so the hooks come with the dependencies. It
+# no-ops under `CI`: a runner has no commits to lint, and a half-written
+# `.git/hooks/pre-commit` is what broke the workflows that do commit.
 run = "aube install"
 
 [tasks.lint]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "type": "module",
   "scripts": {
-    "prepare": "lefthook install"
+    "prepare": "test -n \"$CI\" || lefthook install"
   },
   "dependencies": {
     "zod": "4.4.3"

--- a/packages/infra/src/update-apps.ts
+++ b/packages/infra/src/update-apps.ts
@@ -242,9 +242,14 @@ for (const entry of entries) {
     writeAt(doc, entry.path, decision.to);
     await writeFile(CONFIG, doc.toString(STRINGIFY_OPTIONS));
     await git("add", CONFIG);
+    // `-n`: the pre-commit hook lints, formats and typechecks a working tree a
+    // human is about to push. This commit is one YAML scalar written by the
+    // process that just parsed it, on a runner whose only stake in the hook is
+    // that it can fail — which it did, aborting a run that had already computed
+    // the right bump.
     await git(
       "commit",
-      "-q",
+      "-qn",
       "-m",
       `chore: update ${entry.app} to ${decision.to}`,
     );


### PR DESCRIPTION
Closes #349

The root `prepare` script ran `lefthook install` on every `aube install`, runners included. On `update-apps.yml` that install raced itself — one attempt failed `permission denied` on `.git/hooks/pre-commit`, a retry succeeded — and the hook it left behind then aborted the `git commit` in `update-apps.ts`, killing a run that had already computed a correct bump (`mariastew 0.1.9 -> 0.1.19`).

Two changes, both narrow:

- `prepare` no-ops when `CI` is set. Hooks lint, format and typecheck a working tree a human is about to push; a runner has no such tree, so it should never have been installing one.
- The updater's commit passes `-n`. That is the command that actually died, and `generate-schemas.yml` already commits this way — a bot writing one YAML scalar has no use for a hook that can only fail it.

## Verifying

- `test -n "$CI" || lefthook install` — no-ops with `CI=1`, installs without it. Both checked; the hooks still ran on this branch's own commit.
- `./packages/infra/src/update-apps.ts --dry-run` walks every tracked entry and reports `mariastew 0.1.23 -> 0.1.24`.
- `mise run check` green.

The `mise ERROR ... are not trusted` line in that run log is the second half of the same symptom and disappears with it — nothing on a runner invokes mise during install once `prepare` is quiet. The trust config itself (`MISE_TRUSTED_CONFIG_PATHS`, set by `jdx/mise-action`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrhkJpYQy48ncp6d77mo3H