### PR TITLE
337 refactor: one cloud-init wait, not eight copies of it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,11 @@ The project uses Lefthook for pre-commit validation:
 
 Components live in their own packages and know nothing about this deployment;
 `packages/infra` is the only thing that knows what jaritanet is. Nothing imports
-`infra`, and nothing imports sideways except from `@jaritanet/k8s`.
+`infra`, and the only sideways imports are `@jaritanet/k8s` and
+`@jaritanet/remote`, both of which are leaves.
 
 - **`@jaritanet/k8s`** — Deployment/Service/PV/PVC templates and the primitives the others share (`ImageSchema`, `LimitsSchema`, `cpuRequests`, `sha256hex`)
+- **`@jaritanet/remote`** — `remotePreamble`, the shell every `command.remote.Command` opens with: wait for cloud-init, then set a dpkg lock timeout apt honours on its own so the vendor installers inherit it. It has no dependencies and belongs to no cloud, which is what lets the `-systemd` transports and the k3s install share one copy without either depending on the other
 - **`@jaritanet/vpn`** — the transports: Xray VLESS-REALITY, Hysteria2, tailnet relay, `unbound`, ss-rust exits, and the sing-box profile builder. Each has a DaemonSet form and a `-systemd` form; the latter takes an SSH connection and opaque `dependsOn`, so it works on any reachable box rather than one cloud's server type
 - **`@jaritanet/hetzner`** — the VPS, its firewall rules, network tuning, k3s over SSH, Cilium as the CNI, the tailnet-rule DaemonSet that keeps Cilium's identity marks from tripping tailscaled's bypass routing (see docs/architecture.md), and the upgrade Plans that carry the k3s version to nodes Pulumi cannot reach
 - **`@jaritanet/ingress`** — Traefik Helm chart, IngressRoute CRDs, and the redirect middleware

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ jaritanet:exits:
 One Pulumi program, assembled from packages that don't know it exists. A
 component package describes a thing you could run anywhere; `packages/infra`
 describes *this* deployment. Dependencies only ever point that way — nothing
-imports `infra`, and the only sideways import is `@jaritanet/k8s`.
+imports `infra`, and the only sideways imports are `@jaritanet/k8s` and
+`@jaritanet/remote`.
 
 **`@jaritanet/hetzner`** — the machine
 
@@ -155,13 +156,14 @@ imports `infra`, and the only sideways import is `@jaritanet/k8s`.
 - **`singbox.ts`** / **`profiles.ts`** — builds each user's profile (`buildProfile`) and serves it from a Secret via `serve-from-env`; the routing table *is* the content, so a rotated slug stops existing rather than lingering as a stale file
 - **`*-systemd.ts`** — the same transports installed over SSH, still used by edges, which have no cluster. They take an SSH connection and opaque `dependsOn` rather than a typed server, so nothing here depends on a cloud provider
 
-**`@jaritanet/ingress`**, **`@jaritanet/dns`**, **`@jaritanet/mcp-gateway`**, **`@jaritanet/mariastew`**, **`@jaritanet/k8s`**
+**`@jaritanet/ingress`**, **`@jaritanet/dns`**, **`@jaritanet/mcp-gateway`**, **`@jaritanet/mariastew`**, **`@jaritanet/k8s`**, **`@jaritanet/remote`**
 
 - **`ingress.ts`** — Traefik Helm chart and IngressRoutes
 - **`dns.ts`** — Cloudflare A records, Fastmail MX/DKIM, Bluesky ATProto
 - **`mcp-gateway.ts`** — OAuth-fronted gateway for self-hosted MCP servers (Hydra + Postgres)
 - **`mariastew.ts`** — torrent web UI fronting aria2 (see `apps/mariastew/README.md`); one pod, two containers built from the same image and sharing a network namespace, so aria2's RPC never leaves loopback
 - **`service.ts`** — K8s Deployment/Service/PV/PVC templates, plus the schemas and helpers the other packages share
