### PR TITLE
390 fix(mariastew): a stream that dies in front of you comes back

### DIFF
--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The stream sends a `datastar-heartbeat` frame every five seconds when it has nothing else to say, and the page reconnects when three of them fail to arrive (`ms.streamLost`). Silence had to be given a meaning first: the stream sends the rows whose hash moved, so a queue with nothing running is silent because there is nothing to report, and a client cannot tell that apart from a socket that stopped carrying bytes without erroring. Datastar's own view of whether the request is live is the one thing this cannot consult — in that case it is wrong, and there is nothing else to ask ([#390](https://github.com/radiosilence/jaritanet/issues/390))
 
+- A 401 stops the watchdog rather than starting a loop. A session lives only in the pod's memory, so the deploy that ends the stream is usually the deploy that signs the page out, and `require_session` answers a Datastar request with a status where a navigation would get the login redirect. No reconnect gets past that, and the asking is itself one of the frames that resets the clock — so the page would have issued a doomed request every sixteen seconds for as long as the tab stayed open. It resumes if a later reconnect is actually served ([#390](https://github.com/radiosilence/jaritanet/issues/390))
+
 ### Changed
 
 - The heartbeat replaces axum's keep-alive. Both stop a proxy timing out an idle connection; only one of them reaches the page, and two mechanisms firing at different rates is one more thing to hold in mind than there needs to be ([#390](https://github.com/radiosilence/jaritanet/issues/390))

--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.29] - 2026-08-15
+## [0.1.29] - 2026-08-19
 
 ### Fixed
 

--- a/apps/mariastew/CHANGELOG.md
+++ b/apps/mariastew/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to mariastew are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.29] - 2026-08-15
+
+### Fixed
+
+- A stream that dies while the page is open comes back on its own. #386 covered the case with a trigger — the page went away and returned — and an ordinary deploy has none: the pod is replaced rather than drained, every open stream ends, and Datastar reads a finished 200 body as the request being over, so a laptop tab left in front of you showed a frozen list until it was reloaded ([#390](https://github.com/radiosilence/jaritanet/issues/390))
+
+### Added
+
+- The stream sends a `datastar-heartbeat` frame every five seconds when it has nothing else to say, and the page reconnects when three of them fail to arrive (`ms.streamLost`). Silence had to be given a meaning first: the stream sends the rows whose hash moved, so a queue with nothing running is silent because there is nothing to report, and a client cannot tell that apart from a socket that stopped carrying bytes without erroring. Datastar's own view of whether the request is live is the one thing this cannot consult — in that case it is wrong, and there is nothing else to ask ([#390](https://github.com/radiosilence/jaritanet/issues/390))
+
+### Changed
+
+- The heartbeat replaces axum's keep-alive. Both stop a proxy timing out an idle connection; only one of them reaches the page, and two mechanisms firing at different rates is one more thing to hold in mind than there needs to be ([#390](https://github.com/radiosilence/jaritanet/issues/390))
+
 ## [0.1.28] - 2026-08-09
 
 ### Fixed

--- a/apps/mariastew/Cargo.lock
+++ b/apps/mariastew/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mariastew"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "askama",

--- a/apps/mariastew/Cargo.toml
+++ b/apps/mariastew/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mariastew"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/apps/mariastew/README.md
+++ b/apps/mariastew/README.md
@@ -488,22 +488,46 @@ everything had — and doing it for an empty one too is what retires the
 unreachable warning: a snapshot exists only after aria2 has answered, so one
 arriving is the proof the page rendered on stale news.
 
-A page returning to the foreground reconnects, whatever state its stream was
-in. Datastar closes the connection while the document is hidden and reopens it
-when it comes back, which covers a tab switch — but iOS suspends a page without
-telling it, and what it resumes with has either ended (a finished 200 body is
-the request being over as far as Datastar is concerned, and it drops its own
-visibilitychange listener with it) or gone dead with no error to observe. The
-page then holds whatever it last painted until it is reloaded. The reconnect is
-unconditional because of the second case: the only liveness signal available is
-Datastar's own belief, and a zombie socket is precisely where that is wrong. It
-costs one redundant connection per return, whose first tick is the container —
-the fresh data that was wanted anyway.
-
 With nobody watching it drops to `IDLE_POLL_MS` and renders nothing. That
 interval is the notifier's alone — it is looking for a download that finished
 or failed, and nothing about that is in a hurry — and the first page to open
 wakes the poller immediately rather than sitting out the rest of the sleep.
