### PR TITLE
360 feat(auth): put a verified address on the token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,16 @@ registration cannot be closed — Claude registers its own client — so a
 registered client is assumed hostile. What makes that safe is that a client is
 useless without a token and a token issues only to a login in `auth.github.allowed`.
 
+**Every relying party gets an address, and both halves have to agree.** The
+scope is `read:user user:email` and the claim comes from the primary *verified*
+entry in `/user/emails` — `read:user` alone returns the public profile address,
+which is usually null. `email` is in the client registration's default scopes as
+well, because Hydra grants only what a client is registered for: a service asking
+for a scope its registration lacks is refused with `invalid_scope`, which Grafana
+reports as the provider denying the request, naming neither the scope nor the
+claim. Grafana is what forced this — it refuses a login carrying no address at
+all — but a bare `sub` was showing `github:12345` everywhere else too.
+
 **The session is Hydra's.** Logins are accepted with `remember`, carrying the
 upstream login in the session context, so signing in to a second service skips
 GitHub entirely and restarting the provider logs nobody out. That is also why it

--- a/apps/auth/Cargo.lock
+++ b/apps/auth/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/auth/Cargo.toml
+++ b/apps/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auth"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -48,6 +48,24 @@ every relying party to a token carrying a bare `sub`, which leaves dashboards
 displaying `github:12345` at their user. The auto-grant lives in the handler for
 exactly that reason.
 
+**An address is a claim, not a nicety.** Grafana refuses a login whose token
+carries no `email` at all — `errOAuthMissingRequiredEmail`, before its own user
+sync runs — so a provider that emits none cannot sign anyone in to it, and the
+refusal surfaces at the relying party rather than here. GitHub's `read:user`
+returns only the *public* profile address, which is null unless the person chose
+to publish one, so the scope is `read:user user:email` and the address comes from
+`/user/emails`: the primary verified one, or any verified one. Nothing
+unverified is ever used — that is a string somebody typed, and passing it on as
+an identity claim is how an account gets matched to a mailbox its owner never
+proved they hold. When GitHub cannot be asked, the fallback is that account's own
+`<id>+<login>@users.noreply.github.com`, which routes, is unique, and leads with
+the numeric id so it survives a rename.
+
+Both halves have to agree: Hydra grants only what a client is registered for, so
+`email` is in `default_scopes()` too. A relying party asking for a scope its
+registration lacks is refused with `invalid_scope`, which Grafana reports as the
+provider denying the request — an error naming neither the scope nor the claim.
+
 **The session is Hydra's, not this service's.** Accepting a login with
 `remember` is what makes the second service seamless, and it lives at the
 authorization server where every relying party benefits. So restarting this pod

--- a/apps/auth/src/config.rs
+++ b/apps/auth/src/config.rs
@@ -27,7 +27,11 @@ pub struct FirstPartyClient {
 }
 
 fn default_scopes() -> Vec<String> {
-    ["openid", "profile", "offline_access"]
+    // `email` is not optional in practice: Grafana refuses a login whose
+    // token carries no address at all, and Hydra grants only what the
+    // client is registered for — so a scope missing here is a relying party
+    // that cannot sign anybody in, reported as the provider denying it.
+    ["openid", "profile", "email", "offline_access"]
         .map(str::to_string)
         .to_vec()
 }

--- a/apps/auth/src/github.rs
+++ b/apps/auth/src/github.rs
@@ -11,22 +11,39 @@ use url::Url;
 
 use crate::config::Config;
 
-/// Who GitHub says this is: a stable numeric id, and the login to show.
+/// Who GitHub says this is: a stable numeric id, the login to show, and an
+/// address to reach them at.
 ///
 /// The subject is the id rather than the login because a login can be changed
 /// by its owner and reused by somebody else, and every relying party keys its
 /// own state on whatever is issued here.
+///
+/// The address is not decoration. Grafana refuses a login carrying no `email`
+/// claim outright — `errOAuthMissingRequiredEmail`, before its own user sync
+/// runs — so a provider that emits none cannot sign anyone in to it at all.
 pub struct Identity {
     pub subject: String,
     pub login: String,
+    pub email: String,
+    /// Whether GitHub vouches for the address, which is false for the fallback
+    /// below. Nothing here reads it; it goes on the token because a relying
+    /// party deciding that a verified address is proof of anything deserves to
+    /// be told when it is not one.
+    pub email_verified: bool,
 }
