### PR TITLE
Serve queensheadstratford.london

### DIFF
--- a/.github/tracked-versions.yml
+++ b/.github/tracked-versions.yml
@@ -211,6 +211,16 @@
   value: "sha-{version}"
   image: "ghcr.io/radiosilence/blit:sha-{version}"
 
+# Same reasoning as blit, and the same shape: a website following a branch, whose
+# CI asks this workflow to run once the image is pushed.
+- app: queenshead
+  repo: radiosilence/qhstrtfrd
+  branch: main
+  file: packages/queenshead/src/versions.ts
+  key: queenshead
+  value: "sha-{version}"
+  image: "ghcr.io/radiosilence/qhstrtfrd:sha-{version}"
+
 # Deliberately absent, and each said so where it is pinned, in an `UNTRACKED`
 # const beside the `VERSIONS` the updater does read: Hydra (a major bump needs
 # a database migration), and postgres and redis (major tags that carry their

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -16,6 +16,7 @@
     "@jaritanet/k8s": "workspace:*",
     "@jaritanet/metrics": "workspace:*",
     "@jaritanet/navidrome": "workspace:*",
+    "@jaritanet/queenshead": "workspace:*",
     "@jaritanet/remote": "workspace:*",
     "@jaritanet/vpn": "workspace:*",
     "@pulumi/command": "1.2.1",

--- a/packages/infra/src/services.ts
+++ b/packages/infra/src/services.ts
@@ -27,6 +27,7 @@ import { createMariastew } from "@radiosilence/mariastew-pulumi";
 import { createMcpGateway } from "@radiosilence/mcp-gateway-pulumi";
 import { createMetrics, GRAFANA } from "@jaritanet/metrics";
 import { createNavidrome } from "@jaritanet/navidrome";
+import { createQueenshead } from "@jaritanet/queenshead";
 import {
   createProfileServer,
   type Exit,
@@ -162,6 +163,14 @@ export function createServices(ctx: EstateContext) {
     }),
   );
   add(createBlit(provider, "blit", { hostname: hostnames.blit }));
+  // Somebody else's pub, on somebody else's domain, served from the same node
+  // and the same base image as blit. Nothing about it is special enough to
+  // deserve its own anything.
+  add(
+    createQueenshead(provider, "queenshead", {
+      hostname: hostnames.queenshead,
+    }),
+  );
 
   // What lady serves off the media drive. Shares are anonymous — `map to guest`
   // turns unknown users into `guestAccount`, which must own the files or every

--- a/packages/infra/src/stack.ts
+++ b/packages/infra/src/stack.ts
@@ -202,7 +202,7 @@ export const zones = ZonesConfSchema.parse([
     // is not ours to point anywhere, and adding MX records to a working mailbox
     // is the one mistake here that would actually cost somebody something.
     name: "queensheadstratford.london",
-    zoneId: "REPLACE_WITH_ZONE_ID",
+    zoneId: "14d84661caade3ab45cf9d16f76102a1",
     modules: [],
   },
 ]);

--- a/packages/infra/src/stack.ts
+++ b/packages/infra/src/stack.ts
@@ -81,6 +81,9 @@ export const hostnames: Record<string, string> = {
   "mcp-gateway": "mcp.blit.cc",
   metrics: "dash.blit.cc",
   navidrome: "music.blit.cc",
+  // Not ours, and not on blit.cc: a pub on West Ham Lane, whose domain was
+  // pointing at a dead origin and 502ing.
+  queenshead: "queensheadstratford.london",
   // Deliberately not on blit.cc: FortiGuard rates it "Other Adult Materials",
   // so a filtered network — exactly the network a VPN profile is wanted on —
   // blocks the device from fetching its own subscription.
@@ -193,6 +196,14 @@ export const zones = ZonesConfSchema.parse([
     name: "buttholes.live",
     zoneId: "1115a1e5006523692d61e49e672f6df0",
     modules: MAIL_MODULES,
+  },
+  {
+    // Somebody else's domain, hosted as a favour. No mail modules: their email
+    // is not ours to point anywhere, and adding MX records to a working mailbox
+    // is the one mistake here that would actually cost somebody something.
+    name: "queensheadstratford.london",
+    zoneId: "REPLACE_WITH_ZONE_ID",
+    modules: [],
   },
 ]);
 

--- a/packages/queenshead/package.json
+++ b/packages/queenshead/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@jaritanet/queenshead",
+  "version": "0.0.0",
+  "private": true,
+  "description": "The Queen's Head, Stratford",
+  "license": "ISC",
+  "author": "James Cleveland <jc@blit.cc>",
+  "files": [
+    "src"
+  ],
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@jaritanet/k8s": "workspace:*",
+    "@pulumi/kubernetes": "4.30.0"
+  }
+}