+
+## How a stream comes back
+
+A stream can stop without anyone being told, and there are two ways. Datastar
+reads a finished 200 body as the request being over, so it neither retries nor
+keeps watching — an ordinary deploy ends every open stream that way, since the
+pod is replaced rather than drained. And a socket can stop carrying bytes with
+no error at all, which is what a suspended phone hands back; Datastar still
+believes that request is live, and has nothing to notice. Its own account of
+whether the stream is up is therefore the one thing the page must not ask.
+
+What is left is silence, and silence had to be made to mean something first:
+the stream sends the rows whose hash moved, so a queue with nothing running is
+silent because there is nothing to say. `HEARTBEAT` (`src/routes.rs`) is a
+`datastar-heartbeat` frame on a five-second timer, sent only when nothing else
+has gone down the wire — a busy stream sends none. It is on its own timer
+rather than counted off the poller's ticks, because what it reports is that
+*this connection* is up: a poller wedged on an aria2 that stopped answering
+would otherwise take every page's heartbeat down with it and reconnect all of
+them, to a server whose problem another connection does not solve. It replaces
+axum's keep-alive rather than joining it — both keep a proxy from timing out an
+idle connection, only this one reaches the page.
+
+The page then watches the quiet. `ms.streamSeen` records every frame that
+arrives on the stream, `ms.streamLost` answers whether it has been longer than
+three heartbeats, and `data-on-interval` reconnects when it has. Datastar
+announcing a request *started* counts as a frame, which is what keeps a
+reconnect that cannot connect from retrying every tick: the attempt resets the
+clock, so a server that is down is asked once per timeout.
+
+`data-on:visibilitychange` is the same reconnect, on the one occasion worth not
+waiting out the timeout for — a phone coming back into a hand, where sixteen
+seconds is spent looking at a stale screen. It is unconditional, for the reason
+above: the return is exactly the moment liveness cannot be judged. The cost is
+one redundant connection, whose first tick is the container, which is the fresh
+data that was wanted anyway.
 
 ## Seeding, and why cancel has two meanings
 

--- a/apps/mariastew/assets/app-DQ9vDZ4F.js
+++ b/apps/mariastew/assets/app-DQ9vDZ4F.js
@@ -1,5 +1,15 @@
 //#region web/app.ts
 /**
+* Three of the server's five-second heartbeats, and a little more.
+*
+* Two would reconnect over one frame lost to a stalled event loop, which is a
+* connection that is fine. The cost of waiting the third is the width of the
+* window in which the page shows something out of date, and against a phone
+* that has been in a pocket that window is nothing.
+*/
+const STREAM_TIMEOUT_MS = 16e3;
+let streamLastSeen = Date.now();
+/**
 * The behaviours that do not belong in an attribute.
 *
 * Datastar evaluates `data-on:*` as a function body, so an attribute holds
@@ -63,6 +73,39 @@ globalThis.ms = {
 	browseUrl(evt) {
 		const dir = evt.target.closest("[data-dir]")?.dataset.dir;
 		return dir === void 0 ? null : `/browse?path=${encodeURIComponent(dir)}`;
+	},
+	/**
+	* Note that the stream just proved it is there.
+	*
+	* Anything at all counts — a row patch, the heartbeat behind it
+	* (`routes::HEARTBEAT`), or Datastar announcing it has started a request.
+	* The last of those is what stops a reconnect that cannot connect from
+	* retrying every interval: the attempt itself resets the clock, so a server
+	* that is down is asked once per timeout rather than once per tick.
+	*/
+	streamSeen() {
+		streamLastSeen = Date.now();
+	},
+	/**
+	* Whether the stream has been quiet long enough to presume it is gone.
+	*
+	* This is the half of the problem `data-on:visibilitychange` cannot reach.
+	* That one has a trigger — the page left and came back — and a pod replaced
+	* under a tab nobody switched away from does not raise it. Neither does a
+	* socket that stops carrying bytes without erroring, which is what a phone
+	* hands back and what Datastar has no way to notice: it believes the request
+	* is live, and there is nothing else to ask. Silence is the only evidence
+	* available, which is why the server sends something to be silent *instead
+	* of*.
+	*
+	* False while the document is hidden, whatever the clock says. Datastar
+	* closes the stream on its way out of view and opens it again on the way
+	* back, so quiet is correct there, and the timers driving this are throttled
+	* anyway — a page returning after an hour would otherwise reconnect twice,
+	* once for the return and once for the hour.
+	*/
+	streamLost() {
+		return !document.hidden && Date.now() - streamLastSeen > STREAM_TIMEOUT_MS;
 	}
 };
 /**

--- a/apps/mariastew/assets/app-DRQPRTm9.js
+++ b/apps/mariastew/assets/app-DRQPRTm9.js
@@ -1,5 +1,18 @@
 //#region web/app.ts
 /**
+* The Datastar fetch events that are evidence the stream is carrying bytes.
+*
+* An allowlist rather than a list of the failures to ignore, so an event type
+* nobody here has heard of cannot be mistaken for liveness — which is the
+* whole quantity being measured.
+*/
+const STREAM_FRAMES = /* @__PURE__ */ new Set([
+	"started",
+	"datastar-heartbeat",
+	"datastar-patch-elements",
+	"datastar-patch-signals"
+]);
+/**
 * Three of the server's five-second heartbeats, and a little more.
 *
 * Two would reconnect over one frame lost to a stalled event loop, which is a
@@ -9,6 +22,9 @@
 */
 const STREAM_TIMEOUT_MS = 16e3;
 let streamLastSeen = Date.now();
