### PR TITLE
402 refactor(mcp-gateway): the package depends on nothing of the estate's

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -270,9 +270,6 @@ importers:
 
   packages/mcp-gateway:
     dependencies:
-      '@jaritanet/k8s':
-        specifier: workspace:*
-        version: 0.0.0
       '@pulumi/kubernetes':
         specifier: 4.30.0
         version: 4.30.0(typescript@6.0.3)

--- a/packages/infra/src/services.ts
+++ b/packages/infra/src/services.ts
@@ -22,7 +22,7 @@ import { createServiceRecord } from "@jaritanet/dns";
 import { createFiles } from "@jaritanet/files";
 import { createSamba, createSyncthing } from "@jaritanet/home";
 import { createIngressRoute } from "@jaritanet/ingress";
-import type { Deployed, Route } from "@jaritanet/k8s";
+import { type Deployed, resourceRequests, type Route } from "@jaritanet/k8s";
 import { createMariastew } from "@jaritanet/mariastew";
 import { createMcpGateway } from "@jaritanet/mcp-gateway";
 import { createMetrics, GRAFANA } from "@jaritanet/metrics";
@@ -49,6 +49,9 @@ import { MCPS } from "./mcps.ts";
  * that machine, applied by the seed drive when it joins.
  */
 const MEDIA_NODE = "lady";
+
+/** One binding, because the requests below are derived from it. */
+const MCP_GATEWAY_LIMITS = { cpu: "250m", memory: "256Mi" };
 const FILE_NODE_LABEL = "jaritanet.radiosilence.dev/file-node";
 
 /**
@@ -220,7 +223,11 @@ export function createServices(ctx: EstateContext) {
           replicas: 2,
           // Routes and terminates OAuth rather than serving a file, so more
           // headroom than blit — but it measured 1m CPU idle, not 500m.
-          limits: { cpu: "250m", memory: "256Mi" },
+          limits: MCP_GATEWAY_LIMITS,
+          // The chart takes the numbers and states no policy about them: how
+          // much of a ceiling to reserve depends on what else shares the node,
+          // which is ours to know. See `resourceRequests`.
+          requests: resourceRequests(MCP_GATEWAY_LIMITS).requests,
           mcps: MCPS,
         },
         {

--- a/packages/mcp-gateway/package.json
+++ b/packages/mcp-gateway/package.json
@@ -14,7 +14,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@jaritanet/k8s": "workspace:*",
     "@pulumi/kubernetes": "4.30.0",
     "@pulumi/pulumi": "3.239.0",
     "@pulumi/random": "4.20.0",

--- a/packages/mcp-gateway/src/contract.ts
+++ b/packages/mcp-gateway/src/contract.ts
@@ -1,0 +1,59 @@
+/**
+ * What this package needs from Kubernetes and hands back to whoever deploys it.
+ *
+ * Declared here rather than imported from a shared package, and that is the
+ * point: this is a chart. It describes how to stand the gateway up and knows
+ * nothing about the estate standing it up — so it depends on `@pulumi/*` and
+ * `zod` and nothing else, and can be published and consumed by a deployment
+ * that has never heard of jaritanet.
+ *
+ * The duplication is small and deliberate. A shared-primitives package would
+ * have to be published too, and would make one deployment's conventions part of
+ * every consumer's dependency tree.
+ */
+import * as z from "zod";
+
+/** A Kubernetes resource quantity — `500m`, `2`, `64Mi`, `8Gi`. */
+export const Quantity = z
+  .string()
+  .regex(
+    /^\d+(\.\d+)?([munkMGTPE]|[KMGTPE]i)?$/,
+    "must be a Kubernetes quantity, e.g. 500m, 2, 64Mi, 8Gi",
+  );
+
+export const ResourcesSchema = z.strictObject({
+  cpu: Quantity.default("50m"),
+  memory: Quantity.default("64Mi"),
+});
+
+/**
+ * A hostname the deployment should publish, and the workload answering it.
+ *
+ * `service` is the name prefix: the Service is `<prefix>-service`, so a route
+ * names the pair rather than either half.
+ */
+export type Route = {
+  service: string;
+  hostname: string;
+  paths?: string[];
+  priority?: number;
+};
+
+/**
+ * The OAuth client this needs registered for it.
+ *
+ * Returned rather than configured, because the callback path is the gateway's
+ * own and the host half comes from the hostname it was told to publish at — so
+ * the redirect URI cannot name somewhere the service is not.
+ */
+export type OidcClient = {
+  id: string;
+  name: string;
+  redirectUri: string;
+};
+
+/** What the deployer gets back: where this stands, and what to register. */
+export type Deployed = {
+  routes: Route[];
+  oidc?: OidcClient;
+};