--- a/packages/queenshead/src/index.ts
+++ b/packages/queenshead/src/index.ts
@@ -1,0 +1,2 @@
+export { createQueenshead } from "./queenshead.ts";
+export { VERSIONS as QUEENSHEAD_VERSIONS } from "./versions.ts";

--- a/packages/queenshead/src/queenshead.ts
+++ b/packages/queenshead/src/queenshead.ts
@@ -1,0 +1,37 @@
+import { createService, type Deployed } from "@jaritanet/k8s";
+import type * as k8s from "@pulumi/kubernetes";
+import { VERSIONS } from "./versions.ts";
+
+/**
+ * A pub's website. Static bytes behind nano-web, same shape as blit — the only
+ * difference is whose name is over the door.
+ */
+export function createQueenshead(
+  provider: k8s.Provider,
+  name: string,
+  opts: { hostname?: string },
+): Deployed {
+  createService(provider, name, {
+    // Public-facing, so confine egress to DNS and the internet. No capability
+    // dropping: the image is distroless, so what it needs at runtime cannot be
+    // checked from here — the same reasoning as blit, and for the same image.
+    networkPolicy: true,
+    // One node means one failure domain, so a second replica buys nothing.
+    // maxSurge still brings the new pod up before the old one goes.
+    replicas: 1,
+    healthCheck: {},
+    // Matched to blit, which measured 1m CPU and 68Mi serving the same way from
+    // the same server. The CPU headroom is for nano-web processing every file
+    // before it binds, which under 100m outlasted the liveness probe.
+    limits: { cpu: "500m", memory: "192Mi" },
+    image: {
+      repository: "ghcr.io/radiosilence/qhstrtfrd",
+      tag: VERSIONS.queenshead,
+    },
+    httpPort: 3000,
+  });
+
+  return {
+    routes: opts.hostname ? [{ service: name, hostname: opts.hostname }] : [],
+  };
+}

--- a/packages/queenshead/src/versions.ts
+++ b/packages/queenshead/src/versions.ts
@@ -1,0 +1,12 @@
+/**
+ * Pinned to a build, not a release.
+ *
+ * queenshead is a website: a corrected opening time should reach it without a
+ * version bump, so its images are tagged by commit and this follows the head of
+ * `main`. The updater resolves that itself.
+ *
+ * Rewritten in place by the version updater; see `.github/tracked-versions.yml`.
+ */
+export const VERSIONS = {
+  queenshead: "latest",
+} as const;

--- a/packages/queenshead/src/versions.ts
+++ b/packages/queenshead/src/versions.ts
@@ -8,5 +8,5 @@
  * Rewritten in place by the version updater; see `.github/tracked-versions.yml`.
  */
 export const VERSIONS = {
-  queenshead: "latest",
+  queenshead: "sha-90ffbad",
 } as const;

--- a/packages/queenshead/tsconfig.json
+++ b/packages/queenshead/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../tsconfig.json"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
A pub on West Ham Lane, Stratford E15, whose domain was pointing at a dead origin and returning 502 through Cloudflare. The site is in [radiosilence/qhstrtfrd](https://github.com/radiosilence/qhstrtfrd); this is the half that runs it.

## What it does

Adds `@jaritanet/queenshead` — a `createService` call and nothing else — plus the hostname, the Cloudflare zone, and a `tracked-versions.yml` entry so the pin follows the site's `main` the way blit's does.

## Decisions worth a look

**It is a copy of blit on purpose.** Same base image, same one replica, same `500m`/`192Mi` — the ceilings blit measured serving identical static bytes from this node. A second pub site inventing its own numbers would only be guessing where blit had already measured, and guessing at resource ceilings is what caused #166/#168.

**`modules: []` on the zone, not `MAIL_MODULES`.** Every other zone here is ours. This one is not, and their mail is live. Writing MX, SPF and DMARC records over a working mailbox is the only mistake available in this diff that would cost somebody something real, so the zone is added for DNS and the certificate and nothing else.

**The pin is a build, not `latest`.** `sha-90ffbad` is the tag the site's first CI run published. `latest` deploys whatever was pushed last and cannot be rolled back to.

## Verifying

- `packages/queenshead/src/queenshead.ts` is the whole component; compare it against `packages/blit/src/blit.ts` and the diff should be the name and the image.
- The zone id is `queensheadstratford.london` in account `365e5168…`, the same account as blit.cc — so `cloudflare.apiToken` already reaches it for the DNS-01 challenge. Worth confirming the token is account-scoped rather than zone-scoped before merging, because a zone-scoped token is the one way this deploys green and then fails to get a certificate.
- After `pulumi up`: an A record for the apex pointing at the gateway, an IngressRoute, and the site on https://queensheadstratford.london.

## Dependencies

- **The site repo needs `DEPLOYMENT_PAT`** (`actions: write` on this repo) before its CI can move the pin itself. Its first run built and pushed the image fine and failed only on that last step, so until the secret exists the pin moves by hand here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yfnNMCDsLqFwe22XJQPqP