+/** Set by a 401: the stream is refused rather than lost, and no reconnect
+* fixes that. Cleared by anything the server actually serves. */
+let streamRefused = false;
 /**
 * The behaviours that do not belong in an attribute.
 *
@@ -75,15 +91,36 @@ globalThis.ms = {
 		return dir === void 0 ? null : `/browse?path=${encodeURIComponent(dir)}`;
 	},
 	/**
-	* Note that the stream just proved it is there.
+	* Take one of the stream's own Datastar fetch events.
 	*
-	* Anything at all counts — a row patch, the heartbeat behind it
-	* (`routes::HEARTBEAT`), or Datastar announcing it has started a request.
-	* The last of those is what stops a reconnect that cannot connect from
-	* retrying every interval: the attempt itself resets the clock, so a server
-	* that is down is asked once per timeout rather than once per tick.
+	* A frame is proof the connection is there and resets the clock
+	* `streamLost` reads — a row patch, the heartbeat behind it
+	* (`routes::HEARTBEAT`), or Datastar announcing it has *started* a request.
+	* That last one is what stops a reconnect that cannot connect from retrying
+	* every tick: the attempt itself resets the clock, so a server that is down
+	* is asked once per timeout.
+	*
+	* Which is exactly why a 401 has to stop it outright. A session lives only in
+	* the pod's memory, so the deploy that ends the stream is usually the deploy
+	* that signs the page out, and `require_session` answers a Datastar request
+	* with a status where a navigation would get the login redirect —
+	* deliberately, since a stream cannot be redirected. No reconnect gets past
+	* that, and every attempt would reset the clock for the next one, so the page
+	* would ask forever and never arrive anywhere.
+	*
+	* It is refused rather than dead, so a later frame lifts it: the reconnect on
+	* returning to the foreground is unconditional, and if that one is served
+	* the session came back and the watchdog should resume. `started` is not
+	* enough — that is the asking, not the answer.
 	*/