+- **`preamble.ts`** — `remotePreamble`, the shell every `command.remote.Command` opens with. Pulumi SSHes in the moment the box answers, so waiting for cloud-init and setting a dpkg lock timeout is the first thing on the wire — depending on nothing and on no cloud is what lets the `-systemd` transports and the k3s install share one copy
 
 **`packages/infra`** — this stack
 

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -108,6 +108,9 @@ importers:
 
   packages/hetzner:
     dependencies:
+      '@jaritanet/remote':
+        specifier: workspace:*
+        version: 0.0.0
       '@pulumi/command':
         specifier: 1.2.1
         version: 1.2.1(typescript@6.0.3)
@@ -169,6 +172,9 @@ importers:
         specifier: workspace:*
         version: 0.0.0
       '@jaritanet/mcp-gateway':
+        specifier: workspace:*
+        version: 0.0.0
+      '@jaritanet/remote':
         specifier: workspace:*
         version: 0.0.0
       '@jaritanet/vpn':
@@ -283,9 +289,14 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/remote: {}
+
   packages/vpn:
     dependencies:
       '@jaritanet/k8s':
+        specifier: workspace:*
+        version: 0.0.0
+      '@jaritanet/remote':
         specifier: workspace:*
         version: 0.0.0
       '@pulumi/command':

--- a/packages/hetzner/package.json
+++ b/packages/hetzner/package.json
@@ -14,6 +14,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "@jaritanet/remote": "workspace:*",
     "@pulumi/command": "1.2.1",
     "@pulumi/hcloud": "1.35.0",
     "@pulumi/kubernetes": "4.30.0",

--- a/packages/hetzner/src/k3s.ts
+++ b/packages/hetzner/src/k3s.ts
@@ -1,3 +1,4 @@
+import { remotePreamble } from "@jaritanet/remote";
 import * as command from "@pulumi/command";
 import type * as hcloud from "@pulumi/hcloud";
 import * as pulumi from "@pulumi/pulumi";
@@ -92,23 +93,7 @@ fi`,
     `${p}k3s-install`,
     {
       connection,
-      create: pulumi.interpolate`set -euo pipefail
-# Pulumi SSHes in the moment the server answers, which is long before the box
-# is actually usable. Two separate waits are needed:
-#   1. cloud-init, or directories these scripts write into do not exist yet;
-#   2. the dpkg lock, because Ubuntu runs unattended-upgrades *after* cloud-init
-#      finishes and holds it for minutes — every apt call here exits 100 until
-#      it lets go, and the vendor install scripts give no way to pass a timeout.
-# Both are idempotent and return immediately once the box has settled.
-cloud-init status --wait >/dev/null 2>&1 || true
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes; every apt call exits 100 until it lets go. Telling apt
-# itself to wait is the only approach that also covers the vendor install
-# scripts (xray, hysteria), which shell out to apt with no flags we can pass.
-# A polling loop here cannot help those, and fuser is not even installed on
-# the minimal cloud image anyway.
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\n' > /etc/apt/apt.conf.d/99-lock-timeout
+      create: pulumi.interpolate`${remotePreamble}
 # Cluster DNS upstream. Without this k3s points kubelet — and so coredns —
 # at the host's /etc/resolv.conf, which on Ubuntu is systemd-resolved's stub
 # at 127.0.0.53. coredns runs in a pod network namespace, where that address

--- a/packages/hetzner/src/vps.ts
+++ b/packages/hetzner/src/vps.ts
@@ -1,3 +1,4 @@
+import { remotePreamble } from "@jaritanet/remote";
 import * as command from "@pulumi/command";
 import type * as hcloud from "@pulumi/hcloud";
 import * as pulumi from "@pulumi/pulumi";
@@ -174,16 +175,13 @@ export function createAutomaticPatching(
     `${name}-automatic-patching`,
     {
       connection,
-      create: pulumi.secret(pulumi.interpolate`set -euo pipefail
-# Same wait the k3s install opens with, and needed here for the same reason:
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes, and \`pro attach\` shells out to apt. This command depends
-# only on the server, so on a freshly created box it races both — and since
-# changing the image replaces the server, a fresh box is the normal case rather
-# than the first-run one. Under \`set -e\` losing that race is a failed deploy.
-cloud-init status --wait >/dev/null 2>&1 || true
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\\n' > /etc/apt/apt.conf.d/99-lock-timeout
+      // The preamble earns its place here in particular: `pro attach` shells
+      // out to apt, and this command depends only on the server, so on a
+      // freshly created box it races cloud-init and the dpkg lock both. Under
+      // `set -e` losing that race is a failed deploy, and since changing the
+      // image replaces the server, a fresh box is the normal case rather than
+      // the first-run one.
+      create: pulumi.secret(pulumi.interpolate`${remotePreamble}
 
 cat > /etc/apt/apt.conf.d/51unattended-upgrades-local << 'EOF'
 Unattended-Upgrade::Automatic-Reboot "true";

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -14,6 +14,7 @@
     "@jaritanet/k8s": "workspace:*",
     "@jaritanet/mariastew": "workspace:*",
     "@jaritanet/mcp-gateway": "workspace:*",
