### PR TITLE
360 fix(metrics): what the first deploy found

### DIFF
--- a/packages/ingress/src/ingress.ts
+++ b/packages/ingress/src/ingress.ts
@@ -59,25 +59,22 @@ export function createIngress(
           },
         },
         // Per-route request rates, response codes and latencies — the other
-        // half of "is anything actually broken". The router and service labels
-        // are off by default and are the whole point: without them the numbers
-        // are a single total for the whole estate.
+        // half of "is anything actually broken". Only the labels are set here:
+        // the chart enables its Prometheus endpoint by default and annotates
+        // its own pod with `prometheus.io/scrape` and the metrics entrypoint's
+        // port, which is what @jaritanet/metrics discovers it by. Adding a
+        // `podAnnotations` block of our own is both redundant and rejected —
+        // the key lives under `deployment`, and the chart's values schema
+        // fails the release rather than ignoring it.
         //
-        // The endpoint is on the chart's own `metrics` entrypoint (:9100 inside
-        // the pod, not on the host), and the annotations are what
-        // @jaritanet/metrics discovers it by. Unconditional: an unscraped
-        // counter costs nothing, and gating it would put "is there a metrics
-        // stack" into the config of the thing that publishes one.
+        // `addRoutersLabels` is the one that is off by default and is the whole
+        // point: without it the numbers are a single total for the estate.
         metrics: {
           prometheus: {
             addEntryPointsLabels: true,
             addRoutersLabels: true,
             addServicesLabels: true,
           },
-        },
-        podAnnotations: {
-          "prometheus.io/scrape": "true",
-          "prometheus.io/port": "9100",
         },
         service: {
           // `service.spec.type`, not `service.type` — same trap as

--- a/packages/metrics/src/metrics.ts
+++ b/packages/metrics/src/metrics.ts
@@ -325,8 +325,9 @@ export function createMetrics(
                   "-remoteWrite.tmpDataPath=/buffer",
                   // What the home box gets to hold while its uplink is down.
                   // Beyond it the oldest blocks are dropped rather than the
-                  // node's disk filling.
-                  "-remoteWrite.maxDiskUsagePerURL=512MB",
+                  // node's disk filling. MiB rather than MB: 512MB is below
+                  // vmagent's own minimum and is rounded up with a warning.
+                  "-remoteWrite.maxDiskUsagePerURL=512MiB",
                   "-httpListenAddr=:8429",
                 ],
                 env: [

--- a/packages/metrics/src/scrape.test.ts
+++ b/packages/metrics/src/scrape.test.ts
@@ -41,6 +41,55 @@ describe("scrapeConfig", () => {
     });
   });
 