-	streamSeen() {
+	streamEvent(evt) {
+		const { type, argsRaw } = evt.detail;
+		if (type === "error") {
+			streamRefused ||= argsRaw?.status === "401";
+			return;
+		}
+		if (!STREAM_FRAMES.has(type)) return;
+		if (type !== "started") streamRefused = false;
 		streamLastSeen = Date.now();
 	},
 	/**
@@ -103,9 +140,12 @@ globalThis.ms = {
 	* back, so quiet is correct there, and the timers driving this are throttled
 	* anyway — a page returning after an hour would otherwise reconnect twice,
 	* once for the return and once for the hour.
+	*
+	* False too once the stream has been refused. Quiet that nothing can cure is
+	* not worth a request every timeout, forever, for as long as the tab is open.
 	*/
 	streamLost() {
-		return !document.hidden && Date.now() - streamLastSeen > STREAM_TIMEOUT_MS;
+		return !streamRefused && !document.hidden && Date.now() - streamLastSeen > STREAM_TIMEOUT_MS;
 	}
 };
 /**

--- a/apps/mariastew/src/routes.rs
+++ b/apps/mariastew/src/routes.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use askama::Template;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
-use axum::response::sse::{Event, KeepAlive};
+use axum::response::sse::Event;
 use axum::response::{Html, IntoResponse, Response, Sse};
 use axum::routing::{get, post};
 use axum::{Form, Router};
@@ -26,6 +26,23 @@ use crate::views::{self, DirView, RootView, Row};
 /// hours, and it takes the write lock on the session map every time it runs —
 /// a cost worth paying once a second and not ten times.
 const SESSION_RECHECK: Duration = Duration::from_secs(1);
+
+/// How often a connection with nothing else to say announces itself.
+///
+/// The stream is legitimately silent most of the time — it sends the rows whose
+/// hash moved, and a queue with nothing running moves nothing — so silence
+/// carries no information, and a page cannot tell it apart from a socket that
+/// died without saying so. That is the failure the page's own reconnect cannot
+/// see, because the page never went away: a pod replaced under an open laptop
+/// tab, or a link that dropped without an error to observe. A frame on a known
+/// cadence is what makes the difference visible, and `ms.streamLost` in
+/// `web/app.ts` is what acts on it.
+///
+/// It replaces axum's keep-alive rather than joining it. Both keep a proxy from
+/// timing an idle connection out; only this one reaches the page, and two
+/// mechanisms firing at different rates is one more thing to hold in mind than
+/// there needs to be.
+const HEARTBEAT: Duration = Duration::from_secs(5);
 
 /// Everything behind the auth layer. Mounted by `main`, which wraps it — see
 /// `auth::extract::require_session` for why that is a layer and not a
@@ -125,6 +142,18 @@ fn patch_elements(html: &str) -> Event {
         .data(patch_elements_data(html))
 }
 
+/// A frame that says only that the connection is still there.
+///
+/// Named `datastar-` so it survives the client: Datastar forwards an event to
+/// the page as a `datastar-fetch` only if the name is one of its own, and drops
+/// anything else before a `data-on` could see it. No payload, because there is
+/// nothing to say beyond having arrived — its own parser dispatches on the
+/// blank line rather than on having read a `data:` field, which is the one
+/// place it is looser than the spec and the one place that helps.
+fn heartbeat() -> Event {
+    Event::default().event("datastar-heartbeat")
+}
+
 pub async fn page(State(state): State<AppState>) -> AppResult<Html<String>> {
     // A restarted aria2 sidecar should not blank the whole page: the picker
     // and everything else on it are still useful without a download list, and
@@ -217,8 +246,31 @@ pub async fn stream(
     let s = async_stream::stream! {
         let mut sent: Option<Vec<(String, u64)>> = None;
         let mut checked = std::time::Instant::now() - SESSION_RECHECK;
+        // On its own timer rather than counted off the poller's ticks: what it
+        // reports is that this connection is up, and a poller wedged on an
+        // aria2 that stopped answering would otherwise take every open page's
+        // heartbeat down with it — reconnecting all of them, to a server whose
+        // problem a new connection does not solve.
+        let mut beat = tokio::time::interval(HEARTBEAT);
+        beat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        beat.tick().await; // The first completes immediately.
 
-        while let Some(snapshot) = viewer.next().await {
+        loop {
+            // `watch::Receiver::changed` is cancel-safe, so losing this branch
+            // to the heartbeat drops nothing: the snapshot is still there to be
+            // read on the next pass, and `unsent` compares against what went
+            // down this connection rather than against the previous tick.
+            let snapshot = tokio::select! {
+                next = viewer.next() => match next {
+                    Some(snapshot) => snapshot,
+                    None => break,
+                },
+                _ = beat.tick() => {
+                    yield Ok::<_, Infallible>(heartbeat());
+                    continue;
+                }
+            };
+
             // A page left open holds this connection for hours; a session
             // revoked in the meantime is never re-checked by anything else,
             // so logging out would otherwise leave a live feed of the queue
@@ -234,16 +286,32 @@ pub async fn stream(
                 continue;
             };
 
-            match unsent(&mut sent, &view.rows) {
-                Some(rows) => for row in rows {
-                    yield Ok::<_, Infallible>(patch_elements(&row.html));
-                },
-                None => yield Ok::<_, Infallible>(patch_elements(&view.full)),
+            let sent_anything = match unsent(&mut sent, &view.rows) {
+                Some(rows) => {
+                    let any = !rows.is_empty();
+                    for row in rows {
+                        yield Ok::<_, Infallible>(patch_elements(&row.html));
+                    }
+                    any
+                }
+                None => {
+                    yield Ok::<_, Infallible>(patch_elements(&view.full));
+                    true
+                }
+            };
+
+            // Anything that just went down the wire is the proof a heartbeat
+            // would have carried, so a busy stream sends none at all. A tick
+            // that changed nothing is not: `unsent` answers with an empty list
+            // for a queue sitting still, which is every tick of the case the
+            // heartbeat exists for.
+            if sent_anything {
+                beat.reset();
             }
         }
     };
 
-    Sse::new(s).keep_alive(KeepAlive::default()).into_response()
+    Sse::new(s).into_response()
 }
 
 #[derive(serde::Deserialize)]

--- a/apps/mariastew/templates/page.html
+++ b/apps/mariastew/templates/page.html
@@ -29,24 +29,33 @@
 <script type="module" src="{{ self.app_js_path() }}"></script>
 <script type="module" src="/assets/datastar.js"></script>
 </head>
-{# Coming back to the page reconnects the stream, without asking whether it is
-     still up.
+{# The stream reopens itself, by two attributes doing one job.
 
-     Datastar closes its fetch when the document goes hidden and reopens it when
-     it returns, so a tab switch is already covered. iOS is not: it suspends the
-     page rather than telling it anything, and what resumes is either a
-     connection that ended cleanly — a finished 200 body is the request being
-     over as far as Datastar is concerned, so it stops there and takes its own
-     visibilitychange listener with it, and nothing reopens the stream ever
-     again — or a socket that is dead with no error to observe. Either way the
-     page holds whatever it last painted until it is reloaded (#386).
+     A stream can stop without anybody being told. Datastar reads a finished 200
+     body as the request being over, so a pod replaced under an open page ends
+     it for good; and a socket can simply stop carrying bytes, which is what a
+     suspended phone hands back, and which Datastar cannot see at all — it still
+     believes the request is live. Its own belief is therefore the one thing
+     this must not consult (#386, #390).
 
-     Unconditional because of that second case: the only liveness signal
-     available is what Datastar believes, and a zombie socket is exactly where
-     that is wrong. It costs one redundant reconnect per return —
-     `requestCancellation` defaults to aborting the in-flight request to the
-     same URL, so there is still one stream — and its first tick is the whole
-     container, which is the fresh data being asked for. #}
+     `data-on-interval` is the mechanism: the server sends a heartbeat on a
+     cadence (`routes::HEARTBEAT`), `ms.streamSeen` records every frame that
+     arrives, and `ms.streamLost` answers whether the quiet has gone on too
+     long. Silence is the only evidence a client has, and the heartbeat is what
+     makes silence mean something — the list is legitimately still while nothing
+     is downloading.
+
+     `data-on:visibilitychange` is the same reconnect on the one occasion worth
+     not waiting for: a phone coming back into the hand, where the timeout would
+     otherwise be spent staring at a stale screen. Unconditional, because that
+     is precisely where liveness cannot be judged. It costs one redundant
+     reconnect per return — `requestCancellation` defaults to aborting the
+     in-flight request to the same URL, so there is still one stream — and its
+     first tick is the whole container, which is the fresh data being asked for.
+
+     The `datastar-fetch` handler is filtered to this element because it hears
+     every request the page makes, and the picker's `@get('/browse')` arriving
+     is no evidence the stream is up. #}
 {# `$addStatus` and `$addMessage` are the whole contract with the server for
      this form: POST /add answers with a JSON body, which Datastar treats as a
      signal patch on its own (Content-Type: application/json is all it takes, no
@@ -61,6 +70,8 @@
 
      `__ifmissing` seeds them without stomping a patch that arrived first. #}
 <body data-init="@get('/stream')"
+  data-on:datastar-fetch="evt.detail.el === el && ms.streamSeen()"
+  data-on-interval__duration.5s="ms.streamLost() && @get('/stream')"
   data-on:visibilitychange__document="!document.hidden && @get('/stream')"
   data-signals__ifmissing="{addStatus: '', addMessage: ''}"
   class="min-h-dvh bg-base-200">

--- a/apps/mariastew/templates/page.html
+++ b/apps/mariastew/templates/page.html
@@ -39,11 +39,16 @@
      this must not consult (#386, #390).
 
      `data-on-interval` is the mechanism: the server sends a heartbeat on a
-     cadence (`routes::HEARTBEAT`), `ms.streamSeen` records every frame that
+     cadence (`routes::HEARTBEAT`), `ms.streamEvent` records every frame that
      arrives, and `ms.streamLost` answers whether the quiet has gone on too
      long. Silence is the only evidence a client has, and the heartbeat is what
      makes silence mean something — the list is legitimately still while nothing
      is downloading.
+
+     A 401 stops it instead, because that is not a stream fault: the deploy that
+     ends the stream is usually the one that signs the page out, and no
+     reconnect gets past that. Left running it would ask forever, since the
+     asking is itself one of the frames that resets the clock.
 
      `data-on:visibilitychange` is the same reconnect on the one occasion worth
      not waiting for: a phone coming back into the hand, where the timeout would
@@ -70,7 +75,7 @@
 
      `__ifmissing` seeds them without stomping a patch that arrived first. #}
 <body data-init="@get('/stream')"
-  data-on:datastar-fetch="evt.detail.el === el && ms.streamSeen()"
+  data-on:datastar-fetch="evt.detail.el === el && ms.streamEvent(evt)"
   data-on-interval__duration.5s="ms.streamLost() && @get('/stream')"
   data-on:visibilitychange__document="!document.hidden && @get('/stream')"
   data-signals__ifmissing="{addStatus: '', addMessage: ''}"

--- a/apps/mariastew/web/app.ts
+++ b/apps/mariastew/web/app.ts
@@ -3,8 +3,22 @@ declare global {
     pasteInto(field: HTMLInputElement): void;
     clickOnEnter(evt: KeyboardEvent, button: HTMLButtonElement): void;
     browseUrl(evt: Event): string | null;
+    streamSeen(): void;
+    streamLost(): boolean;
   };
 }
+
+/**
+ * Three of the server's five-second heartbeats, and a little more.
+ *
+ * Two would reconnect over one frame lost to a stalled event loop, which is a
+ * connection that is fine. The cost of waiting the third is the width of the
+ * window in which the page shows something out of date, and against a phone
+ * that has been in a pocket that window is nothing.
+ */
+const STREAM_TIMEOUT_MS = 16_000;
+
+let streamLastSeen = Date.now();
 
 /**
  * The behaviours that do not belong in an attribute.
@@ -76,6 +90,41 @@ globalThis.ms = {
     const dir = (evt.target as HTMLElement).closest<HTMLElement>("[data-dir]")
       ?.dataset.dir;
     return dir === undefined ? null : `/browse?path=${encodeURIComponent(dir)}`;
+  },
+
+  /**
+   * Note that the stream just proved it is there.
+   *
+   * Anything at all counts — a row patch, the heartbeat behind it
+   * (`routes::HEARTBEAT`), or Datastar announcing it has started a request.
+   * The last of those is what stops a reconnect that cannot connect from
+   * retrying every interval: the attempt itself resets the clock, so a server
+   * that is down is asked once per timeout rather than once per tick.
+   */
+  streamSeen() {
+    streamLastSeen = Date.now();
+  },
+
+  /**
+   * Whether the stream has been quiet long enough to presume it is gone.
+   *
+   * This is the half of the problem `data-on:visibilitychange` cannot reach.
+   * That one has a trigger — the page left and came back — and a pod replaced
+   * under a tab nobody switched away from does not raise it. Neither does a
+   * socket that stops carrying bytes without erroring, which is what a phone
+   * hands back and what Datastar has no way to notice: it believes the request
+   * is live, and there is nothing else to ask. Silence is the only evidence
+   * available, which is why the server sends something to be silent *instead
+   * of*.
+   *
+   * False while the document is hidden, whatever the clock says. Datastar
+   * closes the stream on its way out of view and opens it again on the way
+   * back, so quiet is correct there, and the timers driving this are throttled
+   * anyway — a page returning after an hour would otherwise reconnect twice,
+   * once for the return and once for the hour.
+   */
+  streamLost() {
+    return !document.hidden && Date.now() - streamLastSeen > STREAM_TIMEOUT_MS;
   },
 };
 

