### PR TITLE
402 feat(blit): the updater follows it, instead of it rewriting this repo

### DIFF
--- a/.github/tracked-versions.yml
+++ b/.github/tracked-versions.yml
@@ -199,10 +199,22 @@
   value: "v{version}"
   image: "docker.io/rancher/system-upgrade-controller:v{version}"
 
+# blit follows a branch rather than a release: it is a website, and a typo fix
+# should not need a version bump to reach it. Its own CI asks this workflow to
+# run once it has pushed the image, so the pin moves within a minute of a
+# content change rather than at the next scheduled sweep.
+- app: blit
+  repo: radiosilence/blit
+  branch: main
+  file: packages/blit/src/versions.ts
+  key: blit
+  value: "sha-{version}"
+  image: "ghcr.io/radiosilence/blit:sha-{version}"
+
 # Deliberately absent, and each said so where it is pinned, in an `UNTRACKED`
 # const beside the `VERSIONS` the updater does read: Hydra (a major bump needs
-# a database migration), postgres and redis (major tags that carry their own
-# patches), and blit (pinned to a build, because it cuts no releases).
+# a database migration), and postgres and redis (major tags that carry their
+# own patches).
 #
 # Also deliberately absent: k3s and Cilium. Cilium's version has to match the
 # cluster's k8s minor, and k3s is the cluster — bumping either unattended

--- a/packages/blit/src/blit.ts
+++ b/packages/blit/src/blit.ts
@@ -1,6 +1,6 @@
 import { createService, type Deployed } from "@jaritanet/k8s";
 import type * as k8s from "@pulumi/kubernetes";
-import { UNTRACKED } from "./versions.ts";
+import { VERSIONS } from "./versions.ts";
 
 /**
  * The public site. A static bundle behind nano-web, and the only workload here
@@ -29,7 +29,7 @@ export function createBlit(
     // nano-web processes every file before it binds, which under 100m outlasted
     // the liveness probe.
     limits: { cpu: "500m", memory: "192Mi" },
-    image: { repository: "ghcr.io/radiosilence/blit", tag: UNTRACKED.blit },
+    image: { repository: "ghcr.io/radiosilence/blit", tag: VERSIONS.blit },
     httpPort: 3000,
   });
 

--- a/packages/blit/src/index.ts
+++ b/packages/blit/src/index.ts
@@ -1,2 +1,2 @@
 export { createBlit } from "./blit.ts";
-export { UNTRACKED as BLIT_UNTRACKED } from "./versions.ts";
+export { VERSIONS as BLIT_VERSIONS } from "./versions.ts";

--- a/packages/blit/src/versions.ts
+++ b/packages/blit/src/versions.ts
@@ -1,12 +1,14 @@
 /**
- * Pinned to a build rather than a release, which is why it is not in
- * `.github/tracked-versions.yml`: blit cuts no releases, so there is no tag for
- * the updater to follow and this moves by hand.
+ * Pinned to a build, not a release.
  *
- * That is a gap rather than a design — it is the one image in the estate
- * nothing watches. It closes when blit gains a release process of its own,
- * which is also what it needs before it can publish its own deploy package.
+ * blit is a website: a typo fix should reach it without a version bump, so its
+ * images are tagged by commit and this follows the head of `main`. The updater
+ * resolves that itself rather than blit reaching in here and rewriting it,
+ * which is what it used to do — and what broke the moment this repository's
+ * config became TypeScript.
+ *
+ * Rewritten in place by the version updater; see `.github/tracked-versions.yml`.
  */