+  /**
+   * A pod declaring four container ports is discovered four times. Rewriting
+   * the address instead of selecting the port made three of those duplicates
+   * that vmagent dropped, loudly, on every reload.
+   */
+  it("discovers one target per annotated pod, not one per container port", () => {
+    const relabels = jobs.pods?.relabel_configs as {
+      source_labels?: string[];
+      action?: string;
+    }[];
+    expect(relabels).toContainEqual({
+      source_labels: [
+        "__meta_kubernetes_pod_container_port_number",
+        "__meta_kubernetes_pod_annotation_prometheus_io_port",
+      ],
+      action: "keep_if_equal",
+    });
+    expect(relabels.some((r) => r.source_labels?.includes("__address__"))).toBe(
+      false,
+    );
+  });
+
+  /**
+   * k3s serves the apiserver, etcd and scheduler registries from the kubelet's
+   * port, and their latency histograms were two thirds of the whole estate's
+   * series on the first deploy.
+   */
+  it("drops the control plane's histogram buckets from the kubelet", () => {
+    const drop = (
+      jobs.kubelet?.metric_relabel_configs as {
+        regex: string;
+        action: string;
+      }[]
+    )?.[0];
+    expect(drop?.action).toBe("drop");
+    const matcher = new RegExp(`^${drop?.regex}$`);
+    expect(matcher.test("apiserver_request_duration_seconds_bucket")).toBe(
+      true,
+    );
+    expect(matcher.test("etcd_request_duration_seconds_bucket")).toBe(true);
+    // The count and sum survive, so rates and mean latencies still answer.
+    expect(matcher.test("apiserver_request_duration_seconds_count")).toBe(
+      false,
+    );
+    // cAdvisor and the kubelet's own metrics are the point of the job.
+    expect(matcher.test("kubelet_running_pods")).toBe(false);
+    expect(matcher.test("container_memory_working_set_bytes")).toBe(false);
+  });
+
   /** Discovery across every namespace would pull in the cluster's own pods. */
   it("discovers pods in its own namespace only", () => {
     expect(jobs.pods?.kubernetes_sd_configs).toEqual([

--- a/packages/metrics/src/scrape.ts
+++ b/packages/metrics/src/scrape.ts
@@ -53,6 +53,30 @@ export function scrapeConfig(scrapeInterval: string) {
     static_configs: onThisNode(10250),
   });
 
+  /**
+   * k3s runs the apiserver, etcd, scheduler and controller-manager inside the
+   * same process as the kubelet, so they share one Prometheus registry and the
+   * kubelet's `/metrics` hands back all of it. Measured on the first deploy:
+   * 40k of the estate's 61k series came from that one endpoint, nearly all of
+   * it latency histograms of the control plane talking to itself.
+   *
+   * The buckets go and the `_count`/`_sum` stay, so request rates and mean
+   * latencies survive and only the per-bucket breakdown — the part that
+   * multiplies by twelve — does not. That is the difference between a store
+   * that fits in single-digit GB a year, as planned, and one that fills the
+   * gateway's disk inside a year.
+   */
+  const dropControlPlaneHistograms = {
+    metric_relabel_configs: [
+      {
+        source_labels: ["__name__"],
+        regex:
+          "(apiserver|etcd|scheduler|workqueue|apiextensions_apiserver|authentication|authorization)_.*_bucket",
+        action: "drop",
+      },
+    ],
+  };
+
   return yaml.stringify({
     global: {
       scrape_interval: scrapeInterval,
@@ -63,7 +87,11 @@ export function scrapeConfig(scrapeInterval: string) {
     },
     scrape_configs: [
       { job_name: "node-exporter", static_configs: onThisNode(9100) },
-      { job_name: "kubelet", ...kubelet("/metrics") },
+      {
+        job_name: "kubelet",
+        ...kubelet("/metrics"),
+        ...dropControlPlaneHistograms,
+      },
       { job_name: "cadvisor", ...kubelet("/metrics/cadvisor") },
       // NetworkPolicy drop counters, which is how "the policies are enforced
       // now" stops being a belief. `up` going to 0 here means Cilium was
@@ -90,15 +118,22 @@ export function scrapeConfig(scrapeInterval: string) {
             regex: "true",
             action: "keep",
           },
-          // The annotated port replaces whatever the first container declares.
+          // Discovery emits one target per declared container port, so a pod
+          // with four of them — Traefik has web, websecure, traefik and
+          // metrics — produced four targets that a port rewrite then collapsed
+          // onto one address, three of which were dropped as duplicates with an
+          // error logged for each. Selecting the port the annotation names
+          // instead means one target is discovered rather than one surviving.
+          //
+          // The contract this creates: the annotated port has to be a declared
+          // `containerPort`. A pod annotating a port it does not declare is not
+          // scraped, which the "Scrape targets up" panel is there to show.
           {
             source_labels: [
-              "__address__",
+              "__meta_kubernetes_pod_container_port_number",
               "__meta_kubernetes_pod_annotation_prometheus_io_port",
             ],
-            regex: String.raw`([^:]+)(?::\d+)?;(\d+)`,
-            replacement: "$1:$2",
-            target_label: "__address__",
+            action: "keep_if_equal",
           },
           {
             source_labels: [


### PR DESCRIPTION
Follow-up to #376. Three corrections from first contact with the cluster; the
first one is why `main` is red.

## `podAnnotations` broke the Traefik release

Not a top-level chart value — it lives under `deployment`, and Traefik's
`values.schema.json` fails the release rather than ignoring the key. `pulumi
preview` does not validate Helm values against a chart schema, so this passed
preview locally and in CI and failed on `up`.

It was also unnecessary. The chart's `_podtemplate.tpl` writes
`prometheus.io/scrape`, `path` and `port` itself whenever its Prometheus
endpoint is on, which is the default — so Traefik was being scraped correctly the
whole time. The block is deleted rather than moved; the label settings are the
only thing still needed from the chart.

## One target per pod, not one per container port

Discovery emits a target per declared `containerPort`. Traefik declares four, so
the address rewrite mapped all four onto `:9100` and vmagent dropped three as
duplicates with an error apiece, on every config reload. The port the annotation
names is now selected instead of the address being rewritten.

The contract this creates: an annotated port has to be a declared
`containerPort`. A pod that annotates one it does not declare is not scraped —
which the "Scrape targets up" panel exists to show.

## The kubelet was serving the whole control plane

k3s runs the apiserver, etcd, scheduler and controller-manager in the same
process as the kubelet, sharing one Prometheus registry, so `/metrics` on 10250
hands back all of it. Measured: **40k of the estate's 61k series** came from that
one endpoint, nearly all of it latency histograms of the control plane talking to
itself.

The `_bucket` series for those subsystems are dropped and `_count`/`_sum` kept,
so request rates and mean latencies still answer and only the per-bucket
breakdown goes. #360 budgeted single-digit GB a year against an estimate of ~10k
series; 61k at a 30s scrape is 35–65GB a year, which fills the gateway's disk
inside the retention period.

## State of the deploy

Everything else came up on the failed run and is healthy — 13 targets, all
`up=1`, both nodes:

| | sympathy | lady |
|---|---|---|
| node-exporter, kubelet, cadvisor | ✅ | ✅ |
| cilium-agent, hubble | ✅ | ✅ |
| pods (Traefik, vmagent) | ✅ | ✅ |

So `%{ENV_VAR}` expansion, the per-node scrape filter, the RBAC for
`nodes/metrics`, the tailnet remote-write leg and the hostPath store all work as
built. Grafana is Ready and provisioned.

Also `-remoteWrite.maxDiskUsagePerURL` is now `512MiB`: `512MB` is below
vmagent's own minimum and was rounded up with a warning on every start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01222pkEZumhoxT8W7zPuCyb