### PR TITLE
402 refactor(config): hostnames in the clear

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,6 @@ say what it runs — and the compiler checks the shape, the editor completes it,
 and a value needed twice is one binding rather than two entries that can drift.
 `infra/src/secrets.ts` is the only thing that reads stack config.
 
-Service hostnames are the exception, and are in config for one reason: the
-repository is public. They carry certificates, so Certificate Transparency
-publishes them anyway — encrypting them denies the drive-by reader a list, not
-a determined one.
-
 **Every service is a function call.** There is no `services` map and no `kind`
 union; that union existed only so data could select a constructor, which is what
 a program does by calling one. What every service shares — an address, and

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ emit and `@pulumi/pulumi` moved to a peer dependency.
 still in the stack, so `pulumi up` from a laptop needs a Pulumi login and
 nothing else.
 
+Service hostnames used to be encrypted here so a public repository would not
+hand out the list. They carry certificates, so Certificate Transparency held
+them regardless, and that only bought anything while the logs were awkward to
+search — crt.name lists every name under a domain in one query. They are plain
+values in `stack.ts` now, which also retires the rule that no doc or comment
+could name a host.
+
 Secrets inside structured config decrypt to ordinary strings: the `secure:`
 wrapper exists only in the stack file, and the `[secret]` in a deploy's output
 is the engine redacting its own stdout. That is what lets a credential sit in

--- a/packages/infra/Pulumi.main.yaml
+++ b/packages/infra/Pulumi.main.yaml
@@ -13,6 +13,12 @@
 #
 # A secret decrypts to an ordinary string in the program, so one Zod parse in
 # `src/secrets.ts` still validates the whole block.
+#
+# Hostnames used to be here too, encrypted so a public repository would not hand
+# out the list. Every one of them carries a certificate and so was in the
+# Certificate Transparency logs regardless; that only mattered while the logs
+# were awkward to search, which crt.name ended. They are plain values in
+# `src/stack.ts` now.
 config:
   # Configures the provider; nothing can read this copy back out.
   cloudflare:apiToken:
@@ -20,32 +26,6 @@ config:
   # Configures the provider; nothing can read this copy back out.
   hcloud:token:
     secure: AAABALtD7dj7hUYrd1dLznzw5u+hjfJj5fCpMv7fRmoXKOKxtlczVbxdWKzmDhHWJHHfQkj6Z8qoxgZqIatPwDZAvi+CDQS+OqDUhBLRSXl815dDWd8jB+/p6cHE2YTK
-  # The service hostnames, encrypted — which is not the same claim as private.
-  # Every one carries a certificate, so it is in the public Certificate
-  # Transparency logs already and can be found by anyone who goes looking. What
-  # this buys is that a public repository does not hand out the list: the
-  # drive-by case, not the determined one. blit.cc stays in the clear because it
-  # is the apex and fronts a public site, so there is nothing to withhold.
-  #
-  # Only worth anything while the rest of the repository agrees: a hostname
-  # repeated in a doc or a comment undoes it silently.
-  jaritanet:hostnames:
-    auth:
-      secure: AAABABkYbnTgozUhAX/ALlO4+fnO9O6G7GnrIBiLuaR2uBVC9pSXjz8dR3g=
-    files:
-      secure: AAABAHFob6VSSPAryzCz1JmtWNQ9d4CnjpAHx14AgwDb75eRTy4FPmcrmYOXagsN1+RQNzPF
-    mariastew:
-      secure: AAABALH0zY11nQLr6MZkyhv8bm35+Wpvwnxeq3YQBVjpRN6zuFzwHtrA
-    mcp-gateway:
-      secure: AAABADHN+GrfSd0qTwQAuaJp3u9RRiCJf/3Ki4LWnL2HYjO6XupTDBd6qw==
-    metrics:
-      secure: AAABAPrG5CFazA6hrLjmaKcEWD5ye0zMJwhhWlQdHb5ZYE60sU/xNXzJzyA=
-    navidrome:
-      secure: AAABAOdacdl4CcEW/0b8Wssi5aAAtgT36tDzLCGgrCDnUsySnEuGoId0I0g4
-    singbox-profiles:
-      secure: AAABAD4z8yRK5YnDrYTWNebcjtt0TQU8tTs+0AhHNx2NQGoAQ/8G19VGYiUeSGTTVig=
-    # Public, and the only one that is: it is the site.
-    blit: blit.cc
   jaritanet:secrets:
     cloudflareApiToken:
       secure: AAABAJX8cafbz/aUgmLbmT8KblMp3cbVu78cRvOC7JmXtIXI/WMVheCHJvsojIG+k22JfcCFaty4nNxeqRqF5C+dWg0GTAHQarqZhWlgF5toq3RGeA==