-export const UNTRACKED = {
+export const VERSIONS = {
   blit: "sha-e7ec682",
 } as const;

--- a/scripts/update-apps/update-apps.ts
+++ b/scripts/update-apps/update-apps.ts
@@ -101,6 +101,26 @@ async function imageExists(ref: string) {
  * one thing. With a prefix the list is read instead and filtered — skipping
  * drafts and prereleases, which is what `releases/latest` does for us otherwise.
  */
+/**
+ * The short SHA a branch points at, for entries that follow one.
+ *
+ * Seven characters because that is what the container workflows tag with; the
+ * pin has to be a tag that exists, not a commit that does.
+ */
+async function headSha(repo: string, branch: string) {
+  try {
+    const { stdout } = await run("gh", [
+      "api",
+      `repos/${repo}/commits/${branch}`,
+      "--jq",
+      ".sha",
+    ]);
+    return stdout.trim().slice(0, 7) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function latestTag(repo: string, prefix?: string) {
   try {
     if (!prefix) {
@@ -232,14 +252,17 @@ const titles: string[] = [];
 const details: string[] = [];
 
 for (const entry of entries) {
-  const tag = await latestTag(entry.repo, entry.tagPrefix);
+  const tag = entry.branch
+    ? await headSha(entry.repo, entry.branch)
+    : await latestTag(entry.repo, entry.tagPrefix);
   if (!tag) {
     warn(`${entry.app} — no readable release on ${entry.repo}`);
     failed.push(entry.app);
     continue;
   }
 
-  const version = normaliseVersion(tag);
+  // A branch head is already the version; only a release tag needs unpicking.
+  const version = entry.branch ? tag : normaliseVersion(tag);
   const next = applyTemplate(entry.value, version);
   const ref = verifyRef(entry, version);
   const decision = decide({

--- a/scripts/update-apps/versions.ts
+++ b/scripts/update-apps/versions.ts
@@ -41,6 +41,18 @@ export const TrackedSchema = z.intersection(
     value: z.string(),
     image: z.string().optional(),
     tagPrefix: z.string().optional(),
+    /**
+     * Follow a branch's head rather than a release.
+     *
+     * For something released continuously: blit is a website, and a typo fix
+     * should not need a version bump to reach it. Its images are tagged by
+     * commit, so what there is to follow is where the branch points.
+     *
+     * The resolved value is a short commit SHA and is used verbatim — it never
+     * goes through `normaliseVersion`, which strips everything before the first
+     * digit and would turn `e7ec682` into `7ec682`.
+     */
+    branch: z.string().optional(),
   }),
   TargetSchema,
 );


### PR DESCRIPTION
Closes the last unwatched pin — and fixes a cross-repo break I caused.

## blit's deploy is broken right now

blit was never unwatched. **It pushed its own tag in here**: its CI cloned
jaritanet and ran `yq` against
`.config."jaritanet:services".blit.args.image.tag`.

That path stopped existing in #404. blit's next push to main would have gone
red — safely, because `deploy:update` checks the path resolves before writing
anything, but red. I broke it and did not notice, because it lives in another
repository.

## Inverting it is less coupling, not more

blit had to know this repo's file layout, which is precisely what changed under
it. Now it says *"a build exists"* and jaritanet decides what that means.

Paired with **radiosilence/blit#52**, which swaps the clone-and-`yq` for
`gh workflow run update-apps.yml`.

## A source that follows a branch

blit is a website; a typo fix should not need a version bump to reach it. So
there is no release to follow, and the updater grows `branch:`:

```yaml
- app: blit
  repo: radiosilence/blit
  branch: main
  file: packages/blit/src/versions.ts
  key: blit
  value: "sha-{version}"
  image: "ghcr.io/radiosilence/blit:sha-{version}"
```

It resolves the head commit to the short SHA the images are tagged with, and
**skips `normaliseVersion`** — that strips everything before the first digit,
which would read `e7ec682` as `7ec682`.

blit's pin moves `UNTRACKED` → `VERSIONS` accordingly.

## Speed

blit CI pushes the image, asks for the updater, the updater moves the pin and
pushes, and CD deploys. Minutes, and every step is a thing you can look at
afterwards. Nothing runs on a moving tag, so git still says exactly which build
is live.

## How to confirm

- `--dry-run` → `blit — up to date (sha-e7ec682)`, resolved from `main`'s head
  rather than from a release
- `pulumi preview` → `185 unchanged`
- 165 tests

## Needs doing by hand

`DEPLOYMENT_PAT` in blit's repo now wants `actions: write` here, and no longer
wants `contents: write`. Worth narrowing rather than leaving a write-to-main
token lying around.