### PR TITLE
feat(mcp-gateway): fastmail declares its CardDAV credentials

### DIFF
--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -307,9 +307,31 @@ config:
           port: 8080
           path: "/mcp"
           graphqlPath: "/graphql"
-          credentialHeader: "X-Fastmail-Token"
           keyHelpUrl: "https://app.fastmail.com/settings/security/tokens"
-          keyHint: "fmu1-…"
+          # Mail runs on the API token; contacts go over CardDAV, which is a
+          # separate protocol that rejects API tokens — hence three values
+          # rather than one. The CardDAV pair is optional: without it mail works
+          # and contact search doesn't, which the backend reports up front as
+          # `session { carddavConfigured }` rather than failing a query halfway
+          # through one. `token` keeps the id the credentialHeader shorthand
+          # normalised to, so stored credentials survive the change.
+          fields:
+            - id: token
+              label: API token
+              header: "X-Fastmail-Token"
+              hint: "fmu1-…"
+            - id: username
+              label: Username (contacts only)
+              header: "X-Fastmail-Username"
+              secret: false
+              required: false
+              hint: "you@fastmail.com"
+            # An app password, not the API token above: CardDAV won't take one.
+            - id: app_password
+              label: App password (contacts only)
+              header: "X-Fastmail-App-Password"
+              required: false
+              hint: "Blank = mail works, contact search doesn't"
           # Re-runs the handshake rather than reading a cached client, so a
           # revoked token is caught rather than reported as fine. Only a 401 is a
           # verdict on the credential; rate limits and outages are UNREACHABLE.


### PR DESCRIPTION
Mail runs on the API token. Contacts go over CardDAV, which is a separate protocol that rejects API tokens outright — so with only `credentialHeader` declared, the backend never received CardDAV credentials and contact search was unreachable no matter what anyone typed into the dashboard.

Three fields now, the CardDAV pair `required: false`: without them mail works and contacts don't, which fastmail-cli reports up front as `session { carddavConfigured }` rather than failing a query halfway through a plan that assumed contacts were reachable.

## Verifying

**No migration, which is the bit worth checking.** The `credentialHeader` shorthand normalised to a single field with id `token` under `X-Fastmail-Token` — exactly what this now declares explicitly. Storage is keyed by field id, so stored credentials keep working and connected users stay connected.

`mise run check` passes (lint, fmt, 174 tests, typecheck). I also round-tripped the edited entry through the real `McpSchema` + `mcpRegistry()` to confirm what the gateway actually boots from:

```yaml
id: fastmail
backend: http://mcp-gateway-mcp-fastmail:8080/mcp
fields:
  - id: token
    label: API token
    header: X-Fastmail-Token
    hint: fmu1-…
  - id: username
    label: Username (contacts only)
    header: X-Fastmail-Username
    secret: false
    hint: you@fastmail.com
    required: false
  - id: app_password
    label: App password (contacts only)
    header: X-Fastmail-App-Password
    hint: Blank = mail works, contact search doesn't
    required: false
verify:
  query: "{ session { status } }"
  ...
```

`secret` and `required` are spelled out because `mcpRegistry()` omits `undefined`, and the gateway defaults both to true — a username rendered as a password field would be a nuisance, and a required app password would block anyone who only wants mail.

**The image pin is deliberately untouched.** The version updater bumps it from its `tracked-versions.yml` entry once fastmail-cli releases the version that reads these headers. Until then the gateway sends two headers the backend ignores — inert, so this can merge independently.

## Dependencies

- Needs radiosilence/fastmail-cli#63 released for the headers to do anything (harmless until then).
- radiosilence/mcp-gateway#45 is the same change to that repo's worked example and docs — no gateway code change was needed for either; `fields` already did all of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)