+    "@jaritanet/remote": "workspace:*",
     "@jaritanet/vpn": "workspace:*",
     "@pulumi/command": "1.2.1",
     "@pulumi/hcloud": "1.35.0",

--- a/packages/infra/src/gateway.ts
+++ b/packages/infra/src/gateway.ts
@@ -5,6 +5,7 @@ import {
   createNetworkTuning,
   inboundRule,
 } from "@jaritanet/hetzner";
+import { remotePreamble } from "@jaritanet/remote";
 import {
   createHysteriaSystemd,
   createTailscaleSystemd,
@@ -153,23 +154,7 @@ export function createGateway(
       "gateway-unbound",
       {
         connection,
-        create: `set -euo pipefail
-# Pulumi SSHes in the moment the server answers, which is long before the box
-# is actually usable. Two separate waits are needed:
-#   1. cloud-init, or directories these scripts write into do not exist yet;
-#   2. the dpkg lock, because Ubuntu runs unattended-upgrades *after* cloud-init
-#      finishes and holds it for minutes — every apt call here exits 100 until
-#      it lets go, and the vendor install scripts give no way to pass a timeout.
-# Both are idempotent and return immediately once the box has settled.
-cloud-init status --wait >/dev/null 2>&1 || true
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes; every apt call exits 100 until it lets go. Telling apt
-# itself to wait is the only approach that also covers the vendor install
-# scripts (xray, hysteria), which shell out to apt with no flags we can pass.
-# A polling loop here cannot help those, and fuser is not even installed on
-# the minimal cloud image anyway.
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\n' > /etc/apt/apt.conf.d/99-lock-timeout
+        create: `${remotePreamble}
 export DEBIAN_FRONTEND=noninteractive
 apt-get update && apt-get install -y unbound ca-certificates
 cat > /etc/unbound/unbound.conf.d/jaritanet.conf << 'EOF'

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@jaritanet/remote",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shell shared by everything that provisions a box over SSH",
+  "license": "ISC",
+  "author": "James Cleveland <jc@blit.cc>",
+  "files": [
+    "src"
+  ],
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/remote/src/index.ts
+++ b/packages/remote/src/index.ts
@@ -1,0 +1,1 @@
+export { remotePreamble } from "./preamble.ts";

--- a/packages/remote/src/preamble.ts
+++ b/packages/remote/src/preamble.ts
@@ -1,0 +1,24 @@
+/**
+ * What every `command.remote.Command` in this repo opens with.
+ *
+ * Pulumi SSHes in the moment the server answers, which is long before the box
+ * is usable, so two things have to be waited on. cloud-init, or the directories
+ * these scripts write into do not exist yet; and the dpkg lock, because Ubuntu
+ * runs unattended-upgrades *after* cloud-init finishes and holds it for
+ * minutes, so every apt call exits 100 until it lets go.
+ *
+ * Telling apt itself to wait is the only approach that also covers the vendor
+ * install scripts (k3s, xray, hysteria, tailscale), which shell out to apt with
+ * no flags we can pass. A polling loop here cannot help those, and `fuser` is
+ * not installed on the minimal cloud image anyway.
+ *
+ * Both are idempotent and return immediately once the box has settled, so every
+ * command opens with this rather than only whichever one reaches the box first
+ * — that ordering is a property of the dependency graph, not something a script
+ * can assume. It is a string rather than a function because the shell is the
+ * same on every box; nothing about it varies per call site.
+ */
+export const remotePreamble = `set -euo pipefail
+cloud-init status --wait >/dev/null 2>&1 || true
+mkdir -p /etc/apt/apt.conf.d
+printf 'DPkg::Lock::Timeout "600";\\n' > /etc/apt/apt.conf.d/99-lock-timeout`;

--- a/packages/remote/tsconfig.json
+++ b/packages/remote/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../tsconfig.json"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/vpn/package.json
+++ b/packages/vpn/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@jaritanet/k8s": "workspace:*",
+    "@jaritanet/remote": "workspace:*",
     "@pulumi/command": "1.2.1",
     "@pulumi/kubernetes": "4.30.0",
     "@pulumi/pulumi": "3.239.0",

--- a/packages/vpn/src/hysteria-systemd.ts
+++ b/packages/vpn/src/hysteria-systemd.ts
@@ -1,3 +1,4 @@
+import { remotePreamble } from "@jaritanet/remote";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
@@ -56,23 +57,7 @@ export function createHysteriaSystemd(
     `${p}hysteria-install`,
     {
       connection,
-      create: pulumi.interpolate`set -euo pipefail
-# Pulumi SSHes in the moment the server answers, which is long before the box
-# is actually usable. Two separate waits are needed:
-#   1. cloud-init, or directories these scripts write into do not exist yet;
-#   2. the dpkg lock, because Ubuntu runs unattended-upgrades *after* cloud-init
-#      finishes and holds it for minutes — every apt call here exits 100 until
-#      it lets go, and the vendor install scripts give no way to pass a timeout.
-# Both are idempotent and return immediately once the box has settled.
-cloud-init status --wait >/dev/null 2>&1 || true
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes; every apt call exits 100 until it lets go. Telling apt
-# itself to wait is the only approach that also covers the vendor install
-# scripts (xray, hysteria), which shell out to apt with no flags we can pass.
-# A polling loop here cannot help those, and fuser is not even installed on
-# the minimal cloud image anyway.
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\n' > /etc/apt/apt.conf.d/99-lock-timeout
+      create: pulumi.interpolate`${remotePreamble}
 export DEBIAN_FRONTEND=noninteractive
 apt-get update && apt-get install -y openssl
 # Official installer: binary + hysteria-server.service systemd unit.
@@ -94,23 +79,7 @@ fi`,
     `${p}hysteria-config`,
     {
       connection,
-      create: pulumi.interpolate`set -euo pipefail
-# Pulumi SSHes in the moment the server answers, which is long before the box
-# is actually usable. Two separate waits are needed:
-#   1. cloud-init, or directories these scripts write into do not exist yet;
-#   2. the dpkg lock, because Ubuntu runs unattended-upgrades *after* cloud-init
-#      finishes and holds it for minutes — every apt call here exits 100 until
-#      it lets go, and the vendor install scripts give no way to pass a timeout.
-# Both are idempotent and return immediately once the box has settled.
-cloud-init status --wait >/dev/null 2>&1 || true
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes; every apt call exits 100 until it lets go. Telling apt
-# itself to wait is the only approach that also covers the vendor install
-# scripts (xray, hysteria), which shell out to apt with no flags we can pass.
-# A polling loop here cannot help those, and fuser is not even installed on
-# the minimal cloud image anyway.
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\n' > /etc/apt/apt.conf.d/99-lock-timeout
+      create: pulumi.interpolate`${remotePreamble}
 # Every listener is the same server on a different port, so the config is
 # written by one function and the extras ride the installer's
 # hysteria-server@.service template unit (reads /etc/hysteria/<instance>.yaml).

--- a/packages/vpn/src/tailscale-systemd.ts
+++ b/packages/vpn/src/tailscale-systemd.ts
@@ -1,3 +1,4 @@
+import { remotePreamble } from "@jaritanet/remote";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import type * as z from "zod";
@@ -44,23 +45,7 @@ export function createTailscaleSystemd(
     `${p}tailscale-up`,
     {
       connection,
-      create: pulumi.interpolate`set -euo pipefail
-# Pulumi SSHes in the moment the server answers, which is long before the box
-# is actually usable. Two separate waits are needed:
-#   1. cloud-init, or directories these scripts write into do not exist yet;
-#   2. the dpkg lock, because Ubuntu runs unattended-upgrades *after* cloud-init
-#      finishes and holds it for minutes — every apt call here exits 100 until
-#      it lets go, and the vendor install scripts give no way to pass a timeout.
-# Both are idempotent and return immediately once the box has settled.
-cloud-init status --wait >/dev/null 2>&1 || true
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes; every apt call exits 100 until it lets go. Telling apt
-# itself to wait is the only approach that also covers the vendor install
-# scripts (xray, hysteria), which shell out to apt with no flags we can pass.
-# A polling loop here cannot help those, and fuser is not even installed on
-# the minimal cloud image anyway.
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\n' > /etc/apt/apt.conf.d/99-lock-timeout
+      create: pulumi.interpolate`${remotePreamble}
 export DEBIAN_FRONTEND=noninteractive
 if ! command -v tailscale >/dev/null 2>&1; then
   curl -fsSL https://tailscale.com/install.sh | sh

--- a/packages/vpn/src/xray-systemd.ts
+++ b/packages/vpn/src/xray-systemd.ts
@@ -1,3 +1,4 @@
+import { remotePreamble } from "@jaritanet/remote";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
@@ -78,23 +79,7 @@ export function createXraySystemd(
     `${p}xray-install`,
     {
       connection,
-      create: pulumi.interpolate`set -euo pipefail
-# Pulumi SSHes in the moment the server answers, which is long before the box
-# is actually usable. Two separate waits are needed:
-#   1. cloud-init, or directories these scripts write into do not exist yet;
-#   2. the dpkg lock, because Ubuntu runs unattended-upgrades *after* cloud-init
-#      finishes and holds it for minutes — every apt call here exits 100 until
-#      it lets go, and the vendor install scripts give no way to pass a timeout.
-# Both are idempotent and return immediately once the box has settled.
-cloud-init status --wait >/dev/null 2>&1 || true
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes; every apt call exits 100 until it lets go. Telling apt
-# itself to wait is the only approach that also covers the vendor install
-# scripts (xray, hysteria), which shell out to apt with no flags we can pass.
-# A polling loop here cannot help those, and fuser is not even installed on
-# the minimal cloud image anyway.
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\n' > /etc/apt/apt.conf.d/99-lock-timeout
+      create: pulumi.interpolate`${remotePreamble}
 export DEBIAN_FRONTEND=noninteractive
 XRAY_VERSION=$(printf '%s' "${xray.version}" | sed 's/^v//')
 
@@ -131,23 +116,7 @@ fi`,
     `${p}xray-config`,
     {
       connection,
-      create: pulumi.interpolate`set -euo pipefail
-# Pulumi SSHes in the moment the server answers, which is long before the box
-# is actually usable. Two separate waits are needed:
-#   1. cloud-init, or directories these scripts write into do not exist yet;
-#   2. the dpkg lock, because Ubuntu runs unattended-upgrades *after* cloud-init
-#      finishes and holds it for minutes — every apt call here exits 100 until
-#      it lets go, and the vendor install scripts give no way to pass a timeout.
-# Both are idempotent and return immediately once the box has settled.
-cloud-init status --wait >/dev/null 2>&1 || true
-# Ubuntu runs unattended-upgrades once cloud-init finishes and holds the dpkg
-# lock for minutes; every apt call exits 100 until it lets go. Telling apt
-# itself to wait is the only approach that also covers the vendor install
-# scripts (xray, hysteria), which shell out to apt with no flags we can pass.
-# A polling loop here cannot help those, and fuser is not even installed on
-# the minimal cloud image anyway.
-mkdir -p /etc/apt/apt.conf.d
-printf 'DPkg::Lock::Timeout "600";\n' > /etc/apt/apt.conf.d/99-lock-timeout
+      create: pulumi.interpolate`${remotePreamble}
 PRIV=$(cat /usr/local/etc/xray/private.key)
 cat > /usr/local/etc/xray/config.json << XRAY_EOF
 {


### PR DESCRIPTION
Closes #337.

The cloud-init wait and the dpkg lock-timeout that follows it were copy-pasted
into eight `command.remote.Command` bodies across six files, with a ninth
variant in `vps.ts` whose comment said it was "the same wait the k3s install
opens with" instead of being it. A fix to the wait landed in one copy and the
rest kept the bug.

They now share `remotePreamble` from a new leaf package, `@jaritanet/remote`.

## Why a new package

The copies live in `@jaritanet/vpn`, `@jaritanet/hetzner` and `packages/infra`,
so the shared string has to sit below all three. `@jaritanet/k8s` is the only
existing sideways import and is Kubernetes templates; `hetzner` is a cloud
provider's package, and the `-systemd` transports not depending on one is the
property that makes them work against any box with an SSH port (see the comment
on `SshConnection` in `vpn/src/ssh.ts`). `@jaritanet/remote` has no
dependencies at all and belongs to no cloud, so both can import it without
either importing the other. README and CLAUDE.md are updated: the invariant is
now two leaves rather than one.

## What changed in the emitted shell

The two comment blocks were redundant — the second re-explained the dpkg lock
the first had already covered — and both were being shipped over the wire to
boxes nobody reads scripts on. The explanation now lives in a docblock on the
export, and the shell is four lines. `vps.ts`'s site-specific reasoning (`pro
attach` shells out to apt, and that command depends only on the server, so it
races both waits on a fresh box) is kept as a TypeScript comment at the call
site rather than dropped.

## Deploy impact

`create` is not byte-identical to what's in state, and pulumi-command re-runs
`create` on update when no `update` is set, so the affected commands re-run
once. Only `triggers[*]` forces replacement, so nothing is replaced.

The preview says it exactly: **3 to update, 163 unchanged, 0 replaced** —
`k3s-install`, `gateway-automatic-patching` and `tailscale-up`. All three are
idempotent: the k3s installer is a no-op at the pinned version, `pro attach` is
guarded by an is-attached check, and the tailnet node persists after first auth
(`tailscale-up` is not gated on `sshTransports` because tailnet membership is
what k3s reads its `node-ip` from, not a transport).

`gateway-unbound` and the xray/hysteria `-systemd` units aren't instantiated on
this config at all. They'd re-run on a stack with `edges`, which is a restart of
a few seconds each.

## Verify

- `mise run check` — lint, format, typecheck, 160 tests, all green
- The preamble renders to exactly the four lines it should: `set -euo pipefail`,
  the `cloud-init status --wait`, the `mkdir`, and the `printf` writing
  `DPkg::Lock::Timeout "600";`. The old sites emitted a literal newline inside
  the printf's single quotes; this emits `\n` for printf to interpret. Same
  file on the box either way.
- `git grep 'cloud-init status'` returns one hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5mAp7G4joaaTbKt2Gw35f