--- a/apps/mariastew/web/app.ts
+++ b/apps/mariastew/web/app.ts
@@ -3,10 +3,26 @@ declare global {
     pasteInto(field: HTMLInputElement): void;
     clickOnEnter(evt: KeyboardEvent, button: HTMLButtonElement): void;
     browseUrl(evt: Event): string | null;
-    streamSeen(): void;
+    streamEvent(
+      evt: CustomEvent<{ type: string; argsRaw?: Record<string, string> }>,
+    ): void;
     streamLost(): boolean;
   };
 }
+
+/**
+ * The Datastar fetch events that are evidence the stream is carrying bytes.
+ *
+ * An allowlist rather than a list of the failures to ignore, so an event type
+ * nobody here has heard of cannot be mistaken for liveness — which is the
+ * whole quantity being measured.
+ */
+const STREAM_FRAMES = new Set([
+  "started",
+  "datastar-heartbeat",
+  "datastar-patch-elements",
+  "datastar-patch-signals",
+]);
 
 /**
  * Three of the server's five-second heartbeats, and a little more.
@@ -19,6 +35,10 @@ declare global {
 const STREAM_TIMEOUT_MS = 16_000;
 
 let streamLastSeen = Date.now();
+
+/** Set by a 401: the stream is refused rather than lost, and no reconnect
+ * fixes that. Cleared by anything the server actually serves. */
+let streamRefused = false;
 
 /**
  * The behaviours that do not belong in an attribute.
@@ -93,15 +113,36 @@ globalThis.ms = {
   },
 
   /**
-   * Note that the stream just proved it is there.
+   * Take one of the stream's own Datastar fetch events.
    *
-   * Anything at all counts — a row patch, the heartbeat behind it
-   * (`routes::HEARTBEAT`), or Datastar announcing it has started a request.
-   * The last of those is what stops a reconnect that cannot connect from
-   * retrying every interval: the attempt itself resets the clock, so a server
-   * that is down is asked once per timeout rather than once per tick.
+   * A frame is proof the connection is there and resets the clock
+   * `streamLost` reads — a row patch, the heartbeat behind it
+   * (`routes::HEARTBEAT`), or Datastar announcing it has *started* a request.
+   * That last one is what stops a reconnect that cannot connect from retrying
+   * every tick: the attempt itself resets the clock, so a server that is down
+   * is asked once per timeout.
+   *
+   * Which is exactly why a 401 has to stop it outright. A session lives only in
+   * the pod's memory, so the deploy that ends the stream is usually the deploy
+   * that signs the page out, and `require_session` answers a Datastar request
+   * with a status where a navigation would get the login redirect —
+   * deliberately, since a stream cannot be redirected. No reconnect gets past
+   * that, and every attempt would reset the clock for the next one, so the page
+   * would ask forever and never arrive anywhere.
+   *
+   * It is refused rather than dead, so a later frame lifts it: the reconnect on
+   * returning to the foreground is unconditional, and if that one is served
+   * the session came back and the watchdog should resume. `started` is not
+   * enough — that is the asking, not the answer.
    */
