### PR TITLE
402 fix(ci): update-apps could not authenticate to GitHub Packages

### DIFF
--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      packages: read
 
     steps:
       - name: Generate App Token
@@ -49,6 +50,13 @@ jobs:
 
       - name: Setup Environment
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+
+      # `.npmrc` names a token file rather than an ${ENV}, because aube refuses
+      # to expand environment variables in auth settings a project controls.
+      - name: Authenticate to GitHub Packages
+        run: mise run auth
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
         uses: endevco/aube-action@f82ca2f6c943dbde1904945d9f0ee1a0faf8e945 # v1.0.0

--- a/scripts/workflows.test.ts
+++ b/scripts/workflows.test.ts
@@ -1,0 +1,48 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WORKFLOWS = join(import.meta.dirname, "..", ".github", "workflows");
+
+const workflows = async () => {
+  const names = (await readdir(WORKFLOWS)).filter((n) => n.endsWith(".yml"));
+  const texts = await Promise.all(
+    names.map((n) => readFile(join(WORKFLOWS, n), "utf8")),
+  );
+  return names.map((name, i) => ({ name, text: texts[i]! }));
+};
+
+/**
+ * The stack depends on packages published from the app repositories, and
+ * GitHub Packages wants a token even for public ones. `.npmrc` names a token
+ * file rather than an `${ENV}`, because aube refuses to expand environment
+ * variables in auth settings a project controls — so something has to write
+ * that file before anything installs.
+ *
+ * Forgetting it fails at install time with a 401 that reads like a broken
+ * registry. It has already happened once: three workflows got the step and
+ * `update-apps` did not, so the nightly updater failed on a package it had
+ * been installing happily by hand.
+ */
+describe("every workflow that installs can authenticate", () => {
+  it("writes the token file before installing", async () => {
+    for (const { name, text } of await workflows()) {
+      if (!text.includes("aube-action")) continue;
+      expect(
+        text.indexOf("mise run auth"),
+        `${name} authenticates`,
+      ).toBeGreaterThan(-1);
+      expect(
+        text.indexOf("mise run auth"),
+        `${name} authenticates before it installs`,
+      ).toBeLessThan(text.indexOf("aube-action"));
+    }
+  });
+
+  it("grants itself read access to the packages", async () => {
+    for (const { name, text } of await workflows()) {
+      if (!text.includes("aube-action")) continue;
+      expect(text, `${name} has packages: read`).toContain("packages: read");
+    }
+  });
+});


### PR DESCRIPTION
The updater has failed on its last three runs, including the one blit asked for
after #52 merged. **My miss** — I added the GitHub Packages auth step to
`ci.yml`, `cd.yml` and `preview.yml`, and there were four workflows that install.

```
× registry error for @radiosilence/mcp-gateway-pulumi: 401 Unauthorized
  help: packument fetch failed — verify the registry URL in .npmrc, check auth
```

Which reads like a broken registry and isn't: the stack now depends on a package
published from another repository, and GitHub Packages wants a token even for a
public one. `update-apps.yml` never wrote it.

Adds the step, and `packages: read` alongside it.

## Guarded, not just fixed

The same omission will happen to the next workflow that installs. A test walks
`.github/workflows` and fails if one uses `aube-action` without writing the
token first, or without `packages: read`.

Reverting this workflow makes it fail with:

```
AssertionError: update-apps.yml authenticates: expected -1 to be greater than -1
```

Which names the workflow that is wrong — the report the 401 did not give.
Verified by actually reverting it and watching the test fail, then restoring.

## What this unblocks

`blit`'s end-to-end loop. Its CI already works: #52's merge built the image,
`update-deployment` succeeded, and jaritanet received the `workflow_dispatch`.
It then died at install. With this merged, blit's next push should carry
`sha-e7ec682` → `sha-3db1953` on its own.

`Files 1.0.0 → 1.0.1` has also been waiting since this morning and should land
on the same run.