--- a/packages/mcp-gateway/src/mcp-gateway.schemas.ts
+++ b/packages/mcp-gateway/src/mcp-gateway.schemas.ts
@@ -1,5 +1,5 @@
-import { LimitsSchema } from "@jaritanet/k8s";
 import * as z from "zod";
+import { ResourcesSchema } from "./contract.ts";
 
 /** One value a backend MCP needs from the user, injected into its own header. */
 export const McpCredentialFieldSchema = z.object({
@@ -85,7 +85,16 @@ export const McpGatewayConfSchema = z.object({
   // Blank in the (public) repo; injected at CI time from secrets, so the source
   // reveals no hostnames. An empty hostname skips the stack (see infra main.ts).
   replicas: z.number().default(2),
-  limits: LimitsSchema.default({ cpu: "500m", memory: "256Mi" }),
+  limits: ResourcesSchema.default({ cpu: "500m", memory: "256Mi" }),
+  /**
+   * Left to the deployer rather than derived from `limits`.
+   *
+   * How much of a ceiling to reserve is a scheduling policy — it depends on
+   * what else shares the node and how bursty it is — so it belongs to whoever
+   * runs the cluster, not to the chart. Absent means Kubernetes defaults the
+   * request to the limit, which is the conservative reading.
+   */
+  requests: ResourcesSchema.optional(),
   // Postgres uses the cluster's default StorageClass unless set — a few tiny
   // tables, so (unlike the media services) we don't pin them to a disk path.
   postgresStorageClass: z.string().optional(),

--- a/packages/mcp-gateway/src/mcp-gateway.ts
+++ b/packages/mcp-gateway/src/mcp-gateway.ts
@@ -3,10 +3,9 @@ import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import * as yaml from "yaml";
 import type * as z from "zod";
-import type { Deployed } from "@jaritanet/k8s";
+import type { Deployed } from "./contract.ts";
 import { UNTRACKED, VERSIONS } from "./versions.ts";
 import { McpGatewayConfSchema } from "./mcp-gateway.schemas.ts";
-import { resourceRequests } from "@jaritanet/k8s";
 
 const SECRETS_NAME = "mcp-gateway-secrets";
 /** An env `valueFrom` pointing at a key in the stack's Secret. */
@@ -496,7 +495,7 @@ export function createMcpGateway(
                 },
                 resources: {
                   limits: conf.limits,
-                  ...resourceRequests(conf.limits),
+                  ...(conf.requests && { requests: conf.requests }),
                 },
                 securityContext: { allowPrivilegeEscalation: false },
               },


### PR DESCRIPTION
Part of #402. Prerequisite for radiosilence/mcp-gateway#46, which moves this
package into its own repo and publishes it.

A chart cannot import the deployment that instantiates it. Three symbols
crossed that line, and what each turned out to be is the useful part:

| symbol | verdict |
|---|---|
| `Deployed` | the package's own public API — declared in `contract.ts` |
| `LimitsSchema` | same; it's four lines of Zod |
| `resourceRequests` | **does not cross at all** |

**`resourceRequests` is a scheduling policy, not a primitive.** How much of a
ceiling to reserve depends on what else shares the node, which belongs to
whoever runs the cluster — and the reasoning behind ours is thirty lines about
lady's memory and blit holding two of four CPUs. The chart now takes `limits`
and an optional `requests`; jaritanet applies the policy at the call site, from
one binding so the two cannot disagree.

The duplication of the other two is deliberate. The alternative is publishing a
shared-primitives package, which would make one deployment's conventions part
of every consumer's dependency tree.

## How to confirm

`pulumi preview` → `185 unchanged`. `packages/mcp-gateway` now depends on
`@pulumi/*`, `yaml` and `zod`, and nothing else.