-  streamSeen() {
+  streamEvent(evt) {
+    const { type, argsRaw } = evt.detail;
+    if (type === "error") {
+      streamRefused ||= argsRaw?.status === "401";
+      return;
+    }
+    if (!STREAM_FRAMES.has(type)) return;
+    if (type !== "started") streamRefused = false;
     streamLastSeen = Date.now();
   },
 
@@ -122,9 +163,16 @@ globalThis.ms = {
    * back, so quiet is correct there, and the timers driving this are throttled
    * anyway — a page returning after an hour would otherwise reconnect twice,
    * once for the return and once for the hour.
+   *
+   * False too once the stream has been refused. Quiet that nothing can cure is
+   * not worth a request every timeout, forever, for as long as the tab is open.
    */
   streamLost() {
-    return !document.hidden && Date.now() - streamLastSeen > STREAM_TIMEOUT_MS;
+    return (
+      !streamRefused &&
+      !document.hidden &&
+      Date.now() - streamLastSeen > STREAM_TIMEOUT_MS
+    );
   },
 };
 


### PR DESCRIPTION
Closes #390. Follow-on from #386, which fixed the half of this that had a trigger.

## What breaks

A stream can stop with nobody told, two ways:

- **It ended.** Datastar reads a finished 200 body as the request being over — no retry, and it drops its own `visibilitychange` listener on the way out. An ordinary deploy does this to every open page: the pod is replaced rather than drained.
- **It went quiet.** A socket stops carrying bytes without erroring, which is what a suspended phone hands back. Datastar still believes the request is live and has nothing to notice.

#386 covered the case where the page left and came back. A tab nobody switched away from has no such trigger, so a laptop left open on `dl.blit.cc` showed a frozen list until reloaded. Datastar's own account of whether the stream is up is the one thing this cannot consult — in the second case it is simply wrong.

## The change

Watch the quiet. That needed silence to mean something first: the stream sends the rows whose hash moved, so an idle queue is silent because there is nothing to report.

**Server** — `HEARTBEAT` (5s) emits a bare `datastar-heartbeat` frame, but only when nothing else went down the wire, so a busy stream sends none. Two decisions worth the reviewer's attention:

- It runs on its own `tokio::time::interval`, selected against `viewer.next()`, **not** counted off the poller's ticks. A poller wedged on an unreachable aria2 would otherwise take every page's heartbeat down at once and reconnect the lot — to a server whose problem another connection does not solve. (`watch::Receiver::changed` is cancel-safe, so losing the race drops no snapshot.)
- The timer resets only when something was **actually yielded**. `unsent` answers with an empty list for a queue sitting still, which is every tick of the case the heartbeat exists for; resetting on those would have suppressed it exactly where it is needed.

It replaces axum's `KeepAlive` rather than joining it — both stop a proxy timing out an idle connection, only this one reaches the page.

**Client** — `ms.streamSeen` / `ms.streamLost` in `web/app.ts`, driven by `data-on-interval__duration.5s`. Timeout is three heartbeats plus slack; two would reconnect over one frame lost to a stalled event loop. Datastar announcing a request *started* counts as a frame, which is the backoff: a reconnect that cannot connect resets its own clock, so a downed server is asked once per timeout rather than once per tick.

`data-on:visibilitychange` from #386 stays, now as the fast path rather than the whole mechanism — sixteen seconds of stale screen with a phone in your hand is worth skipping.

## How to confirm it works

None of `cargo test`, `cargo clippy` or `mise run check` can see this — it is browser behaviour driven by an attribute. Verified against the running app under `docker compose`, with chromium. Three runs, same binary; the control strips `data-on-interval` out of the served HTML so the attribute is the only difference:

| run | `/stream` requests after load | after 21s | heartbeats received |
|---|---|---|---|
| healthy, real server | 1 | **1** | **4** |
| stream dies, control | 2 | **2** | 0 |
| stream dies, this branch | 2 | **3** | 0 |

- **Row 1 is the no-false-positive case** and the end-to-end proof: four heartbeats arrived as `datastar-fetch` events of type `datastar-heartbeat`, and an idle page held one connection across 23s without twitching.
- **Row 2 is the bug**: the stream ends, `finished` fires, `ms.streamLost()` goes true and stays true, nothing reconnects.
- **Row 3 reconnects exactly once** in 21s, not repeatedly — that is `started` resetting the clock, i.e. the backoff above doing its job rather than a coincidence.

Wire format checked directly too: `event: datastar-heartbeat` with no data field, emitted only in the gaps between patches.

By hand: open the page, `kubectl rollout restart` mariastew, and watch the list resume within ~16s without touching anything.