--- a/packages/infra/src/main.ts
+++ b/packages/infra/src/main.ts
@@ -23,7 +23,7 @@ import {
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { warnUnlessCleanMain } from "./checkout.ts";
-import { hostnames, secrets } from "./secrets.ts";
+import { secrets } from "./secrets.ts";
 import {
   ADMIN_SSH_KEY,
   auth as authConf,
@@ -33,6 +33,7 @@ import {
   exits as exitConfs,
   fastmail,
   gateway as gatewayConf,
+  hostnames,
   MANAGED_BY,
   NAMESPACE,
   tailnet,

--- a/packages/infra/src/secrets.ts
+++ b/packages/infra/src/secrets.ts
@@ -6,16 +6,10 @@
  * the compiler checks it, the editor completes it, and a value used twice is
  * one binding rather than two entries that can disagree.
  *
- * Hostnames are here for the same reason and no other: they carry certificates
- * and are in the public Certificate Transparency logs already, so encrypting
- * them buys nothing against a determined reader — only against a public
- * repository handing out the list.
- *
  * `getObject` returns plaintext. The `secure:` wrapper exists in the stack file,
  * and the `[secret]` in a deploy's output is the engine redacting its own
  * stdout, so one Zod parse still validates the whole block.
  */
-import { Hostname } from "@jaritanet/k8s";
 import * as pulumi from "@pulumi/pulumi";
 import * as z from "zod";
 
@@ -44,14 +38,3 @@ const SecretsSchema = z.strictObject({
 const config = new pulumi.Config();
 
 export const secrets = SecretsSchema.parse(config.requireObject("secrets"));
-
-/**
- * Where each service is published, keyed by the name it is created under.
- *
- * A name with no entry is built and not published, which is a real state: the
- * samba shares and syncthing's UI are reached on the LAN and the tailnet and
- * have no business having an address.
- */
-export const hostnames = z
-  .record(z.string(), Hostname)
-  .parse(config.requireObject("hostnames"));

--- a/packages/infra/src/stack.ts
+++ b/packages/infra/src/stack.ts
@@ -52,6 +52,40 @@ export const VPN_ENTRY_LABEL = "jaritanet.radiosilence.dev/vpn-entry";
 export const ADMIN_SSH_KEY =
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIOKFd98fp579BSC4svd/E8h1Bs5aeu9Iv5qix40+WmI jc@blit.cc";
 
+/**
+ * Where each service is published.
+ *
+ * In the clear. These were encrypted on the grounds that a public repository
+ * should not hand out the list, while conceding that every one of them carries
+ * a certificate and is therefore in the Certificate Transparency logs already.
+ * That distinction rested on the logs being awkward to search, and it has not
+ * survived: crt.name will list every name under a domain in one query. The
+ * encryption was buying nothing and costing a rule that every doc and comment
+ * in the repository had to avoid naming a host.
+ *
+ * Nothing here was ever a security control. `p.radiosilence.dev` is unguessable
+ * by its *path*, which is a generated slug and stays secret; mariastew is a
+ * write endpoint onto the media library and is gated by OIDC, not by its
+ * address.
+ *
+ * A name with no entry is built and not published, which is a real state: the
+ * samba shares and syncthing's UI are reached on the LAN and the tailnet and
+ * have no business having an address.
+ */
+export const hostnames: Record<string, string> = {
+  auth: "auth.blit.cc",
+  blit: "blit.cc",
+  files: "files.radiosilence.dev",
+  mariastew: "dl.blit.cc",
+  "mcp-gateway": "mcp.blit.cc",
+  metrics: "dash.blit.cc",
+  navidrome: "music.blit.cc",
+  // Deliberately not on blit.cc: FortiGuard rates it "Other Adult Materials",
+  // so a filtered network — exactly the network a VPN profile is wanted on —
+  // blocks the device from fetching its own subscription.
+  "singbox-profiles": "p.radiosilence.dev",
+};
+
 export const cloudflare = CloudflareConfSchema.parse({
   accountId: "365e5168438376dc99d7ee2aedef4624",
   apiToken: secrets.cloudflareApiToken,


### PR DESCRIPTION
Part of #402.

The hostnames were encrypted so a public repository would not hand out the
list — while the comment justifying it conceded, in the same breath, that every
one carries a certificate and is in the Certificate Transparency logs anyway.
The whole distinction rested on those logs being awkward to search.

[crt.name](https://crt.name/) ended that. Every name under a domain, one query.

So the encryption was buying nothing, and costing a real rule: *"only worth
anything while the rest of the repository agrees — a hostname repeated in a doc
or a comment undoes it silently."* That constraint is retired.

**Nothing here was ever a security control.** `p.radiosilence.dev` is
unguessable by its *path*, which is a generated slug and stays secret;
mariastew is a write endpoint onto the media library and is gated by OIDC, not
by its address.

`Pulumi.main.yaml` is now 47 lines of credentials.

## How to confirm

`pulumi preview` → `185 unchanged`. Same values, read from a different place.