### PR TITLE
372 fix(mariastew): a metadata pass is not a finished torrent

### DIFF
--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.26] - 2026-08-08
+
+### Fixed
+
+- A magnet no longer announces itself as downloaded before it starts downloading. The metadata pass reaches aria2's `Complete` when the *torrent file* arrives, and every reading taken off its byte counters was answering about the wrong download: the row turned green and said "downloaded" beside the torrent's name, filled its bar, showed "0s left", and the completion watch sent Telegram a finished message and swept a directory nothing had been written to. A metadata pass now measures nothing (`Download::display_totals`), so the bar is indeterminate, the size and ETA are absent, and the state stays *finding peers* until the real download exists ([#372](https://github.com/radiosilence/jaritanet/issues/372))
+- No ETA before the size is known. A resolving magnet moves bytes at a real rate with no total to spend them against, which divided out to "0s left" on a torrent that had not started ([#372](https://github.com/radiosilence/jaritanet/issues/372))
+
 ## [0.1.25] - 2026-08-08
 
 ### Removed

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -121,6 +121,16 @@ than a percentage:
   the badge and the activity log. Nothing in one `tellStatus` separates a
   magnet nobody has from one that is merely slow. How long it has been does,
   and that is what the log's timestamps answer.
+
+  It also holds all the way through, which it did not: the metadata pass
+  reaches aria2's `Complete` the moment the *torrent file* arrives, and every
+  reading taken off its byte counters was answering about the wrong download.
+  For a second the row went green, said "downloaded" beside the torrent's
+  name, filled its bar and put "0s left" under it, Telegram announced a
+  finished download, `sweep_garbage` walked a directory nothing had been
+  written to — and then the torrent started downloading. A metadata pass now
+  measures nothing at all (`Download::display_totals`), so it renders as the
+  unknown it is: indeterminate bar, no size, no ETA, still *finding peers*.
 - **Readings, not just a bar:** bytes done against total, up and down rates,
   bytes given back and the share ratio, peers against seeders, and the piece
   count and size — which is the explanation for both lumpy progress and for a

--- a/apps/mariastew/src/aria2.rs
+++ b/apps/mariastew/src/aria2.rs
@@ -170,6 +170,12 @@ impl From<RawFile> for File {
     }
 }
 
+/// What aria2 calls a magnet it has not resolved yet: `[METADATA]<dn>`, or
+/// `[METADATA]<infohash>` when the magnet carried no display name. The one
+/// place this string is spelled out — it is both how a metadata pass is told
+/// apart and what has to come off before anyone reads the name.
+const METADATA_PREFIX: &str = "[METADATA]";
+
 #[derive(Clone, Debug)]
 pub struct Download {
     pub gid: String,
@@ -251,7 +257,19 @@ impl Download {
     /// of four chosen showed the whole torrent's size next to a bar tracking
     /// only the chosen one. Falls back to the download-level counters, which
     /// is right until the file list arrives and nothing else can answer.
+    ///
+    /// Nothing at all for a metadata pass. Its counters are the torrent
+    /// *file's* — a few kilobytes fetched from whoever has it — and every
+    /// reading built on them was answering about the wrong download: a bar
+    /// that filled and turned green, a size of "34 KB" beside the torrent's
+    /// name, an ETA that read zero, and an `is_finished` that told the
+    /// notifier to announce the torrent as downloaded before a single content
+    /// byte existed. There is nothing to measure yet, so this measures
+    /// nothing and everything downstream renders as the unknown it is.
     pub fn display_totals(&self) -> (u64, u64) {
+        if self.is_metadata() {
+            return (0, 0);
+        }
         self.selected_totals()
             .unwrap_or((self.total_length, self.completed_length))
     }
@@ -292,16 +310,32 @@ impl Download {
     }
 
     pub fn is_metadata(&self) -> bool {
-        self.name().starts_with("[METADATA]")
+        self.name().starts_with(METADATA_PREFIX)
+    }
+
+    /// The name for anything a person reads — a row, a Telegram message.
+    ///
+    /// aria2 names an unresolved magnet `[METADATA]<dn>`, and the marker is
+    /// how the download is classified rather than something worth showing:
+    /// the state already says what it is doing, and the title after the
+    /// marker is the one the torrent will keep.
+    pub fn display_name(&self) -> &str {
+        self.name().trim_start_matches(METADATA_PREFIX)
     }
 
     /// `None` when nothing is moving — an ETA with zero speed is infinity, and
-    /// one taken off a collapsing rate is misleading.
+    /// one taken off a collapsing rate is misleading. Also `None` when the
+    /// size is not known yet: a resolving magnet moves bytes at a real rate
+    /// with no total to subtract them from, and dividing zero remaining by it
+    /// put "0s left" beside a torrent that had not started.
     pub fn eta_secs(&self) -> Option<u64> {
         if self.download_speed == 0 || self.is_finished() {
             return None;
         }
         let (total, done) = self.display_totals();
+        if total == 0 {
+            return None;
+        }
         total
             .checked_sub(done)
             .map(|left| left / self.download_speed)
@@ -356,13 +390,22 @@ impl Download {
     /// Finished *for display*. With `--seed-ratio=0.0`, status never reaches
     /// Complete on its own, and aggregate byte counts lie with selections. A
     /// torrent is finished when all *selected* files are done.
+    ///
+    /// A metadata pass never is. It reaches `Complete` the moment the torrent
+    /// file arrives, which is the beginning of the download rather than the
+    /// end of one — and every consumer here reads this as the torrent's:
+    /// the badge went green and said "downloaded", the notifier sent Telegram
+    /// a finished message, the garbage sweep walked a directory nothing had
+    /// been written to, and the remove button offered to keep files that did
+    /// not exist. All of it about a torrent that then started downloading.
     pub fn is_finished(&self) -> bool {
+        if self.is_metadata() {
+            return false;
+        }
         if self.status == Status::Complete {
             return true;
         }
-        let (total, done) = self
-            .selected_totals()
-            .unwrap_or((self.total_length, self.completed_length));
+        let (total, done) = self.display_totals();
         total > 0 && done >= total
     }
 
@@ -1023,6 +1066,65 @@ mod tests {
         d.total_length = 100;
         d.completed_length = 25;
         assert_eq!(d.percent(), Some(25.0));
+    }
+
+    /// A magnet whose metadata has fully arrived, as aria2 reports it just
+    /// before `follow-torrent` spawns the real download: `Complete`, with one
+    /// file — itself — every byte of which is in.
+    fn resolved_metadata_pass() -> Download {
+        let mut d = download(Status::Complete);
+        d.bittorrent_name = Some("[METADATA]Some.Show.S01".to_string());
+        d.total_length = 34_000;
+        d.completed_length = 34_000;
+        d.files = vec![file(1, 34_000, 34_000, true)];
+        d.download_speed = 34_000;
+        d.upload_length = 1_000;
+        d
+    }
+
+    /// The dance in #372, in one assertion each. A metadata pass reaches
+    /// `Complete` when the torrent *file* arrives, and every reading below
+    /// was answering as though the torrent had: the badge went green and
+    /// said "downloaded", `notify`'s watcher — whose terminal test is this
+    /// same `is_finished` — sent Telegram a finished message and swept a
+    /// directory nothing had been written to, and then the real download
+    /// started, which is the part that was never in doubt.
+    #[test]
+    fn a_resolved_metadata_pass_is_not_a_finished_torrent() {
+        let d = resolved_metadata_pass();
+        assert!(!d.is_finished());
+        assert_eq!(d.health(), Health::Resolving);
+    }
+
+    /// Its 34 KB are the torrent file's, so there is nothing yet to measure
+    /// and nothing is what these say — which is what the row already renders
+    /// as an indeterminate bar and a size of "—".
+    #[test]
+    fn a_metadata_passes_own_bytes_are_not_the_torrents_progress() {
+        let d = resolved_metadata_pass();
+        assert_eq!(d.percent(), None);
+        assert_eq!(d.eta_secs(), None);
+        assert_eq!(d.ratio(), None);
+    }
+
+    /// The magnet's own title, which is the only part of `[METADATA]<dn>`
+    /// worth showing — see `display_name`.
+    #[test]
+    fn a_metadata_pass_is_named_after_the_torrent_it_will_become() {
+        assert_eq!(resolved_metadata_pass().display_name(), "Some.Show.S01");
+        let mut d = download(Status::Active);
+        d.bittorrent_name = Some("Some.Show.S01".to_string());
+        assert_eq!(d.display_name(), "Some.Show.S01");
+    }
+
+    /// An unresolved magnet has a real download speed and no size to spend it
+    /// against, which used to divide out to "0s left" beside a torrent that
+    /// had not started.
+    #[test]
+    fn no_eta_before_the_size_is_known() {
+        let mut d = download(Status::Active);
+        d.download_speed = 1_000;
+        assert_eq!(d.eta_secs(), None);
     }
 
     #[test]

--- a/apps/mariastew/src/notify.rs
+++ b/apps/mariastew/src/notify.rs
@@ -101,13 +101,13 @@ pub fn spawn_watcher(state: AppState) {
                     if d.status == Status::Error {
                         let error = d.error_message.as_deref().unwrap_or("unknown error");
                         state.activity.record(&d.gid, format!("failed — {error}"));
-                        failed(&state, d.name(), error).await;
+                        failed(&state, d.display_name(), error).await;
                     } else {
                         sweep_garbage(&state, d).await;
                         state
                             .activity
                             .record(&d.gid, format!("finished — {}", d.dir));
-                        finished(&state, d.name(), &d.dir).await;
+                        finished(&state, d.display_name(), &d.dir).await;
                     }
                 }
                 seen.insert(

--- a/apps/mariastew/src/views.rs
+++ b/apps/mariastew/src/views.rs
@@ -169,10 +169,7 @@ impl Row {
 
         Row {
             gid: d.gid.clone(),
-            // A still-resolving magnet is named `[METADATA]<infohash>` by
-            // aria2. The marker is how the row is classified, not something
-            // to read — the state badge already says what it is doing.
-            name: d.name().trim_start_matches("[METADATA]").to_string(),
+            name: d.display_name().to_string(),
             percent,
             percent_display: percent.map(|p| format!("{p:.0}")),
             health,
@@ -1408,6 +1405,29 @@ mod tests {
         });
         assert!(finished.contains("badge-success"));
         assert!(!render(&moving()).contains("badge-success"));
+    }
+
+    /// #372: the metadata pass reaches `Complete` when the *torrent file*
+    /// arrives, so for a second the row went green, said "downloaded" beside
+    /// the torrent's name, and showed a full bar — and then the download
+    /// started. The marker comes off the name because it is not worth
+    /// reading; nothing else about the row is allowed to claim the torrent
+    /// arrived with it.
+    #[test]
+    fn a_resolved_metadata_pass_still_renders_as_a_torrent_that_has_not_started() {
+        let html = render(&Download {
+            status: Status::Complete,
+            bittorrent_name: Some("[METADATA]Show.S01E01".to_string()),
+            total_length: 34_000,
+            completed_length: 34_000,
+            ..moving()
+        });
+        assert!(html.contains("Show.S01E01") && !html.contains("[METADATA]"));
+        assert!(html.contains("finding peers"), "{html}");
+        assert!(!html.contains("badge-success") && !html.contains("progress-success"));
+        // The indeterminate bar and the "—" beside `done` are the same
+        // condition — see row.html.
+        assert!(!html.contains("value=\""), "the bar claimed a percentage");
     }
 
     /// A finished torrent is one press from being out of the list, and the


### PR DESCRIPTION
Closes #372.

Adding a magnet briefly showed the torrent as **downloaded** — green badge, full bar, "0s left" — and sent a Telegram "finished" message, before the download actually started.

aria2 resolves a magnet under its own gid. That metadata pass reaches `Complete` the moment the **torrent file** arrives, carrying its own byte counters — a few kilobytes fetched from whoever had it. Everything downstream read those as the torrent's:

| reading | what it said | about |
|---|---|---|
| `is_finished` | true | 34 KB of torrent file |
| badge / bar | "downloaded", 100%, green | — |
| `eta_secs` | "0s left" | — |
| `notify` watcher | Telegram "finished" + `sweep_garbage` | a directory nothing had been written to |
| remove button | "keep the files" | files that did not exist |

## The change

`Download::display_totals` returns `(0, 0)` for a metadata pass — there is nothing to measure yet, so it measures nothing. `percent`, `eta_secs`, `ratio` and `is_finished` all fall out of that, and the row renders as the unknown it already knows how to render: indeterminate bar, size `—`, state *finding peers*, until the real download exists and replaces it.

Two smaller things that came with it:

- `eta_secs` returns `None` when the total is zero. A resolving magnet moves bytes at a real rate with no size to spend them against, which divided out to "0s left" on any torrent that had not started — metadata pass or not.
- `Download::display_name` trims the `[METADATA]` marker, so the prefix is spelled out in one place instead of two and Telegram no longer names a failed add `[METADATA]Some.Show`.

## Verifying

`cargo test` in `apps/mariastew` — the behaviour is pinned by `a_resolved_metadata_pass_is_not_a_finished_torrent`, `a_metadata_passes_own_bytes_are_not_the_torrents_progress` and `no_eta_before_the_size_is_known` in `src/aria2.rs`, plus `a_resolved_metadata_pass_still_renders_as_a_torrent_that_has_not_started` in `src/views.rs`, which renders the row and asserts no `badge-success`, no `progress-success`, no percentage and no `[METADATA]` in the name.

The fixture is aria2's own reported shape at that instant: `Complete`, `bittorrentName` of `[METADATA]<dn>`, one file — itself — fully downloaded.

Version bumped to 0.1.26; the image pin moves when the updater sees the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEWnQLedoSY1Tf4eYdhCbb