+
+/// `user:email` is the narrowest scope that answers "what is this person's
+/// address": `read:user` returns the profile's *public* email, which is null
+/// unless they chose to publish one, so relying on it works for whoever set it
+/// up and fails silently for everyone else.
+const SCOPE: &str = "read:user user:email";
 
 pub fn authorize_url(config: &Config, csrf: &str) -> String {
     let mut url = Url::parse("https://github.com/login/oauth/authorize").expect("static URL");
     url.query_pairs_mut()
         .append_pair("client_id", &config.github.client_id)
         .append_pair("redirect_uri", &config.github_redirect_uri())
-        .append_pair("scope", "read:user")
+        .append_pair("scope", SCOPE)
         .append_pair("state", csrf);
     url.into()
 }
@@ -41,6 +58,36 @@ struct TokenResponse {
 struct User {
     id: u64,
     login: String,
+}
+
+#[derive(Deserialize)]
+struct Address {
+    email: String,
+    primary: bool,
+    verified: bool,
+}
+
+/// GitHub's own no-reply address for an account.
+///
+/// Used when the address list cannot be read or holds nothing verified. It is
+/// not a placeholder: GitHub routes it, it is unique to this account, and it
+/// survives a login being renamed because the numeric id leads. That matters
+/// because a relying party keys a user on whatever arrives here, so an address
+/// that changes shape later is a duplicate account rather than an update.
+fn noreply(user: &User) -> String {
+    format!("{}+{}@users.noreply.github.com", user.id, user.login)
+}
+
+/// The primary verified address, or any verified one.
+///
+/// Verified only, deliberately. An unverified address on GitHub is a string
+/// somebody typed, and handing it downstream as an identity claim is how an
+/// account gets matched to a mailbox its owner never proved they hold.
+fn pick(addresses: &[Address]) -> Option<&Address> {
+    addresses
+        .iter()
+        .find(|a| a.primary && a.verified)
+        .or_else(|| addresses.iter().find(|a| a.verified))
 }
 
 pub async fn exchange_code(
@@ -95,9 +142,36 @@ pub async fn exchange_code(
         .await
         .context("GitHub's user response was not JSON")?;
 
+    // A failure here is not a failed login: the fallback address is derivable
+    // from what is already in hand, and refusing to sign anyone in because
+    // GitHub's address list was briefly unavailable trades an inconvenience
+    // for an outage.
+    let addresses: Vec<Address> = match http
+        .get("https://api.github.com/user/emails")
+        .header("accept", "application/vnd.github+json")
+        .header("user-agent", "jaritanet-auth")
+        .bearer_auth(&access_token)
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+    {
+        Ok(response) => response.json().await.unwrap_or_default(),
+        Err(err) => {
+            tracing::warn!(%err, "GitHub refused the address list; using the no-reply address");
+            Vec::new()
+        }
+    };
+
+    let (email, email_verified) = match pick(&addresses) {
+        Some(address) => (address.email.clone(), true),
+        None => (noreply(&user), false),
+    };
+
     Ok(Identity {
         subject: format!("github:{}", user.id),
         login: user.login,
+        email,
+        email_verified,
     })
 }
 
@@ -128,6 +202,66 @@ mod tests {
         assert!(url.contains("client_id=cid"));
         assert!(url.contains("state=nonce"));
         assert!(url.contains("auth%2Fgithub%2Fcallback"));
+    }
+
+    /// Narrowing this breaks every login at once and reads, downstream, as the
+    /// provider refusing the request rather than as a missing claim.
+    #[test]
+    fn the_authorize_url_asks_for_the_address() {
+        assert!(authorize_url(&config(), "nonce").contains("user%3Aemail"));
+    }
+
+    fn address(email: &str, primary: bool, verified: bool) -> Address {
+        Address {
+            email: email.into(),
+            primary,
+            verified,
+        }
+    }
+
+    #[test]
+    fn the_primary_verified_address_wins() {
+        let addresses = [
+            address("old@example.com", false, true),
+            address("jc@blit.cc", true, true),
+        ];
+        assert_eq!(
+            pick(&addresses).map(|a| a.email.as_str()),
+            Some("jc@blit.cc")
+        );
+    }
+
+    /// An unverified address is a string somebody typed. Handing it downstream
+    /// as an identity claim is how an account is matched to a mailbox its owner
+    /// never proved they hold — so it loses to a verified non-primary, and to
+    /// nothing at all.
+    #[test]
+    fn an_unverified_address_never_wins() {
+        let addresses = [
+            address("unproven@example.com", true, false),
+            address("old@example.com", false, true),
+        ];
+        assert_eq!(
+            pick(&addresses).map(|a| a.email.as_str()),
+            Some("old@example.com")
+        );
+        assert!(pick(&[address("unproven@example.com", true, false)]).is_none());
+        assert!(pick(&[]).is_none());
+    }
+
+    /// The fallback leads with the numeric id, so it survives the login being
+    /// renamed. A relying party keys a user on whatever arrives here, and an
+    /// address that changes shape later is a duplicate account, not an update.
+    #[test]
+    fn the_fallback_address_is_githubs_own() {
+        let user = User {
+            id: 12345,
+            login: "radiosilence".into(),
+        };
+        assert_eq!(
+            noreply(&user),
+            "12345+radiosilence@users.noreply.github.com"
+        );
     }
 
     /// The callback path is what the OAuth App is registered with, so it is

--- a/apps/auth/src/hydra.rs
+++ b/apps/auth/src/hydra.rs
@@ -30,10 +30,16 @@ pub struct LoginRequest {
     #[serde(default)]
     pub subject: String,
     /// Whatever was attached when this session was accepted. Carries the
-    /// upstream login, so a skipped login still knows whose name to put on the
-    /// token without asking GitHub again.
+    /// upstream login and address, so a skipped login still knows what to put
+    /// on the token without asking GitHub again.
     #[serde(default)]
     pub context: Value,
+}
+
+impl LoginRequest {
+    pub fn claims(&self) -> SessionClaims {
+        SessionClaims::from_context(&self.context, &self.subject)
+    }
 }
 
 #[derive(Deserialize)]
@@ -60,11 +66,60 @@ impl ConsentRequest {
             .unwrap_or(&self.client.client_id)
     }
 
-    pub fn login(&self) -> &str {
-        self.context
+    pub fn claims(&self) -> SessionClaims {
+        SessionClaims::from_context(&self.context, &self.subject)
+    }
+}
+
+/// What the login session carries, and what ends up on the ID token.
+///
+/// One shape rather than three positional strings, because it is written at
+/// the end of a GitHub round-trip and read back somewhere else entirely — by a
+/// skipped login and by every consent request — and a transposed pair of
+/// arguments between those two points would put a login in the email field
+/// with nothing to catch it.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SessionClaims {
+    pub login: String,
+    pub email: String,
+    pub email_verified: bool,
+}
+
+impl SessionClaims {
+    /// The subject stands in for a missing login, which is what a session
+    /// written before there was a context looks like. A missing address stays
+    /// missing rather than being invented — see `routes::login`, which
+    /// answers an absent one by asking GitHub again rather than by issuing
+    /// a token no relying party will accept.
+    fn from_context(context: &Value, subject: &str) -> Self {
+        let string = |key: &str| {
+            context
+                .get(key)
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        let login = context
             .get("login")
             .and_then(Value::as_str)
-            .unwrap_or(&self.subject)
+            .unwrap_or(subject)
+            .to_string();
+        Self {
+            login,
+            email: string("email"),
+            email_verified: context
+                .get("email_verified")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        }
+    }
+
+    fn as_context(&self) -> Value {
+        json!({
+            "login": self.login,
+            "email": self.email,
+            "email_verified": self.email_verified,
+        })
     }
 }
 
@@ -135,16 +190,17 @@ impl HydraAdmin {
         .await
     }
 
-    /// Accept the login, and attach the upstream login name to the session.
+    /// Accept the login, and attach what is known about the person to it.
     ///
     /// The `context` is what a later skipped login and every consent request
-    /// read back, so the name survives without GitHub being asked a second
-    /// time — and without this service keeping a session to hold it in.
+    /// read back, so the name and the address survive without GitHub being
+    /// asked a second time — and without this service keeping a session to
+    /// hold them in.
     pub async fn accept_login(
         &self,
         challenge: &str,
         subject: &str,
-        login: &str,
+        claims: &SessionClaims,
     ) -> Result<String> {
         self.put_redirect(
             "/admin/oauth2/auth/requests/login/accept",
@@ -153,7 +209,7 @@ impl HydraAdmin {
                 "subject": subject,
                 "remember": true,
                 "remember_for": REMEMBER_FOR_SECS,
-                "context": { "login": login },
+                "context": claims.as_context(),
             }),
         )
         .await
@@ -171,10 +227,11 @@ impl HydraAdmin {
     ///
     /// A login accepted without session claims yields an ID token carrying
     /// `sub` and nothing else, which leaves every dashboard downstream
-    /// displaying `github:12345` at its user. The name comes from here or it
-    /// does not exist.
+    /// displaying `github:12345` at its user — and, for one that requires an
+    /// address, refusing the login outright. The claims come from here or
+    /// they do not exist.
     pub async fn accept_consent(&self, challenge: &str, req: &ConsentRequest) -> Result<String> {
-        let login = req.login();
+        let claims = req.claims();
         self.put_redirect(
             "/admin/oauth2/auth/requests/consent/accept",
             &[("consent_challenge", challenge)],
@@ -185,8 +242,10 @@ impl HydraAdmin {
                 "remember_for": REMEMBER_FOR_SECS,
                 "session": {
                     "id_token": {
-                        "name": login,
-                        "preferred_username": login,
+                        "name": claims.login,
+                        "preferred_username": claims.login,
+                        "email": claims.email,
+                        "email_verified": claims.email_verified,
                     },
                 },
             }),
@@ -283,9 +342,52 @@ mod tests {
     #[test]
     fn the_login_comes_from_the_session_context() {
         assert_eq!(
-            consent(None, json!({ "login": "radiosilence" })).login(),
+            consent(None, json!({ "login": "radiosilence" }))
+                .claims()
+                .login,
             "radiosilence"
         );
-        assert_eq!(consent(None, Value::Null).login(), "github:12345");
+        assert_eq!(consent(None, Value::Null).claims().login, "github:12345");
+    }
+
+    /// The whole point of carrying the address: a consent request arriving on a
+    /// remembered session has no upstream to ask, so what is not in the context
+    /// is not on the token.
+    #[test]
+    fn the_address_rides_in_the_context_too() {
+        let claims = consent(
+            None,
+            json!({
+                "login": "radiosilence",
+                "email": "jc@blit.cc",
+                "email_verified": true,
+            }),
+        )
+        .claims();
+        assert_eq!(claims.email, "jc@blit.cc");
+        assert!(claims.email_verified);
+    }
+
+    /// A session accepted before the address was a claim. It must read as
+    /// absent rather than as an empty-but-present address, because that is the
+    /// signal `login` uses to ask GitHub again instead of issuing a token no
+    /// relying party will accept.
+    #[test]
+    fn a_session_from_before_the_address_carries_none() {
+        let claims = consent(None, json!({ "login": "radiosilence" })).claims();
+        assert_eq!(claims.email, "");
+        assert!(!claims.email_verified);
+    }
+
+    /// An unverified address is not evidence, so it is never the one chosen —
+    /// the round-trip through the context must not quietly promote one.
+    #[test]
+    fn an_unverified_address_stays_unverified() {
+        let claims = consent(
+            None,
+            json!({ "login": "x", "email": "typo@example", "email_verified": false }),
+        )
+        .claims();
+        assert!(!claims.email_verified);
     }
 }

--- a/apps/auth/src/routes.rs
+++ b/apps/auth/src/routes.rs
@@ -21,6 +21,7 @@ use serde::Deserialize;
 use crate::cookie::{self, FLOW_COOKIE};
 use crate::error::{AppError, AppResult};
 use crate::github;
+use crate::hydra::SessionClaims;
 use crate::state::AppState;
 use crate::store::{FLOW_TTL_SECS, Flow};
 
@@ -84,16 +85,16 @@ pub async fn login(
         .await
         .map_err(|e| AppError::Upstream(e.to_string()))?;
 
-    if request.skip {
-        let login = request
-            .context
-            .get("login")
-            .and_then(|v| v.as_str())
-            .unwrap_or(&request.subject)
-            .to_string();
+    // A session accepted before the address became a claim carries none, and
+    // nothing here can reconstruct one — so that session is not skipped, and
+    // the upstream is asked again. GitHub's own session usually makes the
+    // round-trip invisible, which is what makes this a migration rather than a
+    // forced sign-out.
+    let claims = request.claims();
+    if request.skip && !claims.email.is_empty() {
         let redirect_to = state
             .hydra
-            .accept_login(&q.login_challenge, &request.subject, &login)
+            .accept_login(&q.login_challenge, &request.subject, &claims)
             .await
             .map_err(|e| AppError::Upstream(e.to_string()))?;
         return Ok(redirect(&redirect_to, &[]));
@@ -161,9 +162,14 @@ pub async fn github_callback(
         return Err(AppError::Unauthorized);
     }
 
+    let claims = SessionClaims {
+        login: identity.login,
+        email: identity.email,
+        email_verified: identity.email_verified,
+    };
     let redirect_to = state
         .hydra
-        .accept_login(&flow.login_challenge, &identity.subject, &identity.login)
+        .accept_login(&flow.login_challenge, &identity.subject, &claims)
         .await
         .map_err(|e| AppError::Upstream(e.to_string()))?;
 
@@ -213,7 +219,7 @@ pub async fn consent(
     let page = ConsentTemplate {
         challenge: q.consent_challenge,
         client: request.client_label().to_string(),
-        login: request.login().to_string(),
+        login: request.claims().login,
         scopes: request.requested_scope.clone(),
         audience: request.requested_access_token_audience.clone(),
     };


### PR DESCRIPTION
Grafana (#360) could not sign anyone in. Two faults, stacked, and both are here
rather than in the metrics package.

## What was wrong

**The client was not permitted the scope.** `default_scopes()` was
`openid profile offline_access`. Grafana asks for `openid profile email`, Hydra
grants only what a client is registered for, so the authorization request was
refused with `invalid_scope` — which Grafana renders as *"Login provider denied
login request"*, naming neither the scope nor the claim.

**And there was nothing to put in it.** `accept_consent` attached `name` and
`preferred_username` and nothing else, so even a permitted `email` scope would
have produced an empty claim. Grafana rejects that outright —
`errOAuthMissingRequiredEmail` in `pkg/services/authn/clients/oauth.go:198`,
before its own user sync runs — so dropping `email` from Grafana's request would
only have swapped one failure for another.

Hydra could not have helped: it is headless and holds no upstream connection.
Whatever is on the token is what this service attaches at consent.

## What it does

Scope is `read:user user:email` and the address comes from `/user/emails`.
`read:user` alone returns the *public* profile address, which is null unless the
person published one — so relying on it works for whoever set it up and fails
silently for everybody else.

**Verified only.** An unverified GitHub address is a string somebody typed;
passing it on as an identity claim is how an account gets matched to a mailbox
its owner never proved they hold. Primary-and-verified wins, then any verified.

**The fallback is GitHub's own no-reply address** for that account, used when the
address list cannot be read at all. It routes, it is unique, and it leads with
the numeric id so it survives a rename — which matters because a relying party
keys its user on whatever arrives here, so an address that changes shape later is
a duplicate account rather than an update. `email_verified` is false for it, and
goes on the token so a relying party treating verification as proof is told when
it is not.

A failed `/user/emails` call is not a failed login. Refusing to sign anyone in
because GitHub was briefly unavailable trades an inconvenience for an outage.

## The bit worth reviewing

The login and address now travel as one `SessionClaims` instead of positional
strings. They are written at the end of a GitHub round-trip and read back
somewhere else entirely — by a skipped login and by every consent request — and a
transposed pair between those points would put a login in the email field with
nothing to catch it.

**Migration:** a remembered session predating the claim carries no address, and
nothing here can reconstruct one. Those are no longer skipped, so the upstream is
asked again; GitHub's own session usually makes the round-trip invisible. It
self-heals on next login rather than needing anything cleared.

`ensure_client` is PUT-first, so the widened scope reaches the existing `metrics`,
`mariastew` and `mcp-gateway` registrations on the next deploy — no manual admin
call.

## Verifying it

- `cargo test` — 21 pass. The new ones cover what has no other check: that the
  authorize URL still asks for `user:email` (narrowing it breaks every login at
  once), that an unverified address never wins, that the no-reply fallback leads
  with the id, and that a pre-claim session reads as *absent* rather than as an
  empty address, since that is the signal the skip path branches on.
- After deploy, the ID token should carry `email` and `email_verified`, and
  Grafana should complete a login.

## Consequence to expect

Widening the OAuth app's scope means **re-consenting at GitHub on next login** —
once, for every relying party, since it is the shared provider.

## Follow-up

The `auth` image pin moves once CI publishes `auth-v0.2.0`; `update-apps` will
take it, or I can bump it directly once the image exists. Nothing else deploys
this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01222pkEZumhoxT8W7zPuCyb