### PR TITLE
402 fix(update-apps): a dependency bump is two files

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@pulumi/kubernetes@4.30.0)(@pulumi/pulumi@3.239.0(typescript@6.0.3))(zod@4.4.3)
       '@radiosilence/mcp-gateway-pulumi':
-        specifier: 0.8.3
-        version: 0.8.3(@pulumi/kubernetes@4.30.0)(@pulumi/pulumi@3.239.0(typescript@6.0.3))(@pulumi/random@4.20.0)(zod@4.4.3)
+        specifier: 0.8.4
+        version: 0.8.4(@pulumi/kubernetes@4.30.0)(@pulumi/pulumi@3.239.0(typescript@6.0.3))(@pulumi/random@4.20.0)(zod@4.4.3)
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -853,8 +853,8 @@ packages:
       '@pulumi/pulumi': ^3
       zod: ^4
 
-  '@radiosilence/mcp-gateway-pulumi@0.8.3':
-    resolution: {gitHosted: true, integrity: sha512-Ax/EPZkFG/XcRZ5W0FB53MzOktsP3lguwDhDwz9AH0Y6fqYLhQLrZz/42LMjW9UDtDS6QapWDFEl7p5hj5yKzA==, tarball: https://npm.pkg.github.com/download/@radiosilence/mcp-gateway-pulumi/0.8.3/b701f9ffddae1866d14bc02532c5d8e4cc010ca6}
+  '@radiosilence/mcp-gateway-pulumi@0.8.4':
+    resolution: {gitHosted: true, integrity: sha512-0av9BQIBqnsz0dz1wJWK181SvqtyHsHtu0gHGjJ+Kq7lYWmsSKpBTuKCQwWpMh/gYOS75q0WhW2eMSlTs+eBXQ==, tarball: https://npm.pkg.github.com/download/@radiosilence/mcp-gateway-pulumi/0.8.4/ed0353936392bb7f464473b5c0d838cef4820af4}
     peerDependencies:
       '@pulumi/kubernetes': ^4
       '@pulumi/pulumi': ^3
@@ -2581,7 +2581,7 @@ snapshots:
       '@pulumi/pulumi': 3.239.0(typescript@6.0.3)
       zod: 4.4.3
 
-  '@radiosilence/mcp-gateway-pulumi@0.8.3(@pulumi/kubernetes@4.30.0)(@pulumi/pulumi@3.239.0(typescript@6.0.3))(@pulumi/random@4.20.0)(zod@4.4.3)':
+  '@radiosilence/mcp-gateway-pulumi@0.8.4(@pulumi/kubernetes@4.30.0)(@pulumi/pulumi@3.239.0(typescript@6.0.3))(@pulumi/random@4.20.0)(zod@4.4.3)':
     dependencies:
       '@pulumi/kubernetes': 4.30.0(typescript@6.0.3)
       '@pulumi/pulumi': 3.239.0(typescript@6.0.3)

--- a/scripts/update-apps/update-apps.ts
+++ b/scripts/update-apps/update-apps.ts
@@ -305,6 +305,16 @@ for (const entry of entries) {
     sources.set(abs, rewritten);
     await writeFile(abs, rewritten);
     await git("add", abs);
+
+    // A dependency bump is two files. `aube install --frozen-lockfile` is what
+    // every workflow runs, and it refuses a manifest the lockfile disagrees
+    // with — so a commit carrying only package.json is a red deploy rather than
+    // a version that quietly did not take. Same commit, because the updater
+    // commits per entry and each one has to stand on its own.
+    if (!("file" in entry)) {
+      await run("aube", ["install", "--fix-lockfile"], { cwd: ROOT });
+      await git("add", join(ROOT, "aube-lock.yaml"));
+    }
     // `-n`: the pre-commit hook lints, formats and typechecks a working tree a
     // human is about to push. This commit is one scalar written by the process
     // that just parsed it, on a runner whose only stake in the hook is that it

--- a/scripts/workflows.test.ts
+++ b/scripts/workflows.test.ts
@@ -46,3 +46,32 @@ describe("every workflow that installs can authenticate", () => {
     }
   });
 });
+
+/**
+ * A dependency bump is two files. Every workflow installs with
+ * `--frozen-lockfile`, which refuses a manifest the lockfile disagrees with, so
+ * a commit carrying only `package.json` is a red deploy rather than a version
+ * that quietly did not take. It has happened once: the updater moved
+ * `@radiosilence/mcp-gateway-pulumi` to 0.8.4 and left the lockfile on 0.8.3.
+ */
+describe("the lockfile agrees with every manifest", () => {
+  it("resolves each workspace dependency at the version its manifest asks for", async () => {
+    const root = join(import.meta.dirname, "..");
+    const lock = await readFile(join(root, "aube-lock.yaml"), "utf8");
+    const manifests = ["packages/infra/package.json"];
+    for (const m of manifests) {
+      const { dependencies } = JSON.parse(
+        await readFile(join(root, m), "utf8"),
+      );
+      for (const [name, spec] of Object.entries(dependencies ?? {})) {
+        // Exact pins only. A range resolves to something the lockfile records
+        // and the manifest does not, so there is no string to compare — and
+        // the updater only ever writes exact versions anyway.
+        if (typeof spec !== "string" || !/^\d+\.\d+\.\d+/.test(spec)) continue;
+        expect(lock, `${m}: ${name}@${spec} is in the lockfile`).toContain(
+          `${name}@${spec}`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
**Main is red.** Fixes it, and stops it recurring.

You called it: the updater moved `@radiosilence/mcp-gateway-pulumi` to `0.8.4`
in `package.json` and left `aube-lock.yaml` on `0.8.3`. The deploy that commit
triggered died at install:

```
× lockfile is out of date with package.json: packages/infra:
  @radiosilence/mcp-gateway-pulumi: manifest says 0.8.4, lockfile says 0.8.3
```

`--frozen-lockfile` is right and should stay — it is what stops a deploy
resolving something the repository never agreed to. It also means a commit
carrying only the manifest is a **red deploy** rather than a version that
quietly did not take, which is the better of the two failures but still a
failure.

## The fix

The dependency target runs `aube install --fix-lockfile` and stages the
lockfile **in the same commit** — the updater commits per entry, so each has to
stand on its own.

Image-pin targets are untouched: a `versions.ts` line is one file, which is why
17 of the 20 entries never hit this.

This is a gap I left when I added the dependency target in #406 — it worked in
`--dry-run`, which writes nothing, and the first real bump was mcp-gateway's.

## Guarded

A test reads every **exactly pinned** dependency out of the manifests and fails
if the lockfile does not carry that version. Reverting the lockfile makes it say:

```
AssertionError: packages/infra/package.json:
  @radiosilence/mcp-gateway-pulumi@0.8.4 is in the lockfile
```

Verified by reverting it and watching it fail, then restoring.

Ranges are skipped — they resolve to a version the manifest never states, so
there is no string to compare. `@pulumi/tailscale@^0.29.0` caught that on the
first run, which is the test finding its own bug before I did.

## How to confirm

- `aube install --frozen-lockfile` succeeds, which is what CI runs
- `pulumi preview` → `184 unchanged`, `1 to update`: the gateway image
  `v0.8.3 → v0.8.4`, which is the bump that was stuck
- 168 tests